### PR TITLE
fix: isolate stats dashboard to protect graph rendering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,12 @@
 import { Layout } from '@consta/uikit/Layout';
 import { Tabs } from '@consta/uikit/Tabs';
 import { Text } from '@consta/uikit/Text';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Loader } from '@consta/uikit/Loader';
+import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react';
 import AnalyticsPanel from './components/AnalyticsPanel';
 import DomainTree from './components/DomainTree';
 import FiltersPanel from './components/FiltersPanel';
 import GraphView, { type GraphNode } from './components/GraphView';
-import StatsDashboard from './components/StatsDashboard';
 import NodeDetails from './components/NodeDetails';
 import {
   artifacts,
@@ -23,6 +23,10 @@ import styles from './App.module.css';
 
 const allStatuses: ModuleStatus[] = ['production', 'in-dev', 'deprecated'];
 const allTeams = Array.from(new Set(modules.map((module) => module.team))).sort();
+
+const StatsDashboard = lazy(async () => ({
+  default: (await import('./components/StatsDashboard')).default
+}));
 
 const viewTabs = [
   { label: 'Связи', value: 'graph' },
@@ -535,12 +539,14 @@ function App() {
         </main>
       ) : (
         <main className={styles.statsMain}>
-          <StatsDashboard
-            modules={modules}
-            domains={domainTree}
-            artifacts={artifacts}
-            reuseHistory={reuseIndexHistory}
-          />
+          <Suspense fallback={<Loader size="m" />}>
+            <StatsDashboard
+              modules={modules}
+              domains={domainTree}
+              artifacts={artifacts}
+              reuseHistory={reuseIndexHistory}
+            />
+          </Suspense>
         </main>
       )}
     </Layout>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ function App() {
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>('graph');
   const highlightedDomainId = selectedNode?.type === 'domain' ? selectedNode.id : null;
+  const [statsActivated, setStatsActivated] = useState(() => viewMode === 'stats');
 
   const teams = useMemo(() => allTeams, []);
 
@@ -450,6 +451,12 @@ function App() {
       ? 'Выберите домены, чтобы увидеть связанные модули и выявить пересечения.'
       : 'Обзор ключевых метрик по системам, модулям и обмену данными для планирования развития.';
 
+  useEffect(() => {
+    if (viewMode === 'stats' && !statsActivated) {
+      setStatsActivated(true);
+    }
+  }, [statsActivated, viewMode]);
+
   return (
     <Layout className={styles.app} direction="column">
       <header className={styles.header}>
@@ -470,8 +477,11 @@ function App() {
           onChange={(tab) => setViewMode(tab.value)}
         />
       </header>
-      {viewMode === 'graph' ? (
-        <main className={styles.main}>
+      <main
+        className={styles.main}
+        hidden={viewMode !== 'graph'}
+        aria-hidden={viewMode !== 'graph'}
+      >
           <aside className={styles.sidebar}>
             <Text size="s" weight="semibold" className={styles.sidebarTitle}>
               Домены
@@ -536,9 +546,13 @@ function App() {
               onNavigate={handleNavigate}
             />
           </aside>
-        </main>
-      ) : (
-        <main className={styles.statsMain}>
+      </main>
+      {(statsActivated || viewMode === 'stats') && (
+        <main
+          className={styles.statsMain}
+          hidden={viewMode !== 'stats'}
+          aria-hidden={viewMode !== 'stats'}
+        >
           <Suspense fallback={<Loader size="m" />}>
             <StatsDashboard
               modules={modules}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -444,12 +444,13 @@ function App() {
   }, [handleNavigate]);
 
   const activeViewTab = viewTabs.find((tab) => tab.value === viewMode) ?? viewTabs[0];
+  const isGraphActive = viewMode === 'graph';
+  const isStatsActive = viewMode === 'stats';
 
-  const headerTitle = viewMode === 'graph' ? 'Граф модулей и доменных областей' : 'Статистика экосистемы решений';
-  const headerDescription =
-    viewMode === 'graph'
-      ? 'Выберите домены, чтобы увидеть связанные модули и выявить пересечения.'
-      : 'Обзор ключевых метрик по системам, модулям и обмену данными для планирования развития.';
+  const headerTitle = isGraphActive ? 'Граф модулей и доменных областей' : 'Статистика экосистемы решений';
+  const headerDescription = isGraphActive
+    ? 'Выберите домены, чтобы увидеть связанные модули и выявить пересечения.'
+    : 'Обзор ключевых метрик по системам, модулям и обмену данными для планирования развития.';
 
   useEffect(() => {
     if (viewMode === 'stats' && !statsActivated) {
@@ -479,8 +480,9 @@ function App() {
       </header>
       <main
         className={styles.main}
-        hidden={viewMode !== 'graph'}
-        aria-hidden={viewMode !== 'graph'}
+        hidden={!isGraphActive}
+        aria-hidden={!isGraphActive}
+        style={{ display: isGraphActive ? undefined : 'none' }}
       >
           <aside className={styles.sidebar}>
             <Text size="s" weight="semibold" className={styles.sidebarTitle}>
@@ -547,11 +549,12 @@ function App() {
             />
           </aside>
       </main>
-      {(statsActivated || viewMode === 'stats') && (
+      {(statsActivated || isStatsActive) && (
         <main
           className={styles.statsMain}
-          hidden={viewMode !== 'stats'}
-          aria-hidden={viewMode !== 'stats'}
+          hidden={!isStatsActive}
+          aria-hidden={!isStatsActive}
+          style={{ display: isStatsActive ? undefined : 'none' }}
         >
           <Suspense fallback={<Loader size="m" />}>
             <StatsDashboard


### PR DESCRIPTION
## Summary
- lazy-load the statistics dashboard so heavy chart dependencies no longer run during the graph view
- show a loader while the statistics module is being fetched to keep the UI responsive

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6d906ffc883329401c12b897fde85