### PR TITLE
Keep graph nodes scoped to explicit domain filters

### DIFF
--- a/src/components/FiltersPanel.tsx
+++ b/src/components/FiltersPanel.tsx
@@ -57,29 +57,34 @@ const FiltersPanel: React.FC<FiltersPanelProps> = ({
           Статусы
         </Text>
         <div className={styles.badgeList}>
-          {statuses.map((status) => (
-            <Badge
-              key={status}
-              label={statusLabels[status]}
-              size="s"
-              status={activeStatuses.has(status) ? 'system' : 'normal'}
-              minified
-              interactive
-              onClick={() => onToggleStatus(status)}
-            />
-          ))}
+          {statuses.map((status) => {
+            const isActive = activeStatuses.has(status);
+            return (
+              <Badge
+                key={status}
+                label={statusLabels[status]}
+                size="s"
+                status={isActive ? 'system' : 'normal'}
+                view={isActive ? 'filled' : 'stroked'}
+                interactive
+                onClick={() => onToggleStatus(status)}
+              />
+            );
+          })}
         </div>
       </div>
 
       <div className={styles.field}>
         <Text size="s" weight="semibold">
-          Команда
+          Название продукта
         </Text>
         <Select
-          placeholder="Все команды"
+          placeholder="Все продукты"
           size="s"
           items={teams}
           value={teamFilter}
+          getItemKey={(item) => item}
+          getItemLabel={(item) => item}
           onChange={({ value }) => onTeamChange(value ?? null)}
           form="default"
           className={styles.combobox}

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -198,13 +198,15 @@ function flattenDomains(domains: DomainNode[], visibleDomainIds?: Set<string>): 
   const collect = (node: DomainNode): DomainNode[] => {
     const childLists = node.children?.map(collect) ?? [];
     const hasVisibleChild = childLists.some((list) => list.length > 0);
-    const includeSelf = !visible || visible.has(node.id) || hasVisibleChild;
+    const includeSelf = (!visible || visible.has(node.id) || hasVisibleChild) && (!node.children || node.children.length === 0);
+
+    const collectedChildren = childLists.flat();
 
     if (!includeSelf) {
-      return [];
+      return collectedChildren;
     }
 
-    return [node, ...childLists.flat()];
+    return [node, ...collectedChildren];
   };
 
   return domains.flatMap(collect);

--- a/src/components/NodeDetails.tsx
+++ b/src/components/NodeDetails.tsx
@@ -174,7 +174,7 @@ const NodeDetails: React.FC<NodeDetailsProps> = ({ node, onClose, onNavigate }) 
       </div>
       <div className={styles.section}>
         <Text size="s" weight="semibold">
-          Команда
+          Название продукта
         </Text>
         <Text size="s">{node.team}</Text>
         <Text size="xs" view="secondary">

--- a/src/data.ts
+++ b/src/data.ts
@@ -44,9 +44,9 @@ export type ModuleNode = {
 
 export const domainTree: DomainNode[] = [
   {
-    id: 'competencies',
-    name: 'Компетенции',
-    description: 'Структура цифровых компетенций компании',
+    id: 'extraction',
+    name: 'Добыча',
+    description: 'Функции департамента управления добычей',
     children: [
       {
         id: 'production',


### PR DESCRIPTION
## Summary
- require selected modules to satisfy the explicitly chosen domain filters instead of expanding them automatically
- filter the domain graph to only include domains tied to the visible modules or highlighted nodes so the graph stays empty when all filters are cleared

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e59880766c83329058ed2187c0afd7