### PR TITLE
Add statistics dashboard view

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -4,8 +4,20 @@
 }
 
 .header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
   padding: 24px;
   border-bottom: 1px solid var(--color-bg-border);
+}
+
+.headerContent {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-width: 720px;
 }
 
 .main {
@@ -43,7 +55,7 @@
   padding: 16px;
   border-radius: 12px;
   background: var(--color-bg-default);
-  box-shadow: var(--shadow-layer); 
+  box-shadow: var(--shadow-layer);
 }
 
 .details {
@@ -51,6 +63,13 @@
   border-radius: 12px;
   box-shadow: var(--shadow-layer);
   overflow: auto;
+}
+
+.statsMain {
+  padding: 24px;
+  height: calc(100% - 92px);
+  box-sizing: border-box;
+  overflow-y: auto;
 }
 
 @media (max-width: 1440px) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,12 @@
 import { Layout } from '@consta/uikit/Layout';
+import { Tabs } from '@consta/uikit/Tabs';
 import { Text } from '@consta/uikit/Text';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import AnalyticsPanel from './components/AnalyticsPanel';
 import DomainTree from './components/DomainTree';
 import FiltersPanel from './components/FiltersPanel';
 import GraphView, { type GraphNode } from './components/GraphView';
+import StatsDashboard from './components/StatsDashboard';
 import NodeDetails from './components/NodeDetails';
 import {
   artifacts,
@@ -12,6 +14,7 @@ import {
   moduleById,
   moduleLinks,
   modules,
+  reuseIndexHistory,
   type DomainNode,
   type ModuleNode,
   type ModuleStatus
@@ -20,6 +23,13 @@ import styles from './App.module.css';
 
 const allStatuses: ModuleStatus[] = ['production', 'in-dev', 'deprecated'];
 const allTeams = Array.from(new Set(modules.map((module) => module.team))).sort();
+
+const viewTabs = [
+  { label: 'Связи', value: 'graph' },
+  { label: 'Статистика', value: 'stats' }
+] as const;
+
+type ViewMode = (typeof viewTabs)[number]['value'];
 
 function App() {
   const [selectedDomains, setSelectedDomains] = useState<Set<string>>(
@@ -30,6 +40,7 @@ function App() {
   const [teamFilter, setTeamFilter] = useState<string[]>(allTeams);
   const [showDependencies, setShowDependencies] = useState(true);
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
+  const [viewMode, setViewMode] = useState<ViewMode>('graph');
   const highlightedDomainId = selectedNode?.type === 'domain' ? selectedNode.id : null;
 
   const teams = useMemo(() => allTeams, []);
@@ -427,75 +438,111 @@ function App() {
     }
   }, [handleNavigate]);
 
+  const activeViewTab = viewTabs.find((tab) => tab.value === viewMode) ?? viewTabs[0];
+
+  const headerTitle = viewMode === 'graph' ? 'Граф модулей и доменных областей' : 'Статистика экосистемы решений';
+  const headerDescription =
+    viewMode === 'graph'
+      ? 'Выберите домены, чтобы увидеть связанные модули и выявить пересечения.'
+      : 'Обзор ключевых метрик по системам, модулям и обмену данными для планирования развития.';
+
   return (
     <Layout className={styles.app} direction="column">
       <header className={styles.header}>
-        <div>
+        <div className={styles.headerContent}>
           <Text size="2xl" weight="bold">
-            Граф модулей и доменных областей
+            {headerTitle}
           </Text>
           <Text size="s" view="secondary">
-            Выберите домены, чтобы увидеть связанные модули и выявить пересечения.
+            {headerDescription}
           </Text>
         </div>
+        <Tabs
+          size="s"
+          items={viewTabs}
+          value={activeViewTab}
+          getItemKey={(item) => item.value}
+          getItemLabel={(item) => item.label}
+          onChange={(tab) => setViewMode(tab.value)}
+        />
       </header>
-      <main className={styles.main}>
-        <aside className={styles.sidebar}>
-          <Text size="s" weight="semibold" className={styles.sidebarTitle}>
-            Домены
-          </Text>
-          <DomainTree tree={domainTree} selected={selectedDomains} onToggle={handleDomainToggle} descendants={domainDescendants} />
-          <Text size="s" weight="semibold" className={styles.sidebarTitle}>
-            Фильтры
-          </Text>
-          <FiltersPanel
-            search={search}
-            onSearchChange={setSearch}
-            statuses={allStatuses}
-            activeStatuses={statusFilters}
-            onToggleStatus={(status) => {
-              setSelectedNode(null);
-              setStatusFilters((prev) => {
-                const next = new Set(prev);
-                if (next.has(status)) {
-                  next.delete(status);
-                } else {
-                  next.add(status);
-                }
-                return next;
-              });
-            }}
-            teams={teams}
-            teamFilter={teamFilter}
-            onTeamChange={(team) => {
-              setSelectedNode(null);
-              setTeamFilter(team);
-            }}
-            showDependencies={showDependencies}
-            onToggleDependencies={(value) => setShowDependencies(value)}
-          />
-        </aside>
-        <section className={styles.graphSection}>
-          <div className={styles.graphContainer}>
-            <GraphView
-              modules={graphModules}
-              domains={graphDomains}
-              artifacts={graphArtifacts}
-              links={filteredLinks}
-              showDependencies={showDependencies}
-              onSelect={handleSelectNode}
-              highlightedNode={selectedNode?.id ?? null}
-              visibleDomainIds={relevantDomainIds}
+      {viewMode === 'graph' ? (
+        <main className={styles.main}>
+          <aside className={styles.sidebar}>
+            <Text size="s" weight="semibold" className={styles.sidebarTitle}>
+              Домены
+            </Text>
+            <DomainTree
+              tree={domainTree}
+              selected={selectedDomains}
+              onToggle={handleDomainToggle}
+              descendants={domainDescendants}
             />
-          </div>
-          <div className={styles.analytics}>
-            <AnalyticsPanel modules={filteredModules} />
-          </div>
-        </section>
-        <aside className={styles.details}>
-          <NodeDetails node={selectedNode} onClose={() => setSelectedNode(null)} onNavigate={handleNavigate} />
-        </aside>
-      </main>
+            <Text size="s" weight="semibold" className={styles.sidebarTitle}>
+              Фильтры
+            </Text>
+            <FiltersPanel
+              search={search}
+              onSearchChange={setSearch}
+              statuses={allStatuses}
+              activeStatuses={statusFilters}
+              onToggleStatus={(status) => {
+                setSelectedNode(null);
+                setStatusFilters((prev) => {
+                  const next = new Set(prev);
+                  if (next.has(status)) {
+                    next.delete(status);
+                  } else {
+                    next.add(status);
+                  }
+                  return next;
+                });
+              }}
+              teams={teams}
+              teamFilter={teamFilter}
+              onTeamChange={(team) => {
+                setSelectedNode(null);
+                setTeamFilter(team);
+              }}
+              showDependencies={showDependencies}
+              onToggleDependencies={(value) => setShowDependencies(value)}
+            />
+          </aside>
+          <section className={styles.graphSection}>
+            <div className={styles.graphContainer}>
+              <GraphView
+                modules={graphModules}
+                domains={graphDomains}
+                artifacts={graphArtifacts}
+                links={filteredLinks}
+                showDependencies={showDependencies}
+                onSelect={handleSelectNode}
+                highlightedNode={selectedNode?.id ?? null}
+                visibleDomainIds={relevantDomainIds}
+              />
+            </div>
+            <div className={styles.analytics}>
+              <AnalyticsPanel modules={filteredModules} />
+            </div>
+          </section>
+          <aside className={styles.details}>
+            <NodeDetails
+              node={selectedNode}
+              onClose={() => setSelectedNode(null)}
+              onNavigate={handleNavigate}
+            />
+          </aside>
+        </main>
+      ) : (
+        <main className={styles.statsMain}>
+          <StatsDashboard
+            modules={modules}
+            domains={domainTree}
+            artifacts={artifacts}
+            reuseHistory={reuseIndexHistory}
+          />
+        </main>
+      )}
     </Layout>
   );
 }

--- a/src/components/StatsDashboard.module.css
+++ b/src/components/StatsDashboard.module.css
@@ -1,0 +1,140 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.summaryGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.summaryCard {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-radius: 12px;
+  background: var(--color-bg-default);
+  box-shadow: var(--shadow-layer);
+}
+
+.summaryValue {
+  line-height: 1;
+}
+
+.chartsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  border-radius: 12px;
+  background: var(--color-bg-default);
+  box-shadow: var(--shadow-layer);
+}
+
+.cardTitle {
+  margin-bottom: -4px;
+}
+
+.splitGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.systemTable {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.systemTable th,
+.systemTable td {
+  padding: 8px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--color-bg-border);
+}
+
+.systemTable tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.statusPill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  background: var(--color-bg-ghost);
+  color: var(--color-typo-primary);
+}
+
+.statusPill[data-status='success'] {
+  background: rgba(46, 204, 113, 0.15);
+  color: #1f8a52;
+}
+
+.statusPill[data-status='warning'] {
+  background: rgba(241, 196, 15, 0.15);
+  color: #9a7d08;
+}
+
+.statusPill[data-status='alert'] {
+  background: rgba(231, 76, 60, 0.15);
+  color: #a63a32;
+}
+
+.domainList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.domainPill {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--color-bg-ghost);
+  font-size: 13px;
+}
+
+.metricsList {
+  display: grid;
+  gap: 12px;
+}
+
+.metricsItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.metricsLabel {
+  color: var(--color-typo-secondary);
+  font-size: 14px;
+}
+
+.metricsValue {
+  font-weight: 600;
+  font-size: 20px;
+}
+
+@media (max-width: 1024px) {
+  .chartsGrid {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  }
+
+  .splitGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/StatsDashboard.tsx
+++ b/src/components/StatsDashboard.tsx
@@ -1,0 +1,533 @@
+import { Bar, type BarProps } from '@consta/charts/Bar';
+import { Column, type ColumnProps } from '@consta/charts/Column';
+import { Line, type LineProps } from '@consta/charts/Line';
+import { Pie, type PieProps } from '@consta/charts/Pie';
+import { Card } from '@consta/uikit/Card';
+import { Text } from '@consta/uikit/Text';
+import { useMemo } from 'react';
+import {
+  artifacts as allArtifacts,
+  domainNameById,
+  domainTree as allDomains,
+  modules as allModules,
+  type ArtifactNode,
+  type DomainNode,
+  type ModuleNode,
+  type ModuleStatus,
+  type ReuseTrendPoint
+} from '../data';
+import styles from './StatsDashboard.module.css';
+
+const statusOrder: ModuleStatus[] = ['production', 'in-dev', 'deprecated'];
+const statusLabels: Record<ModuleStatus, string> = {
+  production: 'В эксплуатации',
+  'in-dev': 'В разработке',
+  deprecated: 'Выведено из эксплуатации'
+};
+
+const statusBadgeView: Record<ModuleStatus, 'success' | 'warning' | 'alert'> = {
+  production: 'success',
+  'in-dev': 'warning',
+  deprecated: 'alert'
+};
+
+type StatsDashboardProps = {
+  modules?: ModuleNode[];
+  domains?: DomainNode[];
+  artifacts?: ArtifactNode[];
+  reuseHistory: ReuseTrendPoint[];
+};
+
+type SystemRow = {
+  name: string;
+  total: number;
+  statuses: Record<ModuleStatus, number>;
+};
+
+type ArtifactChartDatum = {
+  type: string;
+  count: number;
+};
+
+type ReuseChartDatum = {
+  periodLabel: string;
+  averagePercent: number;
+};
+
+type DistributionDatum = {
+  label: string;
+  value: number;
+};
+
+type TeamDatum = {
+  team: string;
+  count: number;
+};
+
+const defaultModules = allModules;
+const defaultDomains = allDomains;
+const defaultArtifacts = allArtifacts;
+
+const StatsDashboard = ({
+  modules = defaultModules,
+  domains = defaultDomains,
+  artifacts = defaultArtifacts,
+  reuseHistory
+}: StatsDashboardProps) => {
+  const systems = useMemo(() => {
+    const map = new Map<string, SystemRow>();
+
+    modules.forEach((module) => {
+      const existing = map.get(module.productName);
+      if (existing) {
+        existing.total += 1;
+        existing.statuses[module.status] += 1;
+        return;
+      }
+
+      map.set(module.productName, {
+        name: module.productName,
+        total: 1,
+        statuses: {
+          production: module.status === 'production' ? 1 : 0,
+          'in-dev': module.status === 'in-dev' ? 1 : 0,
+          deprecated: module.status === 'deprecated' ? 1 : 0
+        }
+      });
+    });
+
+    return Array.from(map.values()).sort((a, b) => b.total - a.total);
+  }, [modules]);
+
+  const moduleCount = modules.length;
+  const systemCount = systems.length;
+  const artifactCount = artifacts.length;
+
+  const modulesByStatus = useMemo(() => {
+    return statusOrder.map((status) => ({
+      status,
+      statusLabel: statusLabels[status],
+      count: modules.filter((module) => module.status === status).length
+    }));
+  }, [modules]);
+
+  const artifactTypes = useMemo<ArtifactChartDatum[]>(() => {
+    const counts = new Map<string, number>();
+
+    artifacts.forEach((artifact) => {
+      const type = resolveArtifactType(artifact);
+      counts.set(type, (counts.get(type) ?? 0) + 1);
+    });
+
+    return Array.from(counts.entries())
+      .map(([type, count]) => ({ type, count }))
+      .sort((a, b) => b.count - a.count);
+  }, [artifacts]);
+
+  const reuseChartData = useMemo<ReuseChartDatum[]>(() => {
+    return reuseHistory.map((point) => ({
+      periodLabel: formatPeriod(point.period),
+      averagePercent: Math.round(point.averageScore * 1000) / 10
+    }));
+  }, [reuseHistory]);
+
+  const domainWithoutModules = useMemo(() => {
+    const flatDomains = flattenDomains(domains);
+    const usage = new Map<string, number>();
+
+    modules.forEach((module) => {
+      module.domains.forEach((domainId) => {
+        usage.set(domainId, (usage.get(domainId) ?? 0) + 1);
+      });
+    });
+
+    return flatDomains.filter((domain) => (usage.get(domain.id) ?? 0) === 0);
+  }, [domains, modules]);
+
+  const deploymentDistribution = useMemo<DistributionDatum[]>(() => {
+    const counts = modules.reduce<Record<string, number>>((acc, module) => {
+      const key = module.deploymentTool === 'kubernetes' ? 'Kubernetes' : 'Docker';
+      acc[key] = (acc[key] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    return Object.entries(counts).map(([label, value]) => ({ label, value }));
+  }, [modules]);
+
+  const clientDistribution = useMemo<DistributionDatum[]>(() => {
+    const counts = modules.reduce<Record<string, number>>((acc, module) => {
+      const key = module.clientType === 'desktop' ? 'Desktop' : 'Web';
+      acc[key] = (acc[key] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    return Object.entries(counts).map(([label, value]) => ({ label, value }));
+  }, [modules]);
+
+  const teamLeaders = useMemo<TeamDatum[]>(() => {
+    const counts = modules.reduce<Record<string, number>>((acc, module) => {
+      acc[module.team] = (acc[module.team] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    return Object.entries(counts)
+      .map(([team, count]) => ({ team, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 6);
+  }, [modules]);
+
+  const averageAutomation = useMemo(() => average(modules.map((module) => module.metrics.automationRate)), [modules]);
+  const averageDependencies = useMemo(
+    () => average(modules.map((module) => module.dependencies.length)),
+    [modules]
+  );
+  const averageResponseTime = useMemo(
+    () => average(modules.map((module) => module.nonFunctional.responseTimeMs)),
+    [modules]
+  );
+  const licenseRatio = useMemo(() => {
+    const withLicense = modules.filter((module) => module.licenseServerIntegrated).length;
+    return {
+      withLicense,
+      ratio: modules.length === 0 ? 0 : Math.round((withLicense / modules.length) * 100)
+    };
+  }, [modules]);
+  const artifactsPerModule = useMemo(
+    () => (modules.length === 0 ? 0 : Math.round((artifactCount / modules.length) * 10) / 10),
+    [artifactCount, modules.length]
+  );
+
+  const modulesByStatusPieProps: PieProps<(typeof modulesByStatus)[number]> = {
+    data: modulesByStatus,
+    angleField: 'count',
+    colorField: 'statusLabel',
+    legend: { position: 'bottom' },
+    height: 280,
+    radius: 0.9,
+    innerRadius: 0.45,
+    tooltip: ({ statusLabel, count }) => ({
+      name: statusLabel,
+      value: `${count} мод.`
+    })
+  };
+
+  const artifactColumnProps: ColumnProps<ArtifactChartDatum> = {
+    data: artifactTypes,
+    xField: 'type',
+    yField: 'count',
+    height: 280,
+    columnWidthRatio: 0.6,
+    label: {
+      position: 'top'
+    },
+    tooltip: ({ type, count }) => ({
+      name: type,
+      value: `${count} шт.`
+    })
+  };
+
+  const reuseLineProps: LineProps<ReuseChartDatum> = {
+    data: reuseChartData,
+    xField: 'periodLabel',
+    yField: 'averagePercent',
+    height: 280,
+    smooth: true,
+    point: {
+      size: 4
+    },
+    yAxis: {
+      label: {
+        formatter: (value: string) => `${value}%`
+      }
+    },
+    tooltip: ({ averagePercent, periodLabel }) => ({
+      name: periodLabel,
+      value: `${averagePercent}%`
+    })
+  };
+
+  const deploymentPieProps: PieProps<DistributionDatum> = {
+    data: deploymentDistribution,
+    angleField: 'value',
+    colorField: 'label',
+    legend: { position: 'bottom' },
+    height: 260,
+    tooltip: ({ label, value }) => ({
+      name: label,
+      value: `${value} мод.`
+    })
+  };
+
+  const clientPieProps: PieProps<DistributionDatum> = {
+    data: clientDistribution,
+    angleField: 'value',
+    colorField: 'label',
+    legend: { position: 'bottom' },
+    height: 260,
+    tooltip: ({ label, value }) => ({
+      name: label,
+      value: `${value} мод.`
+    })
+  };
+
+  const teamBarProps: BarProps<TeamDatum> = {
+    data: teamLeaders,
+    xField: 'count',
+    yField: 'team',
+    seriesField: 'team',
+    legend: false,
+    height: 260,
+    autoFit: true
+  };
+
+  return (
+    <div className={styles.container}>
+      <section className={styles.summaryGrid}>
+        <Card className={styles.summaryCard} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="xs" view="secondary">
+            Активные системы
+          </Text>
+          <Text size="3xl" weight="bold" className={styles.summaryValue}>
+            {systemCount}
+          </Text>
+          <Text size="xs" view="ghost">
+            Сформированы по уникальным продуктовым контурам
+          </Text>
+        </Card>
+        <Card className={styles.summaryCard} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="xs" view="secondary">
+            Модули в каталоге
+          </Text>
+          <Text size="3xl" weight="bold" className={styles.summaryValue}>
+            {moduleCount}
+          </Text>
+          <Text size="xs" view="ghost">
+            Включая совместно используемые компоненты
+          </Text>
+        </Card>
+        <Card className={styles.summaryCard} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="xs" view="secondary">
+            Домены без функций
+          </Text>
+          <Text size="3xl" weight="bold" className={styles.summaryValue}>
+            {domainWithoutModules.length}
+          </Text>
+          <Text size="xs" view="ghost">
+            Требуют наполнения или ревизии
+          </Text>
+        </Card>
+        <Card className={styles.summaryCard} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="xs" view="secondary">
+            Артефакты данных
+          </Text>
+          <Text size="3xl" weight="bold" className={styles.summaryValue}>
+            {artifactCount}
+          </Text>
+          <Text size="xs" view="ghost">
+            Используются при обмене между командами
+          </Text>
+        </Card>
+      </section>
+
+      <section className={styles.chartsGrid}>
+        <Card className={styles.card} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="s" weight="semibold" className={styles.cardTitle}>
+            Статусы модулей
+          </Text>
+          <Pie {...modulesByStatusPieProps} />
+        </Card>
+        <Card className={styles.card} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="s" weight="semibold" className={styles.cardTitle}>
+            Артефакты по типам файлов
+          </Text>
+          <Column {...artifactColumnProps} />
+        </Card>
+        <Card className={styles.card} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="s" weight="semibold" className={styles.cardTitle}>
+            Динамика среднего индекса переиспользования
+          </Text>
+          <Line {...reuseLineProps} />
+        </Card>
+      </section>
+
+      <section className={styles.chartsGrid}>
+        <Card className={styles.card} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="s" weight="semibold" className={styles.cardTitle}>
+            Инструменты деплоя
+          </Text>
+          <Pie {...deploymentPieProps} />
+        </Card>
+        <Card className={styles.card} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="s" weight="semibold" className={styles.cardTitle}>
+            Каналы доставки клиентам
+          </Text>
+          <Pie {...clientPieProps} />
+        </Card>
+        <Card className={styles.card} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="s" weight="semibold" className={styles.cardTitle}>
+            Команды-лидеры по числу модулей
+          </Text>
+          <Bar {...teamBarProps} />
+        </Card>
+      </section>
+
+      <section className={styles.splitGrid}>
+        <Card className={styles.card} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="s" weight="semibold" className={styles.cardTitle}>
+            Разрез по системам и статусам
+          </Text>
+          <table className={styles.systemTable}>
+            <thead>
+              <tr>
+                <th>Система</th>
+                <th>Всего</th>
+                {statusOrder.map((status) => (
+                  <th key={status}>{statusLabels[status]}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {systems.map((system) => (
+                <tr key={system.name}>
+                  <td>{system.name}</td>
+                  <td>{system.total}</td>
+                  {statusOrder.map((status) => (
+                    <td key={status}>
+                      <span className={styles.statusPill} data-status={statusBadgeView[status]}>
+                        {system.statuses[status]}
+                      </span>
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Card>
+        <Card className={styles.card} verticalSpace="l" horizontalSpace="l" shadow={false}>
+          <Text size="s" weight="semibold" className={styles.cardTitle}>
+            Домены без закреплённых функций
+          </Text>
+          <div className={styles.domainList}>
+            {domainWithoutModules.length === 0 ? (
+              <Text size="s" view="secondary">
+                Все домены покрыты модулями
+              </Text>
+            ) : (
+              domainWithoutModules.map((domain) => (
+                <span key={domain.id} className={styles.domainPill}>
+                  {domainNameById[domain.id] ?? domain.name}
+                </span>
+              ))
+            )}
+          </div>
+        </Card>
+      </section>
+
+      <Card className={styles.card} verticalSpace="l" horizontalSpace="l" shadow={false}>
+        <Text size="s" weight="semibold" className={styles.cardTitle}>
+          Дополнительные метрики мониторинга
+        </Text>
+        <div className={styles.metricsList}>
+          <div className={styles.metricsItem}>
+            <span className={styles.metricsLabel}>Средний уровень автоматизации тестов</span>
+            <span className={styles.metricsValue}>{Math.round(averageAutomation)}%</span>
+          </div>
+          <div className={styles.metricsItem}>
+            <span className={styles.metricsLabel}>Среднее число зависимостей на модуль</span>
+            <span className={styles.metricsValue}>{averageDependencies.toFixed(1)}</span>
+          </div>
+          <div className={styles.metricsItem}>
+            <span className={styles.metricsLabel}>Средняя длительность ответа сервисов</span>
+            <span className={styles.metricsValue}>{Math.round(averageResponseTime)} мс</span>
+          </div>
+          <div className={styles.metricsItem}>
+            <span className={styles.metricsLabel}>Модулей с интеграцией лицензирования</span>
+            <span className={styles.metricsValue}>
+              {licenseRatio.ratio}% ({licenseRatio.withLicense}/{moduleCount})
+            </span>
+          </div>
+          <div className={styles.metricsItem}>
+            <span className={styles.metricsLabel}>Среднее число артефактов на модуль</span>
+            <span className={styles.metricsValue}>{artifactsPerModule}</span>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+function flattenDomains(nodes: DomainNode[]): DomainNode[] {
+  return nodes.flatMap((node) => [node, ...(node.children ? flattenDomains(node.children) : [])]);
+}
+
+function resolveArtifactType(artifact: ArtifactNode): string {
+  const extension = extractExtension(artifact.sampleUrl);
+
+  if (extension === 'xlsx') {
+    return 'Excel (XLSX)';
+  }
+
+  if (extension === 'las') {
+    return 'LAS';
+  }
+
+  if (extension === 'csv') {
+    return 'CSV';
+  }
+
+  if (extension === 'json') {
+    return 'JSON';
+  }
+
+  if (extension === 'parquet') {
+    return 'Parquet';
+  }
+
+  if (extension === 'pdf') {
+    return 'PDF';
+  }
+
+  return artifact.dataType;
+}
+
+function extractExtension(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const pathname = parsed.pathname;
+    const segments = pathname.split('/');
+    const last = segments[segments.length - 1];
+    if (!last) {
+      return null;
+    }
+    const clean = last.split('.')[1] ? last.split('.').pop() : null;
+    return clean ? clean.toLowerCase() : null;
+  } catch {
+    const parts = url.split('?')[0].split('.');
+    return parts.length > 1 ? parts.pop()?.toLowerCase() ?? null : null;
+  }
+}
+
+function formatPeriod(period: string): string {
+  const [year, month] = period.split('-');
+  if (!month) {
+    return period;
+  }
+
+  const monthIndex = Number(month);
+  if (Number.isNaN(monthIndex) || monthIndex < 1 || monthIndex > 12) {
+    return period;
+  }
+
+  const monthNames = ['янв', 'фев', 'мар', 'апр', 'май', 'июн', 'июл', 'авг', 'сен', 'окт', 'ноя', 'дек'];
+  return `${monthNames[monthIndex - 1]} ${year}`;
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sum = values.reduce((total, value) => total + value, 0);
+  return sum / values.length;
+}
+
+export default StatsDashboard;

--- a/src/data.ts
+++ b/src/data.ts
@@ -818,3 +818,23 @@ export const moduleLinks: GraphLink[] = modules.flatMap((module) => {
 });
 
 export { moduleById };
+
+export type ReuseTrendPoint = {
+  period: string;
+  averageScore: number;
+};
+
+export const reuseIndexHistory: ReuseTrendPoint[] = [
+  { period: '2023-11', averageScore: 0.42 },
+  { period: '2023-12', averageScore: 0.44 },
+  { period: '2024-01', averageScore: 0.45 },
+  { period: '2024-02', averageScore: 0.47 },
+  { period: '2024-03', averageScore: 0.5 },
+  { period: '2024-04', averageScore: 0.53 },
+  { period: '2024-05', averageScore: 0.55 },
+  { period: '2024-06', averageScore: 0.57 },
+  { period: '2024-07', averageScore: 0.6 },
+  { period: '2024-08', averageScore: 0.62 },
+  { period: '2024-09', averageScore: 0.65 },
+  { period: '2024-10', averageScore: 0.66 }
+];


### PR DESCRIPTION
## Summary
- add a view toggle and header updates so the app can switch between the graph and a statistics dashboard
- implement the statistics dashboard with charts, tables, and additional monitoring metrics for modules, domains, and artifacts
- extend the data set with reuse index history to power the reuse trend visualization

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6c206fa108332bcc4a3a21bdb5db3