### PR TITLE
Enable multi-select product filter with checkboxes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,7 +71,7 @@ function App() {
         module.owner.toLowerCase().includes(normalizedSearch);
       const matchesStatus = statusFilters.has(module.status);
       const matchesTeam =
-        teamFilter.length > 0 ? teamFilter.includes(module.team) : true;
+        teamFilter.length === 0 ? false : teamFilter.includes(module.team);
       return matchesDomain && matchesSearch && matchesStatus && matchesTeam;
     },
     [search, selectedDomains, statusFilters, teamFilter]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ function App() {
   const [selectedDomains, setSelectedDomains] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState('');
   const [statusFilters, setStatusFilters] = useState<Set<ModuleStatus>>(new Set(allStatuses));
-  const [teamFilter, setTeamFilter] = useState<string | null>(null);
+  const [teamFilter, setTeamFilter] = useState<string[]>([]);
   const [showDependencies, setShowDependencies] = useState(true);
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
   const highlightedDomainId = selectedNode?.type === 'domain' ? selectedNode.id : null;
@@ -69,7 +69,8 @@ function App() {
         module.name.toLowerCase().includes(normalizedSearch) ||
         module.owner.toLowerCase().includes(normalizedSearch);
       const matchesStatus = statusFilters.has(module.status);
-      const matchesTeam = teamFilter ? module.team === teamFilter : true;
+      const matchesTeam =
+        teamFilter.length > 0 ? teamFilter.includes(module.team) : true;
       return matchesDomain && matchesSearch && matchesStatus && matchesTeam;
     },
     [search, selectedDomains, statusFilters, teamFilter]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,17 +19,18 @@ import {
 import styles from './App.module.css';
 
 const allStatuses: ModuleStatus[] = ['production', 'in-dev', 'deprecated'];
+const allTeams = Array.from(new Set(modules.map((module) => module.team))).sort();
 
 function App() {
   const [selectedDomains, setSelectedDomains] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState('');
   const [statusFilters, setStatusFilters] = useState<Set<ModuleStatus>>(new Set(allStatuses));
-  const [teamFilter, setTeamFilter] = useState<string[]>([]);
+  const [teamFilter, setTeamFilter] = useState<string[]>(allTeams);
   const [showDependencies, setShowDependencies] = useState(true);
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
   const highlightedDomainId = selectedNode?.type === 'domain' ? selectedNode.id : null;
 
-  const teams = useMemo(() => Array.from(new Set(modules.map((module) => module.team))).sort(), []);
+  const teams = useMemo(() => allTeams, []);
 
   const domainDescendants = useMemo(() => buildDomainDescendants(domainTree), []);
   const domainAncestors = useMemo(() => buildDomainAncestors(domainTree), []);

--- a/src/components/FiltersPanel.module.css
+++ b/src/components/FiltersPanel.module.css
@@ -35,6 +35,25 @@
   width: 100%;
 }
 
+.comboboxOption {
+  display: flex;
+  align-items: center;
+  padding: 4px 12px;
+  cursor: pointer;
+}
+
+.comboboxOptionHovered {
+  background: var(--color-control-bg-ghost-hover, rgba(0, 0, 0, 0.05));
+}
+
+.comboboxOptionActive {
+  background: var(--color-control-bg-ghost-press, rgba(0, 0, 0, 0.08));
+}
+
+.comboboxCheckbox {
+  width: 100%;
+}
+
 .switchRow {
   display: flex;
   flex-direction: column;

--- a/src/components/FiltersPanel.tsx
+++ b/src/components/FiltersPanel.tsx
@@ -137,7 +137,7 @@ const FiltersPanel: React.FC<FiltersPanelProps> = ({
           value={teamFilter}
           getItemKey={(item) => item}
           getItemLabel={(item) => item}
-          onChange={({ value }) => onTeamChange(value ?? [])}
+          onChange={(value) => onTeamChange(value ?? [])}
           form="default"
           multiple
           selectAll
@@ -159,7 +159,7 @@ const FiltersPanel: React.FC<FiltersPanelProps> = ({
           label="Сбросить фильтры"
           onClick={() => {
             onSearchChange('');
-            onTeamChange([]);
+            onTeamChange(teams);
             statuses.forEach((status) => {
               if (!activeStatuses.has(status)) {
                 onToggleStatus(status);

--- a/src/components/FiltersPanel.tsx
+++ b/src/components/FiltersPanel.tsx
@@ -1,9 +1,12 @@
 import { Button } from '@consta/uikit/Button';
+import { Checkbox } from '@consta/uikit/Checkbox';
 import { CheckboxGroup } from '@consta/uikit/CheckboxGroup';
-import { Select } from '@consta/uikit/Select';
+import { Combobox } from '@consta/uikit/Combobox';
 import { Switch } from '@consta/uikit/Switch';
 import { Text } from '@consta/uikit/Text';
+import clsx from 'clsx';
 import React from 'react';
+import type { ComboboxPropRenderItem } from '@consta/uikit/Combobox';
 import type { ModuleStatus } from '../data';
 import styles from './FiltersPanel.module.css';
 
@@ -14,8 +17,8 @@ type FiltersPanelProps = {
   activeStatuses: Set<ModuleStatus>;
   onToggleStatus: (status: ModuleStatus) => void;
   teams: string[];
-  teamFilter: string | null;
-  onTeamChange: (team: string | null) => void;
+  teamFilter: string[];
+  onTeamChange: (team: string[]) => void;
   showDependencies: boolean;
   onToggleDependencies: (value: boolean) => void;
 };
@@ -55,6 +58,31 @@ const FiltersPanel: React.FC<FiltersPanelProps> = ({
   const selectedStatusOptions = React.useMemo(
     () => statusOptions.filter((option) => activeStatuses.has(option.id)),
     [statusOptions, activeStatuses]
+  );
+
+  const renderTeamOption = React.useCallback<ComboboxPropRenderItem<string>>(
+    ({ item, active, hovered, onClick, onMouseEnter, ref }) => (
+      <div
+        ref={ref}
+        className={clsx(styles.comboboxOption, {
+          [styles.comboboxOptionHovered]: hovered,
+          [styles.comboboxOptionActive]: active
+        })}
+        onMouseEnter={onMouseEnter}
+        onClick={(event) => {
+          onClick(event);
+        }}
+      >
+        <Checkbox
+          size="s"
+          readOnly
+          checked={teamFilter.includes(item)}
+          label={item}
+          className={styles.comboboxCheckbox}
+        />
+      </div>
+    ),
+    [teamFilter]
   );
 
   return (
@@ -102,15 +130,18 @@ const FiltersPanel: React.FC<FiltersPanelProps> = ({
         <Text size="s" weight="semibold">
           Название продукта
         </Text>
-        <Select
+        <Combobox
           placeholder="Все продукты"
           size="s"
           items={teams}
           value={teamFilter}
           getItemKey={(item) => item}
           getItemLabel={(item) => item}
-          onChange={({ value }) => onTeamChange(value ?? null)}
+          onChange={({ value }) => onTeamChange(value ?? [])}
           form="default"
+          multiple
+          selectAll
+          renderItem={renderTeamOption}
           className={styles.combobox}
         />
       </div>
@@ -128,7 +159,7 @@ const FiltersPanel: React.FC<FiltersPanelProps> = ({
           label="Сбросить фильтры"
           onClick={() => {
             onSearchChange('');
-            onTeamChange(null);
+            onTeamChange([]);
             statuses.forEach((status) => {
               if (!activeStatuses.has(status)) {
                 onToggleStatus(status);


### PR DESCRIPTION
## Summary
- replace the product filter select with a Combobox that supports multi-selection via checkboxes
- update module filtering logic to accept multiple selected teams
- add dropdown styling so checkbox options display consistently

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5aa9b75ac83328c028f1bf046703a