### PR TITLE
Expand module details with grouped attributes

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -4,8 +4,20 @@
 }
 
 .header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
   padding: 24px;
   border-bottom: 1px solid var(--color-bg-border);
+}
+
+.headerContent {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-width: 720px;
 }
 
 .main {
@@ -43,7 +55,7 @@
   padding: 16px;
   border-radius: 12px;
   background: var(--color-bg-default);
-  box-shadow: var(--shadow-layer); 
+  box-shadow: var(--shadow-layer);
 }
 
 .details {
@@ -51,6 +63,13 @@
   border-radius: 12px;
   box-shadow: var(--shadow-layer);
   overflow: auto;
+}
+
+.statsMain {
+  padding: 24px;
+  height: calc(100% - 92px);
+  box-sizing: border-box;
+  overflow-y: auto;
 }
 
 @media (max-width: 1440px) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,9 @@ const allStatuses: ModuleStatus[] = ['production', 'in-dev', 'deprecated'];
 const allTeams = Array.from(new Set(modules.map((module) => module.team))).sort();
 
 function App() {
-  const [selectedDomains, setSelectedDomains] = useState<Set<string>>(new Set());
+  const [selectedDomains, setSelectedDomains] = useState<Set<string>>(
+    () => new Set(flattenDomainTree(domainTree).map((domain) => domain.id))
+  );
   const [search, setSearch] = useState('');
   const [statusFilters, setStatusFilters] = useState<Set<ModuleStatus>>(new Set(allStatuses));
   const [teamFilter, setTeamFilter] = useState<string[]>(allTeams);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,15 @@ function App() {
       const matchesSearch =
         normalizedSearch.length === 0 ||
         module.name.toLowerCase().includes(normalizedSearch) ||
-        module.owner.toLowerCase().includes(normalizedSearch);
+        module.productName.toLowerCase().includes(normalizedSearch) ||
+        module.team.toLowerCase().includes(normalizedSearch) ||
+        module.ridOwner.company.toLowerCase().includes(normalizedSearch) ||
+        module.ridOwner.division.toLowerCase().includes(normalizedSearch) ||
+        module.projectTeam.some(
+          (member) =>
+            member.fullName.toLowerCase().includes(normalizedSearch) ||
+            member.role.toLowerCase().includes(normalizedSearch)
+        );
       const matchesStatus = statusFilters.has(module.status);
       const matchesTeam =
         teamFilter.length === 0 ? false : teamFilter.includes(module.team);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,12 @@
 import { Layout } from '@consta/uikit/Layout';
+import { Tabs } from '@consta/uikit/Tabs';
 import { Text } from '@consta/uikit/Text';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import AnalyticsPanel from './components/AnalyticsPanel';
 import DomainTree from './components/DomainTree';
 import FiltersPanel from './components/FiltersPanel';
 import GraphView, { type GraphNode } from './components/GraphView';
+import StatsDashboard from './components/StatsDashboard';
 import NodeDetails from './components/NodeDetails';
 import {
   artifacts,
@@ -12,6 +14,7 @@ import {
   moduleById,
   moduleLinks,
   modules,
+  reuseIndexHistory,
   type DomainNode,
   type ModuleNode,
   type ModuleStatus
@@ -20,6 +23,13 @@ import styles from './App.module.css';
 
 const allStatuses: ModuleStatus[] = ['production', 'in-dev', 'deprecated'];
 const allTeams = Array.from(new Set(modules.map((module) => module.team))).sort();
+
+const viewTabs = [
+  { label: 'Связи', value: 'graph' },
+  { label: 'Статистика', value: 'stats' }
+] as const;
+
+type ViewMode = (typeof viewTabs)[number]['value'];
 
 function App() {
   const [selectedDomains, setSelectedDomains] = useState<Set<string>>(
@@ -30,6 +40,7 @@ function App() {
   const [teamFilter, setTeamFilter] = useState<string[]>(allTeams);
   const [showDependencies, setShowDependencies] = useState(true);
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
+  const [viewMode, setViewMode] = useState<ViewMode>('graph');
   const highlightedDomainId = selectedNode?.type === 'domain' ? selectedNode.id : null;
 
   const teams = useMemo(() => allTeams, []);
@@ -427,75 +438,111 @@ function App() {
     }
   }, [handleNavigate]);
 
+  const activeViewTab = viewTabs.find((tab) => tab.value === viewMode) ?? viewTabs[0];
+
+  const headerTitle = viewMode === 'graph' ? 'Граф модулей и доменных областей' : 'Статистика экосистемы решений';
+  const headerDescription =
+    viewMode === 'graph'
+      ? 'Выберите домены, чтобы увидеть связанные модули и выявить пересечения.'
+      : 'Обзор ключевых метрик по системам, модулям и обмену данными для планирования развития.';
+
   return (
     <Layout className={styles.app} direction="column">
       <header className={styles.header}>
-        <div>
+        <div className={styles.headerContent}>
           <Text size="2xl" weight="bold">
-            Граф модулей и доменных областей
+            {headerTitle}
           </Text>
           <Text size="s" view="secondary">
-            Выберите домены, чтобы увидеть связанные модули и выявить пересечения.
+            {headerDescription}
           </Text>
         </div>
+        <Tabs
+          size="s"
+          items={viewTabs}
+          value={activeViewTab}
+          getItemKey={(item) => item.value}
+          getItemLabel={(item) => item.label}
+          onChange={(tab) => setViewMode(tab.value)}
+        />
       </header>
-      <main className={styles.main}>
-        <aside className={styles.sidebar}>
-          <Text size="s" weight="semibold" className={styles.sidebarTitle}>
-            Домены
-          </Text>
-          <DomainTree tree={domainTree} selected={selectedDomains} onToggle={handleDomainToggle} descendants={domainDescendants} />
-          <Text size="s" weight="semibold" className={styles.sidebarTitle}>
-            Фильтры
-          </Text>
-          <FiltersPanel
-            search={search}
-            onSearchChange={setSearch}
-            statuses={allStatuses}
-            activeStatuses={statusFilters}
-            onToggleStatus={(status) => {
-              setSelectedNode(null);
-              setStatusFilters((prev) => {
-                const next = new Set(prev);
-                if (next.has(status)) {
-                  next.delete(status);
-                } else {
-                  next.add(status);
-                }
-                return next;
-              });
-            }}
-            teams={teams}
-            teamFilter={teamFilter}
-            onTeamChange={(team) => {
-              setSelectedNode(null);
-              setTeamFilter(team);
-            }}
-            showDependencies={showDependencies}
-            onToggleDependencies={(value) => setShowDependencies(value)}
-          />
-        </aside>
-        <section className={styles.graphSection}>
-          <div className={styles.graphContainer}>
-            <GraphView
-              modules={graphModules}
-              domains={graphDomains}
-              artifacts={graphArtifacts}
-              links={filteredLinks}
-              showDependencies={showDependencies}
-              onSelect={handleSelectNode}
-              highlightedNode={selectedNode?.id ?? null}
-              visibleDomainIds={relevantDomainIds}
+      {viewMode === 'graph' ? (
+        <main className={styles.main}>
+          <aside className={styles.sidebar}>
+            <Text size="s" weight="semibold" className={styles.sidebarTitle}>
+              Домены
+            </Text>
+            <DomainTree
+              tree={domainTree}
+              selected={selectedDomains}
+              onToggle={handleDomainToggle}
+              descendants={domainDescendants}
             />
-          </div>
-          <div className={styles.analytics}>
-            <AnalyticsPanel modules={filteredModules} />
-          </div>
-        </section>
-        <aside className={styles.details}>
-          <NodeDetails node={selectedNode} onClose={() => setSelectedNode(null)} onNavigate={handleNavigate} />
-        </aside>
-      </main>
+            <Text size="s" weight="semibold" className={styles.sidebarTitle}>
+              Фильтры
+            </Text>
+            <FiltersPanel
+              search={search}
+              onSearchChange={setSearch}
+              statuses={allStatuses}
+              activeStatuses={statusFilters}
+              onToggleStatus={(status) => {
+                setSelectedNode(null);
+                setStatusFilters((prev) => {
+                  const next = new Set(prev);
+                  if (next.has(status)) {
+                    next.delete(status);
+                  } else {
+                    next.add(status);
+                  }
+                  return next;
+                });
+              }}
+              teams={teams}
+              teamFilter={teamFilter}
+              onTeamChange={(team) => {
+                setSelectedNode(null);
+                setTeamFilter(team);
+              }}
+              showDependencies={showDependencies}
+              onToggleDependencies={(value) => setShowDependencies(value)}
+            />
+          </aside>
+          <section className={styles.graphSection}>
+            <div className={styles.graphContainer}>
+              <GraphView
+                modules={graphModules}
+                domains={graphDomains}
+                artifacts={graphArtifacts}
+                links={filteredLinks}
+                showDependencies={showDependencies}
+                onSelect={handleSelectNode}
+                highlightedNode={selectedNode?.id ?? null}
+                visibleDomainIds={relevantDomainIds}
+              />
+            </div>
+            <div className={styles.analytics}>
+              <AnalyticsPanel modules={filteredModules} />
+            </div>
+          </section>
+          <aside className={styles.details}>
+            <NodeDetails
+              node={selectedNode}
+              onClose={() => setSelectedNode(null)}
+              onNavigate={handleNavigate}
+            />
+          </aside>
+        </main>
+      ) : (
+        <main className={styles.statsMain}>
+          <StatsDashboard
+            modules={modules}
+            domains={domainTree}
+            artifacts={artifacts}
+            reuseHistory={reuseIndexHistory}
+          />
+        </main>
+      )}
     </Layout>
   );
 }

--- a/src/components/NodeDetails.module.css
+++ b/src/components/NodeDetails.module.css
@@ -130,3 +130,22 @@
   flex-direction: column;
   gap: 2px;
 }
+
+.teamRoster {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.teamRosterHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.teamSummary {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}

--- a/src/components/NodeDetails.module.css
+++ b/src/components/NodeDetails.module.css
@@ -84,3 +84,49 @@
   align-items: center;
   gap: 12px;
 }
+
+.sections {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.collapseLabel {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sectionContent {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px 0 4px;
+}
+
+.keyValueItem {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.value {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.listItem {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}

--- a/src/components/NodeDetails.tsx
+++ b/src/components/NodeDetails.tsx
@@ -37,9 +37,9 @@ type SectionId = 'general' | 'calculation' | 'technical' | 'nonFunctional';
 
 const defaultSectionState: Record<SectionId, boolean> = {
   general: true,
-  calculation: true,
-  technical: true,
-  nonFunctional: true
+  calculation: false,
+  technical: false,
+  nonFunctional: false
 };
 
 const clientTypeLabels: Record<'desktop' | 'web', string> = {

--- a/src/components/NodeDetails.tsx
+++ b/src/components/NodeDetails.tsx
@@ -1,9 +1,10 @@
 import { Badge } from '@consta/uikit/Badge';
 import { Button } from '@consta/uikit/Button';
+import { Collapse } from '@consta/uikit/Collapse';
 import { Select } from '@consta/uikit/Select';
 import { Tag } from '@consta/uikit/Tag';
 import { Text } from '@consta/uikit/Text';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { artifactNameById, domainNameById, moduleNameById, type ModuleInput, type ModuleOutput } from '../data';
 import type { GraphNode } from './GraphView';
 import styles from './NodeDetails.module.css';
@@ -25,7 +26,42 @@ type ConsumerOption = {
   label: string;
 };
 
+type SectionId = 'general' | 'calculation' | 'technical' | 'nonFunctional';
+
+const defaultSectionState: Record<SectionId, boolean> = {
+  general: true,
+  calculation: true,
+  technical: true,
+  nonFunctional: true
+};
+
+const clientTypeLabels: Record<'desktop' | 'web', string> = {
+  desktop: 'Desktop-приложение',
+  web: 'Web-интерфейс'
+};
+
+const deploymentToolLabels: Record<'docker' | 'kubernetes', string> = {
+  docker: 'Docker',
+  kubernetes: 'Kubernetes'
+};
+
 const NodeDetails: React.FC<NodeDetailsProps> = ({ node, onClose, onNavigate }) => {
+  const [openSections, setOpenSections] = useState<Record<SectionId, boolean>>(
+    () => ({ ...defaultSectionState })
+  );
+
+  useEffect(() => {
+    if (node?.type !== 'module') {
+      return;
+    }
+
+    setOpenSections({ ...defaultSectionState });
+  }, [node?.id, node?.type]);
+
+  const toggleSection = (section: SectionId) => {
+    setOpenSections((prev) => ({ ...prev, [section]: !prev[section] }));
+  };
+
   if (!node) {
     return (
       <div className={styles.empty}>
@@ -148,6 +184,216 @@ const NodeDetails: React.FC<NodeDetailsProps> = ({ node, onClose, onNavigate }) 
     );
   }
 
+  const sections: { id: SectionId; title: string; content: React.ReactNode }[] = [
+    {
+      id: 'general',
+      title: 'Общая информация',
+      content: (
+        <>
+          <InfoRow label="Описание модуля">
+            <Text size="s" className={styles.description}>
+              {node.description}
+            </Text>
+          </InfoRow>
+          <InfoRow label="Доменные области">
+            <div className={styles.tagList}>
+              {node.domains.map((domain) => (
+                <Tag key={domain} label={domainNameById[domain] ?? domain} size="xs" />
+              ))}
+            </div>
+          </InfoRow>
+          <InfoRow label="Название продукта">
+            <Text size="s">{node.productName}</Text>
+          </InfoRow>
+          <InfoRow label="Команда">
+            <Text size="s">{node.team}</Text>
+          </InfoRow>
+          <InfoRow label="Владелец продукта">
+            <Text size="s">{node.owner}</Text>
+          </InfoRow>
+          <InfoRow label="Владелец РИД">
+            <Text size="s">{node.ridOwner}</Text>
+          </InfoRow>
+          <InfoRow label="Локализация функции">
+            <Text size="s">{node.localization}</Text>
+          </InfoRow>
+          <InfoRow label="Количество пользователей">
+            <Text size="s">
+              {node.userStats.companies} компаний, {node.userStats.licenses} лицензий
+            </Text>
+          </InfoRow>
+          <InfoRow label="Стек технологий">
+            <div className={styles.tagList}>
+              {node.technologyStack.map((technology) => (
+                <Tag key={technology} label={technology} size="xs" />
+              ))}
+            </div>
+          </InfoRow>
+          <InfoRow label="Команда проекта">
+            <ul className={styles.list}>
+              {node.projectTeam.map((member) => (
+                <li key={member.id} className={styles.listItem}>
+                  <Text size="s" weight="semibold">
+                    {member.fullName}
+                  </Text>
+                  <Text size="xs" view="secondary">
+                    {member.role}
+                  </Text>
+                </li>
+              ))}
+            </ul>
+          </InfoRow>
+        </>
+      )
+    },
+    {
+      id: 'calculation',
+      title: 'Расчётный узел',
+      content: (
+        <>
+          <ModuleIoSection title="Данные In" items={node.dataIn} onNavigate={onNavigate} />
+          <ModuleOutputSection items={node.dataOut} onNavigate={onNavigate} />
+          <InfoRow label="Формула расчёта">
+            <Text size="s" className={styles.code}>
+              {node.formula}
+            </Text>
+          </InfoRow>
+        </>
+      )
+    },
+    {
+      id: 'technical',
+      title: 'Техническая информация',
+      content: (
+        <>
+          {node.repository && (
+            <InfoRow label="Репозиторий">
+              <a href={node.repository} target="_blank" rel="noreferrer" className={styles.link}>
+                {node.repository}
+              </a>
+            </InfoRow>
+          )}
+          {node.api && (
+            <InfoRow label="API">
+              <Text size="s" className={styles.code}>
+                {node.api}
+              </Text>
+            </InfoRow>
+          )}
+          <InfoRow label="Постановка на разработку">
+            <a href={node.specificationUrl} target="_blank" rel="noreferrer" className={styles.link}>
+              {node.specificationUrl}
+            </a>
+          </InfoRow>
+          <InfoRow label="Документация контрактов API">
+            <a href={node.apiContractsUrl} target="_blank" rel="noreferrer" className={styles.link}>
+              {node.apiContractsUrl}
+            </a>
+          </InfoRow>
+          <InfoRow label="Технический дизайн">
+            <a href={node.techDesignUrl} target="_blank" rel="noreferrer" className={styles.link}>
+              {node.techDesignUrl}
+            </a>
+          </InfoRow>
+          <InfoRow label="Архитектурная схема">
+            <a href={node.architectureDiagramUrl} target="_blank" rel="noreferrer" className={styles.link}>
+              {node.architectureDiagramUrl}
+            </a>
+          </InfoRow>
+          <InfoRow label="Интеграция с сервером лицензирования">
+            <Text size="s">{node.licenseServerIntegrated ? 'Да' : 'Нет'}</Text>
+          </InfoRow>
+          <InfoRow label="Перечень библиотек">
+            <ul className={styles.list}>
+              {node.libraries.map((library) => (
+                <li
+                  key={`${node.id}-${library.name}-${library.version}`}
+                  className={styles.listItem}
+                >
+                  <Text size="s">{library.name}</Text>
+                  <Text size="xs" view="secondary">
+                    v{library.version}
+                  </Text>
+                </li>
+              ))}
+            </ul>
+          </InfoRow>
+          <InfoRow label="Клиент">
+            <Text size="s">{clientTypeLabels[node.clientType]}</Text>
+          </InfoRow>
+          <InfoRow label="Средство развертывания">
+            <Text size="s">{deploymentToolLabels[node.deploymentTool]}</Text>
+          </InfoRow>
+          <div>
+            <Text size="xs" view="secondary">
+              Метрики по тестам
+            </Text>
+            <div className={styles.metrics}>
+              <div>
+                <Text size="xs" view="secondary">
+                  Покрытие
+                </Text>
+                <Text size="m" weight="semibold">
+                  {node.metrics.coverage}%
+                </Text>
+              </div>
+              <div>
+                <Text size="xs" view="secondary">
+                  Всего тестов
+                </Text>
+                <Text size="m" weight="semibold">
+                  {node.metrics.tests}
+                </Text>
+              </div>
+              <div>
+                <Text size="xs" view="secondary">
+                  Автоматизация
+                </Text>
+                <Text size="m" weight="semibold">
+                  {node.metrics.automationRate}%
+                </Text>
+              </div>
+            </div>
+          </div>
+        </>
+      )
+    },
+    {
+      id: 'nonFunctional',
+      title: 'Нефункциональные требования',
+      content: (
+        <>
+          <div className={styles.metrics}>
+            <div>
+              <Text size="xs" view="secondary">
+                Время отклика
+              </Text>
+              <Text size="m" weight="semibold">
+                {node.nonFunctional.responseTimeMs} мс
+              </Text>
+            </div>
+            <div>
+              <Text size="xs" view="secondary">
+                Пропускная способность
+              </Text>
+              <Text size="m" weight="semibold">
+                {node.nonFunctional.throughputRps} rps
+              </Text>
+            </div>
+            <div>
+              <Text size="xs" view="secondary">
+                Потребление ресурсов
+              </Text>
+              <Text size="m" weight="semibold">
+                {node.nonFunctional.resourceConsumption}
+              </Text>
+            </div>
+          </div>
+        </>
+      )
+    }
+  ];
+
   return (
     <div className={styles.container}>
       <header className={styles.header}>
@@ -159,87 +405,23 @@ const NodeDetails: React.FC<NodeDetailsProps> = ({ node, onClose, onNavigate }) 
         </div>
         <Button size="xs" label="Закрыть" view="ghost" onClick={onClose} />
       </header>
-      <Text size="s" className={styles.description}>
-        {node.description}
-      </Text>
-      <div className={styles.section}>
-        <Text size="s" weight="semibold">
-          Доменные области
-        </Text>
-        <div className={styles.tagList}>
-          {node.domains.map((domain) => (
-            <Tag key={domain} label={domainNameById[domain] ?? domain} size="xs" />
-          ))}
-        </div>
-      </div>
-      <div className={styles.section}>
-        <Text size="s" weight="semibold">
-          Название продукта
-        </Text>
-        <Text size="s">{node.team}</Text>
-        <Text size="xs" view="secondary">
-          {node.owner}
-        </Text>
-      </div>
-      {node.repository && (
-        <div className={styles.section}>
-          <Text size="s" weight="semibold">
-            Репозиторий
-          </Text>
-          <a href={node.repository} target="_blank" rel="noreferrer" className={styles.link}>
-            {node.repository}
-          </a>
-        </div>
-      )}
-      {node.api && (
-        <div className={styles.section}>
-          <Text size="s" weight="semibold">
-            API
-          </Text>
-          <Text size="s" className={styles.code}>
-            {node.api}
-          </Text>
-        </div>
-      )}
-      <ModuleIoSection
-        title="Данные In"
-        items={node.dataIn}
-        onNavigate={onNavigate}
-      />
-      <ModuleOutputSection items={node.dataOut} onNavigate={onNavigate} />
-      <div className={styles.section}>
-        <Text size="s" weight="semibold">
-          Формула расчёта
-        </Text>
-        <Text size="s" className={styles.code}>
-          {node.formula}
-        </Text>
-      </div>
-      <div className={styles.metrics}>
-        <div>
-          <Text size="xs" view="secondary">
-            Покрытие тестами
-          </Text>
-          <Text size="m" weight="semibold">
-            {node.metrics.coverage}%
-          </Text>
-        </div>
-        <div>
-          <Text size="xs" view="secondary">
-            Количество тестов
-          </Text>
-          <Text size="m" weight="semibold">
-            {node.metrics.tests}
-          </Text>
-        </div>
-        <div>
-          <Text size="xs" view="secondary">
-            Задержка API
-          </Text>
-          <Text size="m" weight="semibold">
-            {node.metrics.latencyMs} мс
-          </Text>
-        </div>
+      <div className={styles.sections}>
+        {sections.map((section) => (
+          <Collapse
+            key={section.id}
+            label={
+              <div className={styles.collapseLabel}>
+                <Text size="s" weight="semibold">
+                  {section.title}
+                </Text>
+              </div>
+            }
+            isOpen={openSections[section.id]}
+            onClick={() => toggleSection(section.id)}
+          >
+            <div className={styles.sectionContent}>{section.content}</div>
+          </Collapse>
+        ))}
       </div>
     </div>
   );
@@ -261,6 +443,20 @@ function statusLabel(status: GraphNode & { type: 'module' }['status']) {
 function resolveEntityName(id: string): string {
   return moduleNameById[id] ?? artifactNameById[id] ?? domainNameById[id] ?? id;
 }
+
+type InfoRowProps = {
+  label: string;
+  children: React.ReactNode;
+};
+
+const InfoRow: React.FC<InfoRowProps> = ({ label, children }) => (
+  <div className={styles.keyValueItem}>
+    <Text size="xs" view="secondary">
+      {label}
+    </Text>
+    <div className={styles.value}>{children}</div>
+  </div>
+);
 
 type ModuleIoSectionProps = {
   title: string;

--- a/src/components/StatsDashboard.module.css
+++ b/src/components/StatsDashboard.module.css
@@ -1,0 +1,140 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.summaryGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.summaryCard {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-radius: 12px;
+  background: var(--color-bg-default);
+  box-shadow: var(--shadow-layer);
+}
+
+.summaryValue {
+  line-height: 1;
+}
+
+.chartsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  border-radius: 12px;
+  background: var(--color-bg-default);
+  box-shadow: var(--shadow-layer);
+}
+
+.cardTitle {
+  margin-bottom: -4px;
+}
+
+.splitGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.systemTable {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.systemTable th,
+.systemTable td {
+  padding: 8px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--color-bg-border);
+}
+
+.systemTable tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.statusPill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  background: var(--color-bg-ghost);
+  color: var(--color-typo-primary);
+}
+
+.statusPill[data-status='success'] {
+  background: rgba(46, 204, 113, 0.15);
+  color: #1f8a52;
+}
+
+.statusPill[data-status='warning'] {
+  background: rgba(241, 196, 15, 0.15);
+  color: #9a7d08;
+}
+
+.statusPill[data-status='alert'] {
+  background: rgba(231, 76, 60, 0.15);
+  color: #a63a32;
+}
+
+.domainList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.domainPill {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--color-bg-ghost);
+  font-size: 13px;
+}
+
+.metricsList {
+  display: grid;
+  gap: 12px;
+}
+
+.metricsItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.metricsLabel {
+  color: var(--color-typo-secondary);
+  font-size: 14px;
+}
+
+.metricsValue {
+  font-weight: 600;
+  font-size: 20px;
+}
+
+@media (max-width: 1024px) {
+  .chartsGrid {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  }
+
+  .splitGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/StatsDashboard.tsx
+++ b/src/components/StatsDashboard.tsx
@@ -1,0 +1,533 @@
+import { Bar, type BarProps } from '@consta/charts/Bar';
+import { Column, type ColumnProps } from '@consta/charts/Column';
+import { Line, type LineProps } from '@consta/charts/Line';
+import { Pie, type PieProps } from '@consta/charts/Pie';
+import { Card } from '@consta/uikit/Card';
+import { Text } from '@consta/uikit/Text';
+import { useMemo } from 'react';
+import {
+  artifacts as allArtifacts,
+  domainNameById,
+  domainTree as allDomains,
+  modules as allModules,
+  type ArtifactNode,
+  type DomainNode,
+  type ModuleNode,
+  type ModuleStatus,
+  type ReuseTrendPoint
+} from '../data';
+import styles from './StatsDashboard.module.css';
+
+const statusOrder: ModuleStatus[] = ['production', 'in-dev', 'deprecated'];
+const statusLabels: Record<ModuleStatus, string> = {
+  production: 'В эксплуатации',
+  'in-dev': 'В разработке',
+  deprecated: 'Выведено из эксплуатации'
+};
+
+const statusBadgeView: Record<ModuleStatus, 'success' | 'warning' | 'alert'> = {
+  production: 'success',
+  'in-dev': 'warning',
+  deprecated: 'alert'
+};
+
+type StatsDashboardProps = {
+  modules?: ModuleNode[];
+  domains?: DomainNode[];
+  artifacts?: ArtifactNode[];
+  reuseHistory: ReuseTrendPoint[];
+};
+
+type SystemRow = {
+  name: string;
+  total: number;
+  statuses: Record<ModuleStatus, number>;
+};
+
+type ArtifactChartDatum = {
+  type: string;
+  count: number;
+};
+
+type ReuseChartDatum = {
+  periodLabel: string;
+  averagePercent: number;
+};
+
+type DistributionDatum = {
+  label: string;
+  value: number;
+};
+
+type TeamDatum = {
+  team: string;
+  count: number;
+};
+
+const defaultModules = allModules;
+const defaultDomains = allDomains;
+const defaultArtifacts = allArtifacts;
+
+const StatsDashboard = ({
+  modules = defaultModules,
+  domains = defaultDomains,
+  artifacts = defaultArtifacts,
+  reuseHistory
+}: StatsDashboardProps) => {
+  const systems = useMemo(() => {
+    const map = new Map<string, SystemRow>();
+
+    modules.forEach((module) => {
+      const existing = map.get(module.productName);
+      if (existing) {
+        existing.total += 1;
+        existing.statuses[module.status] += 1;
+        return;
+      }
+
+      map.set(module.productName, {
+        name: module.productName,
+        total: 1,
+        statuses: {
+          production: module.status === 'production' ? 1 : 0,
+          'in-dev': module.status === 'in-dev' ? 1 : 0,
+          deprecated: module.status === 'deprecated' ? 1 : 0
+        }
+      });
+    });
+
+    return Array.from(map.values()).sort((a, b) => b.total - a.total);
+  }, [modules]);
+
+  const moduleCount = modules.length;
+  const systemCount = systems.length;
+  const artifactCount = artifacts.length;
+
+  const modulesByStatus = useMemo(() => {
+    return statusOrder.map((status) => ({
+      status,
+      statusLabel: statusLabels[status],
+      count: modules.filter((module) => module.status === status).length
+    }));
+  }, [modules]);
+
+  const artifactTypes = useMemo<ArtifactChartDatum[]>(() => {
+    const counts = new Map<string, number>();
+
+    artifacts.forEach((artifact) => {
+      const type = resolveArtifactType(artifact);
+      counts.set(type, (counts.get(type) ?? 0) + 1);
+    });
+
+    return Array.from(counts.entries())
+      .map(([type, count]) => ({ type, count }))
+      .sort((a, b) => b.count - a.count);
+  }, [artifacts]);
+
+  const reuseChartData = useMemo<ReuseChartDatum[]>(() => {
+    return reuseHistory.map((point) => ({
+      periodLabel: formatPeriod(point.period),
+      averagePercent: Math.round(point.averageScore * 1000) / 10
+    }));
+  }, [reuseHistory]);
+
+  const domainWithoutModules = useMemo(() => {
+    const flatDomains = flattenDomains(domains);
+    const usage = new Map<string, number>();
+
+    modules.forEach((module) => {
+      module.domains.forEach((domainId) => {
+        usage.set(domainId, (usage.get(domainId) ?? 0) + 1);
+      });
+    });
+
+    return flatDomains.filter((domain) => (usage.get(domain.id) ?? 0) === 0);
+  }, [domains, modules]);
+
+  const deploymentDistribution = useMemo<DistributionDatum[]>(() => {
+    const counts = modules.reduce<Record<string, number>>((acc, module) => {
+      const key = module.deploymentTool === 'kubernetes' ? 'Kubernetes' : 'Docker';
+      acc[key] = (acc[key] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    return Object.entries(counts).map(([label, value]) => ({ label, value }));
+  }, [modules]);
+
+  const clientDistribution = useMemo<DistributionDatum[]>(() => {
+    const counts = modules.reduce<Record<string, number>>((acc, module) => {
+      const key = module.clientType === 'desktop' ? 'Desktop' : 'Web';
+      acc[key] = (acc[key] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    return Object.entries(counts).map(([label, value]) => ({ label, value }));
+  }, [modules]);
+
+  const teamLeaders = useMemo<TeamDatum[]>(() => {
+    const counts = modules.reduce<Record<string, number>>((acc, module) => {
+      acc[module.team] = (acc[module.team] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    return Object.entries(counts)
+      .map(([team, count]) => ({ team, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 6);
+  }, [modules]);
+
+  const averageAutomation = useMemo(() => average(modules.map((module) => module.metrics.automationRate)), [modules]);
+  const averageDependencies = useMemo(
+    () => average(modules.map((module) => module.dependencies.length)),
+    [modules]
+  );
+  const averageResponseTime = useMemo(
+    () => average(modules.map((module) => module.nonFunctional.responseTimeMs)),
+    [modules]
+  );
+  const licenseRatio = useMemo(() => {
+    const withLicense = modules.filter((module) => module.licenseServerIntegrated).length;
+    return {
+      withLicense,
+      ratio: modules.length === 0 ? 0 : Math.round((withLicense / modules.length) * 100)
+    };
+  }, [modules]);
+  const artifactsPerModule = useMemo(
+    () => (modules.length === 0 ? 0 : Math.round((artifactCount / modules.length) * 10) / 10),
+    [artifactCount, modules.length]
+  );
+
+  const modulesByStatusPieProps: PieProps<(typeof modulesByStatus)[number]> = {
+    data: modulesByStatus,
+    angleField: 'count',
+    colorField: 'statusLabel',
+    legend: { position: 'bottom' },
+    height: 280,
+    radius: 0.9,
+    innerRadius: 0.45,
+    tooltip: ({ statusLabel, count }) => ({
+      name: statusLabel,
+      value: `${count} мод.`
+    })
+  };
+
+  const artifactColumnProps: ColumnProps<ArtifactChartDatum> = {
+    data: artifactTypes,
+    xField: 'type',
+    yField: 'count',
+    height: 280,
+    columnWidthRatio: 0.6,
+    label: {
+      position: 'top'
+    },
+    tooltip: ({ type, count }) => ({
+      name: type,
+      value: `${count} шт.`
+    })
+  };
+
+  const reuseLineProps: LineProps<ReuseChartDatum> = {
+    data: reuseChartData,
+    xField: 'periodLabel',
+    yField: 'averagePercent',
+    height: 280,
+    smooth: true,
+    point: {
+      size: 4
+    },
+    yAxis: {
+      label: {
+        formatter: (value: string) => `${value}%`
+      }
+    },
+    tooltip: ({ averagePercent, periodLabel }) => ({
+      name: periodLabel,
+      value: `${averagePercent}%`
+    })
+  };
+
+  const deploymentPieProps: PieProps<DistributionDatum> = {
+    data: deploymentDistribution,
+    angleField: 'value',
+    colorField: 'label',
+    legend: { position: 'bottom' },
+    height: 260,
+    tooltip: ({ label, value }) => ({
+      name: label,
+      value: `${value} мод.`
+    })
+  };
+
+  const clientPieProps: PieProps<DistributionDatum> = {
+    data: clientDistribution,
+    angleField: 'value',
+    colorField: 'label',
+    legend: { position: 'bottom' },
+    height: 260,
+    tooltip: ({ label, value }) => ({
+      name: label,
+      value: `${value} мод.`
+    })
+  };
+
+  const teamBarProps: BarProps<TeamDatum> = {
+    data: teamLeaders,
+    xField: 'count',
+    yField: 'team',
+    seriesField: 'team',
+    legend: false,
+    height: 260,
+    autoFit: true
+  };
+
+  return (
+    <div className={styles.container}>
+      <section className={styles.summaryGrid}>
+        <Card className={styles.summaryCard} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="xs" view="secondary">
+            Активные системы
+          </Text>
+          <Text size="3xl" weight="bold" className={styles.summaryValue}>
+            {systemCount}
+          </Text>
+          <Text size="xs" view="ghost">
+            Сформированы по уникальным продуктовым контурам
+          </Text>
+        </Card>
+        <Card className={styles.summaryCard} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="xs" view="secondary">
+            Модули в каталоге
+          </Text>
+          <Text size="3xl" weight="bold" className={styles.summaryValue}>
+            {moduleCount}
+          </Text>
+          <Text size="xs" view="ghost">
+            Включая совместно используемые компоненты
+          </Text>
+        </Card>
+        <Card className={styles.summaryCard} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="xs" view="secondary">
+            Домены без функций
+          </Text>
+          <Text size="3xl" weight="bold" className={styles.summaryValue}>
+            {domainWithoutModules.length}
+          </Text>
+          <Text size="xs" view="ghost">
+            Требуют наполнения или ревизии
+          </Text>
+        </Card>
+        <Card className={styles.summaryCard} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="xs" view="secondary">
+            Артефакты данных
+          </Text>
+          <Text size="3xl" weight="bold" className={styles.summaryValue}>
+            {artifactCount}
+          </Text>
+          <Text size="xs" view="ghost">
+            Используются при обмене между командами
+          </Text>
+        </Card>
+      </section>
+
+      <section className={styles.chartsGrid}>
+        <Card className={styles.card} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="s" weight="semibold" className={styles.cardTitle}>
+            Статусы модулей
+          </Text>
+          <Pie {...modulesByStatusPieProps} />
+        </Card>
+        <Card className={styles.card} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="s" weight="semibold" className={styles.cardTitle}>
+            Артефакты по типам файлов
+          </Text>
+          <Column {...artifactColumnProps} />
+        </Card>
+        <Card className={styles.card} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="s" weight="semibold" className={styles.cardTitle}>
+            Динамика среднего индекса переиспользования
+          </Text>
+          <Line {...reuseLineProps} />
+        </Card>
+      </section>
+
+      <section className={styles.chartsGrid}>
+        <Card className={styles.card} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="s" weight="semibold" className={styles.cardTitle}>
+            Инструменты деплоя
+          </Text>
+          <Pie {...deploymentPieProps} />
+        </Card>
+        <Card className={styles.card} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="s" weight="semibold" className={styles.cardTitle}>
+            Каналы доставки клиентам
+          </Text>
+          <Pie {...clientPieProps} />
+        </Card>
+        <Card className={styles.card} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="s" weight="semibold" className={styles.cardTitle}>
+            Команды-лидеры по числу модулей
+          </Text>
+          <Bar {...teamBarProps} />
+        </Card>
+      </section>
+
+      <section className={styles.splitGrid}>
+        <Card className={styles.card} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="s" weight="semibold" className={styles.cardTitle}>
+            Разрез по системам и статусам
+          </Text>
+          <table className={styles.systemTable}>
+            <thead>
+              <tr>
+                <th>Система</th>
+                <th>Всего</th>
+                {statusOrder.map((status) => (
+                  <th key={status}>{statusLabels[status]}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {systems.map((system) => (
+                <tr key={system.name}>
+                  <td>{system.name}</td>
+                  <td>{system.total}</td>
+                  {statusOrder.map((status) => (
+                    <td key={status}>
+                      <span className={styles.statusPill} data-status={statusBadgeView[status]}>
+                        {system.statuses[status]}
+                      </span>
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Card>
+        <Card className={styles.card} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="s" weight="semibold" className={styles.cardTitle}>
+            Домены без закреплённых функций
+          </Text>
+          <div className={styles.domainList}>
+            {domainWithoutModules.length === 0 ? (
+              <Text size="s" view="secondary">
+                Все домены покрыты модулями
+              </Text>
+            ) : (
+              domainWithoutModules.map((domain) => (
+                <span key={domain.id} className={styles.domainPill}>
+                  {domainNameById[domain.id] ?? domain.name}
+                </span>
+              ))
+            )}
+          </div>
+        </Card>
+      </section>
+
+      <Card className={styles.card} verticalSpace="l" horizontalSpace="l" shadow={false}>
+        <Text size="s" weight="semibold" className={styles.cardTitle}>
+          Дополнительные метрики мониторинга
+        </Text>
+        <div className={styles.metricsList}>
+          <div className={styles.metricsItem}>
+            <span className={styles.metricsLabel}>Средний уровень автоматизации тестов</span>
+            <span className={styles.metricsValue}>{Math.round(averageAutomation)}%</span>
+          </div>
+          <div className={styles.metricsItem}>
+            <span className={styles.metricsLabel}>Среднее число зависимостей на модуль</span>
+            <span className={styles.metricsValue}>{averageDependencies.toFixed(1)}</span>
+          </div>
+          <div className={styles.metricsItem}>
+            <span className={styles.metricsLabel}>Средняя длительность ответа сервисов</span>
+            <span className={styles.metricsValue}>{Math.round(averageResponseTime)} мс</span>
+          </div>
+          <div className={styles.metricsItem}>
+            <span className={styles.metricsLabel}>Модулей с интеграцией лицензирования</span>
+            <span className={styles.metricsValue}>
+              {licenseRatio.ratio}% ({licenseRatio.withLicense}/{moduleCount})
+            </span>
+          </div>
+          <div className={styles.metricsItem}>
+            <span className={styles.metricsLabel}>Среднее число артефактов на модуль</span>
+            <span className={styles.metricsValue}>{artifactsPerModule}</span>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+function flattenDomains(nodes: DomainNode[]): DomainNode[] {
+  return nodes.flatMap((node) => [node, ...(node.children ? flattenDomains(node.children) : [])]);
+}
+
+function resolveArtifactType(artifact: ArtifactNode): string {
+  const extension = extractExtension(artifact.sampleUrl);
+
+  if (extension === 'xlsx') {
+    return 'Excel (XLSX)';
+  }
+
+  if (extension === 'las') {
+    return 'LAS';
+  }
+
+  if (extension === 'csv') {
+    return 'CSV';
+  }
+
+  if (extension === 'json') {
+    return 'JSON';
+  }
+
+  if (extension === 'parquet') {
+    return 'Parquet';
+  }
+
+  if (extension === 'pdf') {
+    return 'PDF';
+  }
+
+  return artifact.dataType;
+}
+
+function extractExtension(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const pathname = parsed.pathname;
+    const segments = pathname.split('/');
+    const last = segments[segments.length - 1];
+    if (!last) {
+      return null;
+    }
+    const clean = last.split('.')[1] ? last.split('.').pop() : null;
+    return clean ? clean.toLowerCase() : null;
+  } catch {
+    const parts = url.split('?')[0].split('.');
+    return parts.length > 1 ? parts.pop()?.toLowerCase() ?? null : null;
+  }
+}
+
+function formatPeriod(period: string): string {
+  const [year, month] = period.split('-');
+  if (!month) {
+    return period;
+  }
+
+  const monthIndex = Number(month);
+  if (Number.isNaN(monthIndex) || monthIndex < 1 || monthIndex > 12) {
+    return period;
+  }
+
+  const monthNames = ['янв', 'фев', 'мар', 'апр', 'май', 'июн', 'июл', 'авг', 'сен', 'окт', 'ноя', 'дек'];
+  return `${monthNames[monthIndex - 1]} ${year}`;
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sum = values.reduce((total, value) => total + value, 0);
+  return sum / values.length;
+}
+
+export default StatsDashboard;

--- a/src/data.ts
+++ b/src/data.ts
@@ -19,6 +19,43 @@ export type ModuleOutput = {
   consumerIds?: string[];
 };
 
+export type TeamRole =
+  | 'Владелец продукта'
+  | 'Эксперт R&D'
+  | 'Аналитик'
+  | 'Backend'
+  | 'Frontend'
+  | 'Архитектор'
+  | 'Тестировщик';
+
+export type TeamMember = {
+  id: string;
+  fullName: string;
+  role: TeamRole;
+};
+
+export type LibraryDependency = {
+  name: string;
+  version: string;
+};
+
+export type UserStats = {
+  companies: number;
+  licenses: number;
+};
+
+export type ModuleMetrics = {
+  tests: number;
+  coverage: number;
+  automationRate: number;
+};
+
+export type NonFunctionalRequirements = {
+  responseTimeMs: number;
+  throughputRps: number;
+  resourceConsumption: string;
+};
+
 export type ModuleNode = {
   id: string;
   name: string;
@@ -26,20 +63,31 @@ export type ModuleNode = {
   domains: string[];
   team: string;
   owner: string;
+  productName: string;
+  projectTeam: TeamMember[];
+  technologyStack: string[];
+  localization: string;
+  ridOwner: string;
+  userStats: UserStats;
   status: ModuleStatus;
   repository?: string;
   api?: string;
+  specificationUrl: string;
+  apiContractsUrl: string;
+  techDesignUrl: string;
+  architectureDiagramUrl: string;
+  licenseServerIntegrated: boolean;
+  libraries: LibraryDependency[];
+  clientType: 'desktop' | 'web';
+  deploymentTool: 'docker' | 'kubernetes';
   dependencies: string[];
   produces: string[];
   reuseScore: number;
-  metrics: {
-    tests?: number;
-    coverage?: number;
-    latencyMs?: number;
-  };
+  metrics: ModuleMetrics;
   dataIn: ModuleInput[];
   dataOut: ModuleOutput[];
   formula: string;
+  nonFunctional: NonFunctionalRequirements;
 };
 
 export const domainTree: DomainNode[] = [
@@ -123,16 +171,42 @@ export const modules: ModuleNode[] = [
     domains: ['well-operations', 'lift-diagnostics'],
     team: 'Field Data Platform',
     owner: 'Наталья Коваль',
+    productName: 'Well Insight Suite',
+    projectTeam: [
+      { id: 'telemetry-owner', fullName: 'Наталья Коваль', role: 'Владелец продукта' },
+      { id: 'telemetry-rd', fullName: 'Роман Кузнецов', role: 'Эксперт R&D' },
+      { id: 'telemetry-analyst', fullName: 'Павел Лобанов', role: 'Аналитик' },
+      { id: 'telemetry-backend', fullName: 'Василий Титов', role: 'Backend' },
+      { id: 'telemetry-frontend', fullName: 'Евгения Громова', role: 'Frontend' },
+      { id: 'telemetry-architect', fullName: 'Артём Есипов', role: 'Архитектор' },
+      { id: 'telemetry-tester', fullName: 'Марина Куприянова', role: 'Тестировщик' }
+    ],
+    technologyStack: ['TypeScript', 'NestJS', 'Apache Kafka', 'PostgreSQL'],
+    localization: 'Мультиязычная (ru, en)',
+    ridOwner: 'АО «НефтеИнтеллект»',
+    userStats: { companies: 12, licenses: 1850 },
     status: 'production',
     repository: 'https://git.example.com/upstream/telemetry-cleansing',
     api: 'Kafka stream telemetry.normalized',
+    specificationUrl: 'https://confluence.example.com/pages/viewpage.action?pageId=11001',
+    apiContractsUrl: 'https://docs.example.com/apis/telemetry-cleansing',
+    techDesignUrl: 'https://confluence.example.com/display/FD/Telemetry+Cleansing+Design',
+    architectureDiagramUrl: 'https://diagrams.example.com/telemetry-cleansing',
+    licenseServerIntegrated: true,
+    libraries: [
+      { name: '@nestjs/core', version: '9.4.2' },
+      { name: 'rxjs', version: '7.8.1' },
+      { name: 'kafkajs', version: '2.2.4' }
+    ],
+    clientType: 'web',
+    deploymentTool: 'kubernetes',
     dependencies: [],
     produces: ['artifact-clean-telemetry'],
     reuseScore: 0.86,
     metrics: {
       tests: 210,
       coverage: 93,
-      latencyMs: 240
+      automationRate: 88
     },
     dataIn: [
       {
@@ -151,7 +225,12 @@ export const modules: ModuleNode[] = [
         consumerIds: ['module-well-dashboard', 'module-lift-predictor']
       }
     ],
-    formula: 'value_norm = (value_raw - bias) * scale'
+    formula: 'value_norm = (value_raw - bias) * scale',
+    nonFunctional: {
+      responseTimeMs: 240,
+      throughputRps: 320,
+      resourceConsumption: '4 vCPU / 12 GB RAM'
+    }
   },
   {
     id: 'module-well-dashboard',
@@ -161,16 +240,42 @@ export const modules: ModuleNode[] = [
     domains: ['well-operations', 'short-term-planning'],
     team: 'Production Control Room',
     owner: 'Илья Киселёв',
+    productName: 'Production Command Center',
+    projectTeam: [
+      { id: 'dashboard-owner', fullName: 'Илья Киселёв', role: 'Владелец продукта' },
+      { id: 'dashboard-rd', fullName: 'Станислав Ершов', role: 'Эксперт R&D' },
+      { id: 'dashboard-analyst', fullName: 'Ольга Захарова', role: 'Аналитик' },
+      { id: 'dashboard-frontend', fullName: 'Екатерина Белова', role: 'Frontend' },
+      { id: 'dashboard-backend', fullName: 'Алексей Гущин', role: 'Backend' },
+      { id: 'dashboard-architect', fullName: 'Владимир Копылов', role: 'Архитектор' },
+      { id: 'dashboard-tester', fullName: 'Галина Рябова', role: 'Тестировщик' }
+    ],
+    technologyStack: ['TypeScript', 'React', 'D3.js', 'Node.js'],
+    localization: 'Мультиязычная (ru, en, kk)',
+    ridOwner: 'АО «НефтеИнтеллект»',
+    userStats: { companies: 18, licenses: 4200 },
     status: 'production',
     repository: 'https://git.example.com/production/well-dashboard',
     api: 'REST /api/v1/wells/dashboard',
+    specificationUrl: 'https://confluence.example.com/pages/viewpage.action?pageId=11852',
+    apiContractsUrl: 'https://docs.example.com/apis/well-dashboard',
+    techDesignUrl: 'https://confluence.example.com/display/PC/well-dashboard-tech-design',
+    architectureDiagramUrl: 'https://diagrams.example.com/well-dashboard',
+    licenseServerIntegrated: true,
+    libraries: [
+      { name: 'react', version: '18.2.0' },
+      { name: '@tanstack/react-query', version: '4.35.3' },
+      { name: 'echarts', version: '5.5.0' }
+    ],
+    clientType: 'web',
+    deploymentTool: 'kubernetes',
     dependencies: ['module-telemetry-cleansing'],
     produces: ['artifact-deviation-report'],
     reuseScore: 0.74,
     metrics: {
       tests: 168,
       coverage: 88,
-      latencyMs: 360
+      automationRate: 82
     },
     dataIn: [
       {
@@ -190,7 +295,12 @@ export const modules: ModuleNode[] = [
         consumerIds: ['module-shift-planner', 'module-investment-evaluator']
       }
     ],
-    formula: 'deviation = fact_volume - plan_volume'
+    formula: 'deviation = fact_volume - plan_volume',
+    nonFunctional: {
+      responseTimeMs: 360,
+      throughputRps: 210,
+      resourceConsumption: '6 vCPU / 16 GB RAM'
+    }
   },
   {
     id: 'module-shift-planner',
@@ -200,16 +310,42 @@ export const modules: ModuleNode[] = [
     domains: ['short-term-planning'],
     team: 'Production Planning',
     owner: 'Елена Савина',
+    productName: 'Shift Orchestrator',
+    projectTeam: [
+      { id: 'shift-owner', fullName: 'Елена Савина', role: 'Владелец продукта' },
+      { id: 'shift-rd', fullName: 'Николай Дорошин', role: 'Эксперт R&D' },
+      { id: 'shift-analyst', fullName: 'Ксения Литвинова', role: 'Аналитик' },
+      { id: 'shift-backend', fullName: 'Максим Фадеев', role: 'Backend' },
+      { id: 'shift-frontend', fullName: 'Инна Котова', role: 'Frontend' },
+      { id: 'shift-architect', fullName: 'Рустам Ганиев', role: 'Архитектор' },
+      { id: 'shift-tester', fullName: 'Дарья Королёва', role: 'Тестировщик' }
+    ],
+    technologyStack: ['Kotlin', 'Spring Boot', 'PostgreSQL', 'Camunda'],
+    localization: 'Только русский язык',
+    ridOwner: 'АО «НефтеИнтеллект»',
+    userStats: { companies: 9, licenses: 1150 },
     status: 'production',
     repository: 'https://git.example.com/production/shift-planner',
     api: 'REST /api/v1/plans/shift',
+    specificationUrl: 'https://confluence.example.com/pages/viewpage.action?pageId=21045',
+    apiContractsUrl: 'https://docs.example.com/apis/shift-planner',
+    techDesignUrl: 'https://confluence.example.com/display/PC/shift-planner-design',
+    architectureDiagramUrl: 'https://diagrams.example.com/shift-planner',
+    licenseServerIntegrated: false,
+    libraries: [
+      { name: 'spring-boot-starter-web', version: '3.1.2' },
+      { name: 'camunda-bpm-spring-boot-starter', version: '7.19.0' },
+      { name: 'mapstruct', version: '1.5.5.Final' }
+    ],
+    clientType: 'desktop',
+    deploymentTool: 'kubernetes',
     dependencies: ['module-well-dashboard'],
     produces: ['artifact-shift-plan'],
     reuseScore: 0.69,
     metrics: {
       tests: 124,
       coverage: 85,
-      latencyMs: 540
+      automationRate: 76
     },
     dataIn: [
       {
@@ -229,7 +365,12 @@ export const modules: ModuleNode[] = [
         consumerIds: ['module-investment-evaluator']
       }
     ],
-    formula: 'plan = optimize(targets, constraints)'
+    formula: 'plan = optimize(targets, constraints)',
+    nonFunctional: {
+      responseTimeMs: 540,
+      throughputRps: 120,
+      resourceConsumption: '6 vCPU / 24 GB RAM'
+    }
   },
   {
     id: 'module-lift-predictor',
@@ -239,16 +380,42 @@ export const modules: ModuleNode[] = [
     domains: ['lift-diagnostics'],
     team: 'Reliability Engineering',
     owner: 'Сергей Баширов',
+    productName: 'Reliability Intelligence Platform',
+    projectTeam: [
+      { id: 'lift-owner', fullName: 'Сергей Баширов', role: 'Владелец продукта' },
+      { id: 'lift-rd', fullName: 'Дарья Прокофьева', role: 'Эксперт R&D' },
+      { id: 'lift-analyst', fullName: 'Антон Тарский', role: 'Аналитик' },
+      { id: 'lift-backend', fullName: 'Владислав Кочетков', role: 'Backend' },
+      { id: 'lift-frontend', fullName: 'Светлана Бушуева', role: 'Frontend' },
+      { id: 'lift-architect', fullName: 'Игорь Щербаков', role: 'Архитектор' },
+      { id: 'lift-tester', fullName: 'Олеся Макарова', role: 'Тестировщик' }
+    ],
+    technologyStack: ['Python', 'FastAPI', 'PyTorch', 'Apache Kafka'],
+    localization: 'Мультиязычная (ru, en)',
+    ridOwner: 'АО «НефтеИнтеллект»',
+    userStats: { companies: 7, licenses: 640 },
     status: 'in-dev',
     repository: 'https://git.example.com/reliability/lift-predictor',
     api: 'gRPC reliability.FailurePredictor/Score',
+    specificationUrl: 'https://confluence.example.com/pages/viewpage.action?pageId=30551',
+    apiContractsUrl: 'https://docs.example.com/apis/lift-predictor',
+    techDesignUrl: 'https://confluence.example.com/display/RD/lift-predictor-design',
+    architectureDiagramUrl: 'https://diagrams.example.com/lift-predictor',
+    licenseServerIntegrated: false,
+    libraries: [
+      { name: 'fastapi', version: '0.111.0' },
+      { name: 'pydantic', version: '1.10.13' },
+      { name: 'torch', version: '2.1.0' }
+    ],
+    clientType: 'web',
+    deploymentTool: 'docker',
     dependencies: ['module-telemetry-cleansing'],
     produces: ['artifact-failure-forecast'],
     reuseScore: 0.58,
     metrics: {
       tests: 98,
       coverage: 80,
-      latencyMs: 620
+      automationRate: 72
     },
     dataIn: [
       {
@@ -268,7 +435,12 @@ export const modules: ModuleNode[] = [
         consumerIds: ['module-energy-optimizer']
       }
     ],
-    formula: 'p_fail = model(telemetry, history)'
+    formula: 'p_fail = model(telemetry, history)',
+    nonFunctional: {
+      responseTimeMs: 620,
+      throughputRps: 85,
+      resourceConsumption: '8 vCPU / 32 GB RAM (GPU)'
+    }
   },
   {
     id: 'module-energy-optimizer',
@@ -278,16 +450,42 @@ export const modules: ModuleNode[] = [
     domains: ['energy-optimization'],
     team: 'Energy Efficiency Lab',
     owner: 'Мария Егорова',
+    productName: 'Reliability Intelligence Platform',
+    projectTeam: [
+      { id: 'energy-owner', fullName: 'Мария Егорова', role: 'Владелец продукта' },
+      { id: 'energy-rd', fullName: 'Виктор Маликов', role: 'Эксперт R&D' },
+      { id: 'energy-analyst', fullName: 'Людмила Котова', role: 'Аналитик' },
+      { id: 'energy-backend', fullName: 'Григорий Аверин', role: 'Backend' },
+      { id: 'energy-frontend', fullName: 'Елена Серова', role: 'Frontend' },
+      { id: 'energy-architect', fullName: 'Кирилл Никитин', role: 'Архитектор' },
+      { id: 'energy-tester', fullName: 'Жанна Фирсова', role: 'Тестировщик' }
+    ],
+    technologyStack: ['Python', 'FastAPI', 'NumPy', 'Redis'],
+    localization: 'Мультиязычная (ru, en)',
+    ridOwner: 'АО «НефтеИнтеллект»',
+    userStats: { companies: 11, licenses: 980 },
     status: 'production',
     repository: 'https://git.example.com/energy/optimizer',
     api: 'REST /api/v1/energy/optimization',
+    specificationUrl: 'https://confluence.example.com/pages/viewpage.action?pageId=31502',
+    apiContractsUrl: 'https://docs.example.com/apis/energy-optimizer',
+    techDesignUrl: 'https://confluence.example.com/display/EN/energy-optimizer-design',
+    architectureDiagramUrl: 'https://diagrams.example.com/energy-optimizer',
+    licenseServerIntegrated: true,
+    libraries: [
+      { name: 'fastapi', version: '0.111.0' },
+      { name: 'numpy', version: '1.26.4' },
+      { name: 'scikit-learn', version: '1.4.2' }
+    ],
+    clientType: 'web',
+    deploymentTool: 'kubernetes',
     dependencies: ['module-lift-predictor'],
     produces: ['artifact-energy-balance'],
     reuseScore: 0.77,
     metrics: {
       tests: 156,
       coverage: 87,
-      latencyMs: 480
+      automationRate: 81
     },
     dataIn: [
       {
@@ -311,7 +509,12 @@ export const modules: ModuleNode[] = [
         label: 'Рекомендации по энергоэффективности'
       }
     ],
-    formula: 'balance = Σ(load_i * tariff_i) - savings_risk_adjusted'
+    formula: 'balance = Σ(load_i * tariff_i) - savings_risk_adjusted',
+    nonFunctional: {
+      responseTimeMs: 480,
+      throughputRps: 150,
+      resourceConsumption: '6 vCPU / 20 GB RAM'
+    }
   },
   {
     id: 'module-investment-evaluator',
@@ -321,16 +524,42 @@ export const modules: ModuleNode[] = [
     domains: ['investment-analysis'],
     team: 'Corporate Finance Analytics',
     owner: 'Дмитрий Орлов',
+    productName: 'Capital Strategy Workspace',
+    projectTeam: [
+      { id: 'invest-owner', fullName: 'Дмитрий Орлов', role: 'Владелец продукта' },
+      { id: 'invest-rd', fullName: 'Вера Литвиненко', role: 'Эксперт R&D' },
+      { id: 'invest-analyst', fullName: 'Олег Каменев', role: 'Аналитик' },
+      { id: 'invest-backend', fullName: 'Михаил Греков', role: 'Backend' },
+      { id: 'invest-frontend', fullName: 'Анна Шульгина', role: 'Frontend' },
+      { id: 'invest-architect', fullName: 'Игорь Цветков', role: 'Архитектор' },
+      { id: 'invest-tester', fullName: 'Полина Юрьева', role: 'Тестировщик' }
+    ],
+    technologyStack: ['C#', '.NET 7', 'React', 'MS SQL'],
+    localization: 'Мультиязычная (ru, en)',
+    ridOwner: 'АО «НефтеИнтеллект»',
+    userStats: { companies: 15, licenses: 3100 },
     status: 'production',
     repository: 'https://git.example.com/finance/invest-evaluator',
     api: 'REST /api/v1/investments/score',
+    specificationUrl: 'https://confluence.example.com/pages/viewpage.action?pageId=40211',
+    apiContractsUrl: 'https://docs.example.com/apis/investment-evaluator',
+    techDesignUrl: 'https://confluence.example.com/display/FIN/investment-evaluator-design',
+    architectureDiagramUrl: 'https://diagrams.example.com/investment-evaluator',
+    licenseServerIntegrated: true,
+    libraries: [
+      { name: 'AutoMapper', version: '12.0.1' },
+      { name: 'Dapper', version: '2.1.35' },
+      { name: 'Serilog', version: '3.0.1' }
+    ],
+    clientType: 'desktop',
+    deploymentTool: 'kubernetes',
     dependencies: ['module-shift-planner', 'module-energy-optimizer'],
     produces: ['artifact-investment-brief'],
     reuseScore: 0.83,
     metrics: {
       tests: 204,
       coverage: 91,
-      latencyMs: 850
+      automationRate: 86
     },
     dataIn: [
       {
@@ -354,7 +583,12 @@ export const modules: ModuleNode[] = [
         label: 'Показатели NPV и IRR'
       }
     ],
-    formula: 'NPV = Σ((cash_in_t - cash_out_t) / (1 + WACC)^t) - CAPEX'
+    formula: 'NPV = Σ((cash_in_t - cash_out_t) / (1 + WACC)^t) - CAPEX',
+    nonFunctional: {
+      responseTimeMs: 850,
+      throughputRps: 65,
+      resourceConsumption: '10 vCPU / 40 GB RAM'
+    }
   },
   {
     id: 'module-risk-register',
@@ -364,16 +598,42 @@ export const modules: ModuleNode[] = [
     domains: ['investment-analysis'],
     team: 'Project Governance',
     owner: 'Анна Лебедева',
+    productName: 'Capital Strategy Workspace',
+    projectTeam: [
+      { id: 'risk-owner', fullName: 'Анна Лебедева', role: 'Владелец продукта' },
+      { id: 'risk-rd', fullName: 'Руслан Фетисов', role: 'Эксперт R&D' },
+      { id: 'risk-analyst', fullName: 'Ирина Сидорова', role: 'Аналитик' },
+      { id: 'risk-backend', fullName: 'Георгий Аксенов', role: 'Backend' },
+      { id: 'risk-frontend', fullName: 'Алёна Крайнова', role: 'Frontend' },
+      { id: 'risk-architect', fullName: 'Виталий Муромцев', role: 'Архитектор' },
+      { id: 'risk-tester', fullName: 'Наталия Фомина', role: 'Тестировщик' }
+    ],
+    technologyStack: ['TypeScript', 'NestJS', 'PostgreSQL', 'RabbitMQ'],
+    localization: 'Только русский язык',
+    ridOwner: 'АО «НефтеИнтеллект»',
+    userStats: { companies: 6, licenses: 540 },
     status: 'in-dev',
     repository: 'https://git.example.com/governance/risk-register',
     api: 'REST /api/v1/risks',
+    specificationUrl: 'https://confluence.example.com/pages/viewpage.action?pageId=41222',
+    apiContractsUrl: 'https://docs.example.com/apis/risk-register',
+    techDesignUrl: 'https://confluence.example.com/display/GOV/risk-register-design',
+    architectureDiagramUrl: 'https://diagrams.example.com/risk-register',
+    licenseServerIntegrated: false,
+    libraries: [
+      { name: '@nestjs/swagger', version: '7.1.12' },
+      { name: 'typeorm', version: '0.3.20' },
+      { name: 'pg', version: '8.11.3' }
+    ],
+    clientType: 'web',
+    deploymentTool: 'docker',
     dependencies: [],
     produces: [],
     reuseScore: 0.42,
     metrics: {
       tests: 48,
       coverage: 72,
-      latencyMs: 620
+      automationRate: 60
     },
     dataIn: [
       {
@@ -391,7 +651,12 @@ export const modules: ModuleNode[] = [
         label: 'Дашборд рисков'
       }
     ],
-    formula: 'risk_score = probability * impact'
+    formula: 'risk_score = probability * impact',
+    nonFunctional: {
+      responseTimeMs: 620,
+      throughputRps: 55,
+      resourceConsumption: '4 vCPU / 10 GB RAM'
+    }
   }
 ];
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -818,3 +818,23 @@ export const moduleLinks: GraphLink[] = modules.flatMap((module) => {
 });
 
 export { moduleById };
+
+export type ReuseTrendPoint = {
+  period: string;
+  averageScore: number;
+};
+
+export const reuseIndexHistory: ReuseTrendPoint[] = [
+  { period: '2023-11', averageScore: 0.42 },
+  { period: '2023-12', averageScore: 0.44 },
+  { period: '2024-01', averageScore: 0.45 },
+  { period: '2024-02', averageScore: 0.47 },
+  { period: '2024-03', averageScore: 0.5 },
+  { period: '2024-04', averageScore: 0.53 },
+  { period: '2024-05', averageScore: 0.55 },
+  { period: '2024-06', averageScore: 0.57 },
+  { period: '2024-07', averageScore: 0.6 },
+  { period: '2024-08', averageScore: 0.62 },
+  { period: '2024-09', averageScore: 0.65 },
+  { period: '2024-10', averageScore: 0.66 }
+];

--- a/src/data.ts
+++ b/src/data.ts
@@ -34,6 +34,11 @@ export type TeamMember = {
   role: TeamRole;
 };
 
+export type RidOwner = {
+  company: string;
+  division: string;
+};
+
 export type LibraryDependency = {
   name: string;
   version: string;
@@ -54,6 +59,7 @@ export type NonFunctionalRequirements = {
   responseTimeMs: number;
   throughputRps: number;
   resourceConsumption: string;
+  baselineUsers: number;
 };
 
 export type ModuleNode = {
@@ -62,12 +68,11 @@ export type ModuleNode = {
   description: string;
   domains: string[];
   team: string;
-  owner: string;
   productName: string;
   projectTeam: TeamMember[];
   technologyStack: string[];
   localization: string;
-  ridOwner: string;
+  ridOwner: RidOwner;
   userStats: UserStats;
   status: ModuleStatus;
   repository?: string;
@@ -170,7 +175,6 @@ export const modules: ModuleNode[] = [
       'Собирает телеметрию скважин, нормализует показания датчиков и обогащает их паспортами оборудования.',
     domains: ['well-operations', 'lift-diagnostics'],
     team: 'Field Data Platform',
-    owner: 'Наталья Коваль',
     productName: 'Well Insight Suite',
     projectTeam: [
       { id: 'telemetry-owner', fullName: 'Наталья Коваль', role: 'Владелец продукта' },
@@ -183,7 +187,10 @@ export const modules: ModuleNode[] = [
     ],
     technologyStack: ['TypeScript', 'NestJS', 'Apache Kafka', 'PostgreSQL'],
     localization: 'Мультиязычная (ru, en)',
-    ridOwner: 'АО «НефтеИнтеллект»',
+    ridOwner: {
+      company: 'АО «НефтеИнтеллект»',
+      division: 'Департамент цифровых сервисов'
+    },
     userStats: { companies: 12, licenses: 1850 },
     status: 'production',
     repository: 'https://git.example.com/upstream/telemetry-cleansing',
@@ -229,7 +236,8 @@ export const modules: ModuleNode[] = [
     nonFunctional: {
       responseTimeMs: 240,
       throughputRps: 320,
-      resourceConsumption: '4 vCPU / 12 GB RAM'
+      resourceConsumption: '4 vCPU / 12 GB RAM',
+      baselineUsers: 1200
     }
   },
   {
@@ -239,7 +247,6 @@ export const modules: ModuleNode[] = [
       'Агрегирует показатели фонда скважин, визуализирует отклонения факта от сменных лимитов и формирует предупреждения.',
     domains: ['well-operations', 'short-term-planning'],
     team: 'Production Control Room',
-    owner: 'Илья Киселёв',
     productName: 'Production Command Center',
     projectTeam: [
       { id: 'dashboard-owner', fullName: 'Илья Киселёв', role: 'Владелец продукта' },
@@ -252,7 +259,10 @@ export const modules: ModuleNode[] = [
     ],
     technologyStack: ['TypeScript', 'React', 'D3.js', 'Node.js'],
     localization: 'Мультиязычная (ru, en, kk)',
-    ridOwner: 'АО «НефтеИнтеллект»',
+    ridOwner: {
+      company: 'АО «НефтеИнтеллект»',
+      division: 'Центр производственного контроля'
+    },
     userStats: { companies: 18, licenses: 4200 },
     status: 'production',
     repository: 'https://git.example.com/production/well-dashboard',
@@ -299,7 +309,8 @@ export const modules: ModuleNode[] = [
     nonFunctional: {
       responseTimeMs: 360,
       throughputRps: 210,
-      resourceConsumption: '6 vCPU / 16 GB RAM'
+      resourceConsumption: '6 vCPU / 16 GB RAM',
+      baselineUsers: 1800
     }
   },
   {
@@ -309,7 +320,6 @@ export const modules: ModuleNode[] = [
       'Оптимизирует сменные задания на основе фактических ограничений, отклонений и доступности оборудования.',
     domains: ['short-term-planning'],
     team: 'Production Planning',
-    owner: 'Елена Савина',
     productName: 'Shift Orchestrator',
     projectTeam: [
       { id: 'shift-owner', fullName: 'Елена Савина', role: 'Владелец продукта' },
@@ -322,7 +332,10 @@ export const modules: ModuleNode[] = [
     ],
     technologyStack: ['Kotlin', 'Spring Boot', 'PostgreSQL', 'Camunda'],
     localization: 'Только русский язык',
-    ridOwner: 'АО «НефтеИнтеллект»',
+    ridOwner: {
+      company: 'АО «НефтеИнтеллект»',
+      division: 'Управление оперативного планирования'
+    },
     userStats: { companies: 9, licenses: 1150 },
     status: 'production',
     repository: 'https://git.example.com/production/shift-planner',
@@ -369,7 +382,8 @@ export const modules: ModuleNode[] = [
     nonFunctional: {
       responseTimeMs: 540,
       throughputRps: 120,
-      resourceConsumption: '6 vCPU / 24 GB RAM'
+      resourceConsumption: '6 vCPU / 24 GB RAM',
+      baselineUsers: 650
     }
   },
   {
@@ -379,7 +393,6 @@ export const modules: ModuleNode[] = [
       'Использует исторические ремонты и текущие режимы работы для расчёта вероятности отказов погружных установок.',
     domains: ['lift-diagnostics'],
     team: 'Reliability Engineering',
-    owner: 'Сергей Баширов',
     productName: 'Reliability Intelligence Platform',
     projectTeam: [
       { id: 'lift-owner', fullName: 'Сергей Баширов', role: 'Владелец продукта' },
@@ -392,7 +405,10 @@ export const modules: ModuleNode[] = [
     ],
     technologyStack: ['Python', 'FastAPI', 'PyTorch', 'Apache Kafka'],
     localization: 'Мультиязычная (ru, en)',
-    ridOwner: 'АО «НефтеИнтеллект»',
+    ridOwner: {
+      company: 'АО «НефтеИнтеллект»',
+      division: 'Лаборатория надежности оборудования'
+    },
     userStats: { companies: 7, licenses: 640 },
     status: 'in-dev',
     repository: 'https://git.example.com/reliability/lift-predictor',
@@ -439,7 +455,8 @@ export const modules: ModuleNode[] = [
     nonFunctional: {
       responseTimeMs: 620,
       throughputRps: 85,
-      resourceConsumption: '8 vCPU / 32 GB RAM (GPU)'
+      resourceConsumption: '8 vCPU / 32 GB RAM (GPU)',
+      baselineUsers: 320
     }
   },
   {
@@ -449,7 +466,6 @@ export const modules: ModuleNode[] = [
       'Рассчитывает режимы работы насосов для снижения энергозатрат с учётом риска отказов и тарифов.',
     domains: ['energy-optimization'],
     team: 'Energy Efficiency Lab',
-    owner: 'Мария Егорова',
     productName: 'Reliability Intelligence Platform',
     projectTeam: [
       { id: 'energy-owner', fullName: 'Мария Егорова', role: 'Владелец продукта' },
@@ -462,7 +478,10 @@ export const modules: ModuleNode[] = [
     ],
     technologyStack: ['Python', 'FastAPI', 'NumPy', 'Redis'],
     localization: 'Мультиязычная (ru, en)',
-    ridOwner: 'АО «НефтеИнтеллект»',
+    ridOwner: {
+      company: 'АО «НефтеИнтеллект»',
+      division: 'Центр энергоэффективности'
+    },
     userStats: { companies: 11, licenses: 980 },
     status: 'production',
     repository: 'https://git.example.com/energy/optimizer',
@@ -513,7 +532,8 @@ export const modules: ModuleNode[] = [
     nonFunctional: {
       responseTimeMs: 480,
       throughputRps: 150,
-      resourceConsumption: '6 vCPU / 20 GB RAM'
+      resourceConsumption: '6 vCPU / 20 GB RAM',
+      baselineUsers: 900
     }
   },
   {
@@ -523,7 +543,6 @@ export const modules: ModuleNode[] = [
       'Консолидирует производственные планы и энергопоказатели для расчёта NPV, IRR и формирования инвестиционного досье.',
     domains: ['investment-analysis'],
     team: 'Corporate Finance Analytics',
-    owner: 'Дмитрий Орлов',
     productName: 'Capital Strategy Workspace',
     projectTeam: [
       { id: 'invest-owner', fullName: 'Дмитрий Орлов', role: 'Владелец продукта' },
@@ -536,7 +555,10 @@ export const modules: ModuleNode[] = [
     ],
     technologyStack: ['C#', '.NET 7', 'React', 'MS SQL'],
     localization: 'Мультиязычная (ru, en)',
-    ridOwner: 'АО «НефтеИнтеллект»',
+    ridOwner: {
+      company: 'АО «НефтеИнтеллект»',
+      division: 'Дирекция корпоративных финансов'
+    },
     userStats: { companies: 15, licenses: 3100 },
     status: 'production',
     repository: 'https://git.example.com/finance/invest-evaluator',
@@ -587,7 +609,8 @@ export const modules: ModuleNode[] = [
     nonFunctional: {
       responseTimeMs: 850,
       throughputRps: 65,
-      resourceConsumption: '10 vCPU / 40 GB RAM'
+      resourceConsumption: '10 vCPU / 40 GB RAM',
+      baselineUsers: 450
     }
   },
   {
@@ -597,7 +620,6 @@ export const modules: ModuleNode[] = [
       'Хранит и классифицирует риски инвестиционных проектов, собирая информацию из аудитов и комплаенс-проверок.',
     domains: ['investment-analysis'],
     team: 'Project Governance',
-    owner: 'Анна Лебедева',
     productName: 'Capital Strategy Workspace',
     projectTeam: [
       { id: 'risk-owner', fullName: 'Анна Лебедева', role: 'Владелец продукта' },
@@ -610,7 +632,10 @@ export const modules: ModuleNode[] = [
     ],
     technologyStack: ['TypeScript', 'NestJS', 'PostgreSQL', 'RabbitMQ'],
     localization: 'Только русский язык',
-    ridOwner: 'АО «НефтеИнтеллект»',
+    ridOwner: {
+      company: 'АО «НефтеИнтеллект»',
+      division: 'Служба управления рисками'
+    },
     userStats: { companies: 6, licenses: 540 },
     status: 'in-dev',
     repository: 'https://git.example.com/governance/risk-register',
@@ -655,7 +680,8 @@ export const modules: ModuleNode[] = [
     nonFunctional: {
       responseTimeMs: 620,
       throughputRps: 55,
-      resourceConsumption: '4 vCPU / 10 GB RAM'
+      resourceConsumption: '4 vCPU / 10 GB RAM',
+      baselineUsers: 280
     }
   }
 ];


### PR DESCRIPTION
## Summary
- add grouped collapsible sections to the module details panel with new general, calculation, technical and non-functional attributes
- extend module mock data with product, team, technology, documentation, licensing and non-functional details to support the richer view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6a9faf3048332b4d0c5bf981d2cc9