### PR TITLE
Update domain taxonomy labels and filter UI

### DIFF
--- a/src/components/FiltersPanel.tsx
+++ b/src/components/FiltersPanel.tsx
@@ -57,29 +57,34 @@ const FiltersPanel: React.FC<FiltersPanelProps> = ({
           Статусы
         </Text>
         <div className={styles.badgeList}>
-          {statuses.map((status) => (
-            <Badge
-              key={status}
-              label={statusLabels[status]}
-              size="s"
-              status={activeStatuses.has(status) ? 'system' : 'normal'}
-              minified
-              interactive
-              onClick={() => onToggleStatus(status)}
-            />
-          ))}
+          {statuses.map((status) => {
+            const isActive = activeStatuses.has(status);
+            return (
+              <Badge
+                key={status}
+                label={statusLabels[status]}
+                size="s"
+                status={isActive ? 'system' : 'normal'}
+                view={isActive ? 'filled' : 'stroked'}
+                interactive
+                onClick={() => onToggleStatus(status)}
+              />
+            );
+          })}
         </div>
       </div>
 
       <div className={styles.field}>
         <Text size="s" weight="semibold">
-          Команда
+          Название продукта
         </Text>
         <Select
-          placeholder="Все команды"
+          placeholder="Все продукты"
           size="s"
           items={teams}
           value={teamFilter}
+          getItemKey={(item) => item}
+          getItemLabel={(item) => item}
           onChange={({ value }) => onTeamChange(value ?? null)}
           form="default"
           className={styles.combobox}

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -198,13 +198,15 @@ function flattenDomains(domains: DomainNode[], visibleDomainIds?: Set<string>): 
   const collect = (node: DomainNode): DomainNode[] => {
     const childLists = node.children?.map(collect) ?? [];
     const hasVisibleChild = childLists.some((list) => list.length > 0);
-    const includeSelf = !visible || visible.has(node.id) || hasVisibleChild;
+    const includeSelf = (!visible || visible.has(node.id) || hasVisibleChild) && (!node.children || node.children.length === 0);
+
+    const collectedChildren = childLists.flat();
 
     if (!includeSelf) {
-      return [];
+      return collectedChildren;
     }
 
-    return [node, ...childLists.flat()];
+    return [node, ...collectedChildren];
   };
 
   return domains.flatMap(collect);

--- a/src/components/NodeDetails.tsx
+++ b/src/components/NodeDetails.tsx
@@ -174,7 +174,7 @@ const NodeDetails: React.FC<NodeDetailsProps> = ({ node, onClose, onNavigate }) 
       </div>
       <div className={styles.section}>
         <Text size="s" weight="semibold">
-          Команда
+          Название продукта
         </Text>
         <Text size="s">{node.team}</Text>
         <Text size="xs" view="secondary">

--- a/src/data.ts
+++ b/src/data.ts
@@ -44,9 +44,9 @@ export type ModuleNode = {
 
 export const domainTree: DomainNode[] = [
   {
-    id: 'competencies',
-    name: 'Компетенции',
-    description: 'Структура цифровых компетенций компании',
+    id: 'extraction',
+    name: 'Добыча',
+    description: 'Функции департамента управления добычей',
     children: [
       {
         id: 'production',


### PR DESCRIPTION
## Summary
- rename the competencies root domain to the добыча section with updated description text
- hide the top-level domain categories from the graph while retaining them for filtering
- replace status dots with readable labels and restore the product selector label/content in filters and module details

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e59eef76dc8332b39ecaf48bdf6491