### PR TITLE
feat: add entity creation workspace

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -72,6 +72,13 @@
   overflow-y: auto;
 }
 
+.creationMain {
+  padding: 24px;
+  height: calc(100% - 92px);
+  box-sizing: border-box;
+  overflow-y: auto;
+}
+
 @media (max-width: 1440px) {
   .main {
     grid-template-columns: 280px 1fr 280px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,9 @@ import EntityCreation, {
   type ModuleDraftPayload
 } from './components/EntityCreation';
 import FiltersPanel from './components/FiltersPanel';
+import GraphPersistenceControls, {
+  type GraphSnapshotPayload
+} from './components/GraphPersistenceControls';
 import GraphView, { type GraphNode } from './components/GraphView';
 import NodeDetails from './components/NodeDetails';
 import {
@@ -769,6 +772,19 @@ function App() {
     [artifactData, firstDomainId, moduleById]
   );
 
+  const handleImportGraph = useCallback((snapshot: GraphSnapshotPayload) => {
+    setDomainData(snapshot.domains);
+    setModuleData(snapshot.modules);
+    setArtifactData(snapshot.artifacts);
+    setSelectedNode(null);
+    setSearch('');
+    setStatusFilters(new Set(allStatuses));
+    setProductFilter(buildProductList(snapshot.modules));
+    setSelectedDomains(
+      new Set(flattenDomainTree(snapshot.domains).map((domain) => domain.id))
+    );
+  }, []);
+
   const activeViewTab = viewTabs.find((tab) => tab.value === viewMode) ?? viewTabs[0];
   const isGraphActive = viewMode === 'graph';
   const isStatsActive = viewMode === 'stats';
@@ -916,6 +932,12 @@ function App() {
         aria-hidden={!isCreateActive}
         style={{ display: isCreateActive ? undefined : 'none' }}
       >
+        <GraphPersistenceControls
+          modules={moduleData}
+          domains={domainData}
+          artifacts={artifactData}
+          onImport={handleImportGraph}
+        />
         <EntityCreation
           modules={moduleData}
           domains={domainData}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,25 +5,31 @@ import { Loader } from '@consta/uikit/Loader';
 import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react';
 import AnalyticsPanel from './components/AnalyticsPanel';
 import DomainTree from './components/DomainTree';
-import EntityCreation from './components/EntityCreation';
+import EntityCreation, {
+  type ArtifactDraftPayload,
+  type DomainDraftPayload,
+  type ModuleDraftPayload
+} from './components/EntityCreation';
 import FiltersPanel from './components/FiltersPanel';
 import GraphView, { type GraphNode } from './components/GraphView';
 import NodeDetails from './components/NodeDetails';
 import {
-  artifacts,
-  domainTree,
-  moduleById,
-  moduleLinks,
-  modules,
+  artifacts as initialArtifacts,
+  domainTree as initialDomainTree,
+  modules as initialModules,
   reuseIndexHistory,
+  type ArtifactNode,
   type DomainNode,
+  type GraphLink,
+  type ModuleInput,
   type ModuleNode,
+  type ModuleOutput,
   type ModuleStatus
 } from './data';
 import styles from './App.module.css';
 
 const allStatuses: ModuleStatus[] = ['production', 'in-dev', 'deprecated'];
-const allProducts = Array.from(new Set(modules.map((module) => module.productName))).sort();
+const initialProducts = buildProductList(initialModules);
 
 const StatsDashboard = lazy(async () => ({
   default: (await import('./components/StatsDashboard')).default
@@ -38,27 +44,42 @@ const viewTabs = [
 type ViewMode = (typeof viewTabs)[number]['value'];
 
 function App() {
+  const [domainData, setDomainData] = useState<DomainNode[]>(initialDomainTree);
+  const [moduleData, setModuleData] = useState<ModuleNode[]>(initialModules);
+  const [artifactData, setArtifactData] = useState<ArtifactNode[]>(initialArtifacts);
   const [selectedDomains, setSelectedDomains] = useState<Set<string>>(
-    () => new Set(flattenDomainTree(domainTree).map((domain) => domain.id))
+    () => new Set(flattenDomainTree(initialDomainTree).map((domain) => domain.id))
   );
   const [search, setSearch] = useState('');
   const [statusFilters, setStatusFilters] = useState<Set<ModuleStatus>>(new Set(allStatuses));
-  const [productFilter, setProductFilter] = useState<string[]>(allProducts);
+  const [productFilter, setProductFilter] = useState<string[]>(initialProducts);
   const [showAllConnections, setShowAllConnections] = useState(false);
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>('graph');
   const highlightedDomainId = selectedNode?.type === 'domain' ? selectedNode.id : null;
   const [statsActivated, setStatsActivated] = useState(() => viewMode === 'stats');
 
-  const products = useMemo(() => allProducts, []);
+  const products = useMemo(() => buildProductList(moduleData), [moduleData]);
 
-  const domainDescendants = useMemo(() => buildDomainDescendants(domainTree), []);
-  const domainAncestors = useMemo(() => buildDomainAncestors(domainTree), []);
+  useEffect(() => {
+    setProductFilter((prev) => {
+      const preserved = products.filter((product) => prev.includes(product));
+      const missing = products.filter((product) => !prev.includes(product));
+      const next = [...preserved, ...missing];
+      if (next.length === prev.length && next.every((value, index) => value === prev[index])) {
+        return prev;
+      }
+      return next;
+    });
+  }, [products]);
+
+  const domainDescendants = useMemo(() => buildDomainDescendants(domainData), [domainData]);
+  const domainAncestors = useMemo(() => buildDomainAncestors(domainData), [domainData]);
 
   const moduleDependents = useMemo(() => {
     const dependents = new Map<string, Set<string>>();
 
-    modules.forEach((module) => {
+    moduleData.forEach((module) => {
       module.dependencies.forEach((dependencyId) => {
         if (!dependents.has(dependencyId)) {
           dependents.set(dependencyId, new Set());
@@ -67,7 +88,7 @@ function App() {
       });
     });
 
-    artifacts.forEach((artifact) => {
+    artifactData.forEach((artifact) => {
       if (!dependents.has(artifact.producedBy)) {
         dependents.set(artifact.producedBy, new Set());
       }
@@ -78,7 +99,7 @@ function App() {
     });
 
     return dependents;
-  }, []);
+  }, [moduleData, artifactData]);
 
   const matchesModuleFilters = useCallback(
     (module: ModuleNode) => {
@@ -108,15 +129,55 @@ function App() {
   );
 
   const filteredModules = useMemo(
-    () => modules.filter((module) => matchesModuleFilters(module)),
-    [matchesModuleFilters]
+    () => moduleData.filter((module) => matchesModuleFilters(module)),
+    [moduleData, matchesModuleFilters]
   );
 
-  const artifactMap = useMemo(() => new Map(artifacts.map((artifact) => [artifact.id, artifact])), []);
-  const domainMap = useMemo(
-    () => new Map(flattenDomainTree(domainTree).map((domain) => [domain.id, domain])),
-    []
+  const artifactMap = useMemo(
+    () => new Map(artifactData.map((artifact) => [artifact.id, artifact])),
+    [artifactData]
   );
+  const domainMap = useMemo(
+    () => new Map(flattenDomainTree(domainData).map((domain) => [domain.id, domain])),
+    [domainData]
+  );
+
+  const moduleById = useMemo(() => {
+    const map: Record<string, ModuleNode> = {};
+    moduleData.forEach((module) => {
+      map[module.id] = module;
+    });
+    return map;
+  }, [moduleData]);
+
+  const moduleNameMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    moduleData.forEach((module) => {
+      map[module.id] = module.name;
+    });
+    return map;
+  }, [moduleData]);
+
+  const artifactNameMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    artifactData.forEach((artifact) => {
+      map[artifact.id] = artifact.name;
+    });
+    return map;
+  }, [artifactData]);
+
+  const domainNameMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    flattenDomainTree(domainData).forEach((domain) => {
+      map[domain.id] = domain.name;
+    });
+    return map;
+  }, [domainData]);
+
+  const firstDomainId = useMemo(() => {
+    const flattened = flattenDomainTree(domainData);
+    return flattened.length > 0 ? flattened[0].id : null;
+  }, [domainData]);
 
   const contextModuleIds = useMemo(() => {
     const ids = new Set<string>();
@@ -157,7 +218,7 @@ function App() {
     }
 
     if (selectedNode.type === 'domain') {
-      modules.forEach((module) => {
+      moduleData.forEach((module) => {
         if (module.domains.includes(selectedNode.id)) {
           ids.add(module.id);
         }
@@ -165,7 +226,7 @@ function App() {
     }
 
     return ids;
-  }, [selectedNode, moduleDependents, artifactMap]);
+  }, [selectedNode, moduleDependents, artifactMap, moduleData]);
 
   const graphModules = useMemo(() => {
     if (contextModuleIds.size === 0) {
@@ -209,8 +270,8 @@ function App() {
   }, [graphModules, highlightedDomainId, domainAncestors]);
 
   const graphDomains = useMemo(
-    () => filterDomainTreeByIds(domainTree, relevantDomainIds),
-    [relevantDomainIds]
+    () => filterDomainTreeByIds(domainData, relevantDomainIds),
+    [domainData, relevantDomainIds]
   );
 
   const graphArtifacts = useMemo(() => {
@@ -226,7 +287,7 @@ function App() {
       });
     });
 
-    let scopedArtifacts = artifacts.filter(
+    let scopedArtifacts = artifactData.filter(
       (artifact) =>
         relevantArtifactIds.has(artifact.id) ||
         moduleIds.has(artifact.producedBy) ||
@@ -234,21 +295,26 @@ function App() {
     );
 
     if (selectedNode?.type === 'artifact' && !scopedArtifacts.some((artifact) => artifact.id === selectedNode.id)) {
-      const fallback = artifacts.find((artifact) => artifact.id === selectedNode.id);
+      const fallback = artifactData.find((artifact) => artifact.id === selectedNode.id);
       if (fallback) {
         scopedArtifacts = [...scopedArtifacts, fallback];
       }
     }
 
     return scopedArtifacts;
-  }, [graphModules, selectedNode]);
+  }, [artifactData, graphModules, selectedNode]);
+
+  const graphLinksAll = useMemo(
+    () => buildModuleLinks(moduleData, artifactData),
+    [moduleData, artifactData]
+  );
 
   const filteredLinks = useMemo(() => {
     const moduleIds = new Set(graphModules.map((module) => module.id));
     const artifactIds = new Set(graphArtifacts.map((artifact) => artifact.id));
     const domainIds = relevantDomainIds.size > 0 ? relevantDomainIds : null;
 
-    return moduleLinks.filter((link) => {
+    return graphLinksAll.filter((link) => {
       const sourceId = getLinkEndpointId(link.source);
       const targetId = getLinkEndpointId(link.target);
 
@@ -300,7 +366,7 @@ function App() {
       const artifactIds = new Set(graphArtifacts.map((artifact) => artifact.id));
       const domainIds = relevantDomainIds.size > 0 ? relevantDomainIds : null;
 
-      const recomputedLinks = moduleLinks.filter((link) => {
+      const recomputedLinks = graphLinksAll.filter((link) => {
         const sourceId = getLinkEndpointId(link.source);
         const targetId = getLinkEndpointId(link.target);
 
@@ -343,7 +409,7 @@ function App() {
         return false;
       });
 
-      const excludedLinks = moduleLinks
+      const excludedLinks = graphLinksAll
         .filter((link) => !recomputedLinks.includes(link))
         .map((link) => {
           const sourceId = getLinkEndpointId(link.source);
@@ -392,6 +458,7 @@ function App() {
     filteredLinks,
     graphArtifacts,
     graphModules,
+    graphLinksAll,
     artifactMap,
     relevantDomainIds,
     selectedDomains,
@@ -478,7 +545,7 @@ function App() {
         setSelectedNode({ ...domain, type: 'domain' });
       }
     },
-    [artifactMap, domainMap, moduleDependents]
+    [artifactMap, domainMap, moduleById, moduleDependents]
   );
 
   useEffect(() => {
@@ -488,6 +555,219 @@ function App() {
       };
     }
   }, [handleNavigate]);
+
+  const handleCreateModule = useCallback(
+    (draft: ModuleDraftPayload) => {
+      const existingIds = new Set(moduleData.map((module) => module.id));
+      const moduleId = createEntityId('module', draft.name, existingIds);
+      const normalizedName = draft.name.trim() || `Новый модуль ${existingIds.size + 1}`;
+      const normalizedDescription = draft.description.trim() || 'Описание не заполнено';
+      const normalizedProduct = draft.productName.trim() || 'Новый продукт';
+      const normalizedTeam = draft.team.trim() || 'Команда не указана';
+      const uniqueDomains = deduplicateNonEmpty(draft.domainIds);
+      const fallbackDomain =
+        selectedNode?.type === 'domain'
+          ? [selectedNode.id]
+          : firstDomainId
+            ? [firstDomainId]
+            : [];
+      const domainIds = (uniqueDomains.length > 0 ? uniqueDomains : fallbackDomain).filter(Boolean);
+      const uniqueDependencies = deduplicateNonEmpty(draft.dependencyIds).filter((id) => id !== moduleId);
+      const uniqueProduces = deduplicateNonEmpty(draft.producedArtifactIds);
+
+      const sanitizedInputs = draft.dataIn.map<ModuleInput>((input, index) => ({
+        id: input.id || `input-${index}`,
+        label: input.label.trim() || `Вход ${index + 1}`,
+        sourceId: input.sourceId ?? undefined
+      }));
+
+      const sanitizedOutputs = draft.dataOut.map<ModuleOutput>((output, index) => ({
+        id: output.id || `output-${index}`,
+        label: output.label.trim() || `Выход ${index + 1}`,
+        consumerIds: deduplicateNonEmpty(output.consumerIds)
+      }));
+
+      const newModule: ModuleNode = {
+        id: moduleId,
+        name: normalizedName,
+        description: normalizedDescription,
+        domains: domainIds,
+        team: normalizedTeam,
+        productName: normalizedProduct,
+        projectTeam: [],
+        technologyStack: [],
+        localization: 'ru',
+        ridOwner: { company: 'Не указано', division: 'Не указано' },
+        userStats: { companies: 0, licenses: 0 },
+        status: draft.status,
+        repository: undefined,
+        api: undefined,
+        specificationUrl: '#',
+        apiContractsUrl: '#',
+        techDesignUrl: '#',
+        architectureDiagramUrl: '#',
+        licenseServerIntegrated: false,
+        libraries: [],
+        clientType: 'web',
+        deploymentTool: 'docker',
+        dependencies: uniqueDependencies,
+        produces: uniqueProduces,
+        reuseScore: 0,
+        metrics: { tests: 0, coverage: 0, automationRate: 0 },
+        dataIn: sanitizedInputs,
+        dataOut: sanitizedOutputs,
+        formula: '',
+        nonFunctional: {
+          responseTimeMs: 0,
+          throughputRps: 0,
+          resourceConsumption: '—',
+          baselineUsers: 0
+        }
+      };
+
+      const inputSourceIds = sanitizedInputs
+        .map((input) => input.sourceId)
+        .filter((value): value is string => Boolean(value));
+
+      const updatedArtifacts = artifactData.map((artifact) => {
+        let next = artifact;
+        if (inputSourceIds.includes(artifact.id) && !artifact.consumerIds.includes(moduleId)) {
+          next = { ...next, consumerIds: [...next.consumerIds, moduleId] };
+        }
+        if (uniqueProduces.includes(artifact.id) && next.producedBy !== moduleId) {
+          next = { ...next, producedBy: moduleId };
+        }
+        return next;
+      });
+
+      setArtifactData(updatedArtifacts);
+      setModuleData([...moduleData, newModule]);
+      setSelectedDomains((prev) => {
+        const next = new Set(prev);
+        domainIds.forEach((domainId) => {
+          if (domainId) {
+            next.add(domainId);
+          }
+        });
+        return next;
+      });
+      setSelectedNode({ ...newModule, type: 'module' });
+      setViewMode('graph');
+    },
+    [artifactData, firstDomainId, moduleData, selectedNode]
+  );
+
+  const handleCreateDomain = useCallback(
+    (draft: DomainDraftPayload) => {
+      const flattened = flattenDomainTree(domainData);
+      const existingIds = new Set(flattened.map((domain) => domain.id));
+      const domainId = createEntityId('domain', draft.name, existingIds);
+      const normalizedName = draft.name.trim() || `Новый домен ${existingIds.size + 1}`;
+      const normalizedDescription = draft.description.trim() || 'Описание не заполнено';
+      const newDomain: DomainNode = { id: domainId, name: normalizedName, description: normalizedDescription };
+
+      const updatedDomains = addDomainToTree(domainData, draft.parentId, newDomain);
+      setDomainData(updatedDomains);
+
+      if (draft.moduleIds.length > 0) {
+        const moduleSet = new Set(draft.moduleIds);
+        setModuleData((prev) =>
+          prev.map((module) =>
+            moduleSet.has(module.id) && !module.domains.includes(domainId)
+              ? { ...module, domains: [...module.domains, domainId] }
+              : module
+          )
+        );
+      }
+
+      setSelectedDomains((prev) => {
+        const next = new Set(prev);
+        next.add(domainId);
+        return next;
+      });
+
+      setSelectedNode({ ...newDomain, type: 'domain' });
+      setViewMode('graph');
+    },
+    [domainData]
+  );
+
+  const handleCreateArtifact = useCallback(
+    (draft: ArtifactDraftPayload) => {
+      const existingIds = new Set(artifactData.map((artifact) => artifact.id));
+      const artifactId = createEntityId('artifact', draft.name, existingIds);
+      const normalizedName = draft.name.trim() || `Новый артефакт ${existingIds.size + 1}`;
+      const normalizedDescription = draft.description.trim() || 'Описание не заполнено';
+      const normalizedDataType = draft.dataType.trim() || 'Не указан';
+      const normalizedSampleUrl = draft.sampleUrl.trim() || '#';
+      const producerId = draft.producedBy as string;
+      const domainId = draft.domainId ?? moduleById[producerId]?.domains[0] ?? firstDomainId;
+      const consumers = deduplicateNonEmpty(draft.consumerIds);
+
+      if (!domainId) {
+        return;
+      }
+
+      const newArtifact: ArtifactNode = {
+        id: artifactId,
+        name: normalizedName,
+        description: normalizedDescription,
+        domainId,
+        producedBy: producerId,
+        consumerIds: consumers,
+        dataType: normalizedDataType,
+        sampleUrl: normalizedSampleUrl
+      };
+
+      setArtifactData([...artifactData, newArtifact]);
+
+      setModuleData((prev) =>
+        prev.map((module) => {
+          if (module.id === producerId) {
+            const produces = module.produces.includes(artifactId)
+              ? module.produces
+              : [...module.produces, artifactId];
+            const dataOut = module.dataOut.some((output) => output.label === normalizedName)
+              ? module.dataOut
+              : [
+                  ...module.dataOut,
+                  {
+                    id: `output-${module.dataOut.length + 1}-${artifactId}`,
+                    label: normalizedName,
+                    consumerIds: consumers
+                  }
+                ];
+            return { ...module, produces, dataOut };
+          }
+
+          if (consumers.includes(module.id) && !module.dataIn.some((input) => input.sourceId === artifactId)) {
+            return {
+              ...module,
+              dataIn: [
+                ...module.dataIn,
+                {
+                  id: `input-${module.dataIn.length + 1}-${artifactId}`,
+                  label: normalizedName,
+                  sourceId: artifactId
+                }
+              ]
+            };
+          }
+
+          return module;
+        })
+      );
+
+      setSelectedNode({ ...newArtifact, type: 'artifact', reuseScore: 0 });
+      setSelectedDomains((prev) => {
+        const next = new Set(prev);
+        next.add(domainId);
+        return next;
+      });
+      setViewMode('graph');
+    },
+    [artifactData, firstDomainId, moduleById]
+  );
 
   const activeViewTab = viewTabs.find((tab) => tab.value === viewMode) ?? viewTabs[0];
   const isGraphActive = viewMode === 'graph';
@@ -551,7 +831,7 @@ function App() {
               Домены
             </Text>
             <DomainTree
-              tree={domainTree}
+              tree={domainData}
               selected={selectedDomains}
               onToggle={handleDomainToggle}
               descendants={domainDescendants}
@@ -599,7 +879,7 @@ function App() {
               />
             </div>
             <div className={styles.analytics}>
-              <AnalyticsPanel modules={filteredModules} />
+              <AnalyticsPanel modules={filteredModules} domainNameMap={domainNameMap} />
             </div>
           </section>
           <aside className={styles.details}>
@@ -607,6 +887,9 @@ function App() {
               node={selectedNode}
               onClose={() => setSelectedNode(null)}
               onNavigate={handleNavigate}
+              moduleNameMap={moduleNameMap}
+              artifactNameMap={artifactNameMap}
+              domainNameMap={domainNameMap}
             />
           </aside>
       </main>
@@ -619,9 +902,9 @@ function App() {
         >
           <Suspense fallback={<Loader size="m" />}>
             <StatsDashboard
-              modules={modules}
-              domains={domainTree}
-              artifacts={artifacts}
+              modules={moduleData}
+              domains={domainData}
+              artifacts={artifactData}
               reuseHistory={reuseIndexHistory}
             />
           </Suspense>
@@ -633,10 +916,128 @@ function App() {
         aria-hidden={!isCreateActive}
         style={{ display: isCreateActive ? undefined : 'none' }}
       >
-        <EntityCreation modules={modules} domains={domainTree} artifacts={artifacts} />
+        <EntityCreation
+          modules={moduleData}
+          domains={domainData}
+          artifacts={artifactData}
+          onCreateModule={handleCreateModule}
+          onCreateDomain={handleCreateDomain}
+          onCreateArtifact={handleCreateArtifact}
+        />
       </main>
     </Layout>
   );
+}
+
+function buildProductList(modules: ModuleNode[]): string[] {
+  const products = new Set<string>();
+  modules.forEach((module) => {
+    if (module.productName) {
+      products.add(module.productName);
+    }
+  });
+  return Array.from(products).sort((a, b) => a.localeCompare(b, 'ru'));
+}
+
+function deduplicateNonEmpty(values: (string | null | undefined)[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  values.forEach((value) => {
+    if (!value) {
+      return;
+    }
+    if (!seen.has(value)) {
+      seen.add(value);
+      result.push(value);
+    }
+  });
+  return result;
+}
+
+function createEntityId(prefix: string, name: string, existing: Set<string>): string {
+  const normalized = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const base = normalized ? `${prefix}-${normalized}` : `${prefix}-${Date.now()}`;
+  let candidate = base;
+  let counter = 1;
+  while (existing.has(candidate)) {
+    candidate = `${base}-${counter++}`;
+  }
+  return candidate;
+}
+
+function addDomainToTree(domains: DomainNode[], parentId: string | undefined, newDomain: DomainNode): DomainNode[] {
+  if (!parentId) {
+    return [...domains, newDomain];
+  }
+
+  const [next, inserted] = insertDomain(domains, parentId, newDomain);
+  if (inserted) {
+    return next;
+  }
+
+  return [...domains, newDomain];
+}
+
+function insertDomain(domains: DomainNode[], parentId: string, newDomain: DomainNode): [DomainNode[], boolean] {
+  let inserted = false;
+  const next = domains.map((domain) => {
+    if (domain.id === parentId) {
+      inserted = true;
+      const children = domain.children ? [...domain.children, newDomain] : [newDomain];
+      return { ...domain, children };
+    }
+
+    if (domain.children) {
+      const [childUpdated, childInserted] = insertDomain(domain.children, parentId, newDomain);
+      if (childInserted) {
+        inserted = true;
+        return { ...domain, children: childUpdated };
+      }
+    }
+
+    return domain;
+  });
+
+  return [next, inserted];
+}
+
+function buildModuleLinks(modules: ModuleNode[], artifacts: ArtifactNode[]): GraphLink[] {
+  const artifactMap = new Map<string, ArtifactNode>();
+  artifacts.forEach((artifact) => artifactMap.set(artifact.id, artifact));
+
+  return modules.flatMap((module) => {
+    const domainLinks: GraphLink[] = module.domains.map((domainId) => ({
+      source: module.id,
+      target: domainId,
+      type: 'domain'
+    }));
+
+    const dependencyLinks: GraphLink[] = module.dependencies.map((dependencyId) => ({
+      source: module.id,
+      target: dependencyId,
+      type: 'dependency'
+    }));
+
+    const produceLinks: GraphLink[] = module.produces.map((artifactId) => ({
+      source: module.id,
+      target: artifactId,
+      type: 'produces'
+    }));
+
+    const consumeLinks: GraphLink[] = module.dataIn
+      .filter((input) => input.sourceId && artifactMap.has(input.sourceId))
+      .map((input) => ({
+        source: input.sourceId as string,
+        target: module.id,
+        type: 'consumes'
+      }));
+
+    return [...domainLinks, ...dependencyLinks, ...produceLinks, ...consumeLinks];
+  });
 }
 
 function flattenDomainTree(domains: DomainNode[]): DomainNode[] {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -261,6 +261,10 @@ function App() {
       ancestors?.forEach((ancestorId) => ids.add(ancestorId));
     };
 
+    selectedDomains.forEach((domainId) => {
+      addWithAncestors(domainId);
+    });
+
     graphModules.forEach((module) => {
       module.domains.forEach((domainId) => addWithAncestors(domainId));
     });
@@ -270,7 +274,7 @@ function App() {
     }
 
     return ids;
-  }, [graphModules, highlightedDomainId, domainAncestors]);
+  }, [graphModules, highlightedDomainId, domainAncestors, selectedDomains]);
 
   const graphDomains = useMemo(
     () => filterDomainTreeByIds(domainData, relevantDomainIds),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Loader } from '@consta/uikit/Loader';
 import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react';
 import AnalyticsPanel from './components/AnalyticsPanel';
 import DomainTree from './components/DomainTree';
+import EntityCreation from './components/EntityCreation';
 import FiltersPanel from './components/FiltersPanel';
 import GraphView, { type GraphNode } from './components/GraphView';
 import NodeDetails from './components/NodeDetails';
@@ -30,7 +31,8 @@ const StatsDashboard = lazy(async () => ({
 
 const viewTabs = [
   { label: 'Связи', value: 'graph' },
-  { label: 'Статистика', value: 'stats' }
+  { label: 'Статистика', value: 'stats' },
+  { label: 'Добавление', value: 'create' }
 ] as const;
 
 type ViewMode = (typeof viewTabs)[number]['value'];
@@ -490,11 +492,27 @@ function App() {
   const activeViewTab = viewTabs.find((tab) => tab.value === viewMode) ?? viewTabs[0];
   const isGraphActive = viewMode === 'graph';
   const isStatsActive = viewMode === 'stats';
+  const isCreateActive = viewMode === 'create';
 
-  const headerTitle = isGraphActive ? 'Граф модулей и доменных областей' : 'Статистика экосистемы решений';
-  const headerDescription = isGraphActive
-    ? 'Выберите домены, чтобы увидеть связанные модули и выявить пересечения.'
-    : 'Обзор ключевых метрик по системам, модулям и обмену данными для планирования развития.';
+  const headerTitle = (() => {
+    if (isGraphActive) {
+      return 'Граф модулей и доменных областей';
+    }
+    if (isStatsActive) {
+      return 'Статистика экосистемы решений';
+    }
+    return 'Конструктор сущностей экосистемы';
+  })();
+
+  const headerDescription = (() => {
+    if (isGraphActive) {
+      return 'Выберите домены, чтобы увидеть связанные модули и выявить пересечения.';
+    }
+    if (isStatsActive) {
+      return 'Обзор ключевых метрик по системам, модулям и обмену данными для планирования развития.';
+    }
+    return 'Добавляйте новые модули, домены и артефакты, связывая их с уже существующими элементами графа.';
+  })();
 
   useEffect(() => {
     if (viewMode === 'stats' && !statsActivated) {
@@ -609,6 +627,14 @@ function App() {
           </Suspense>
         </main>
       )}
+      <main
+        className={styles.creationMain}
+        hidden={!isCreateActive}
+        aria-hidden={!isCreateActive}
+        style={{ display: isCreateActive ? undefined : 'none' }}
+      >
+        <EntityCreation modules={modules} domains={domainTree} artifacts={artifacts} />
+      </main>
     </Layout>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -244,13 +244,14 @@ function App() {
         return;
       }
       const module = moduleById[moduleId];
-      if (module && matchesModuleFilters(module)) {
+      if (module) {
         extended.push(module);
+        existing.add(moduleId);
       }
     });
 
     return extended;
-  }, [filteredModules, contextModuleIds, matchesModuleFilters]);
+  }, [filteredModules, contextModuleIds, moduleById]);
 
   const relevantDomainIds = useMemo(() => {
     const ids = new Set<string>();

--- a/src/components/AnalyticsPanel.tsx
+++ b/src/components/AnalyticsPanel.tsx
@@ -2,19 +2,19 @@ import { Bar, BarProps } from '@consta/charts/Bar';
 import { Card } from '@consta/uikit/Card';
 import { Text } from '@consta/uikit/Text';
 import React, { useMemo } from 'react';
-import { domainNameById } from '../data';
 import type { ModuleNode } from '../data';
 import styles from './AnalyticsPanel.module.css';
 
 type AnalyticsPanelProps = {
   modules: ModuleNode[];
+  domainNameMap: Record<string, string>;
 };
 
-const AnalyticsPanel: React.FC<AnalyticsPanelProps> = ({ modules }) => {
+const AnalyticsPanel: React.FC<AnalyticsPanelProps> = ({ modules, domainNameMap }) => {
   const data = useMemo(() => {
     const totals = modules.reduce<Record<string, { count: number; label: string }>>((acc, module) => {
       module.domains.forEach((domainId) => {
-        const label = domainNameById[domainId] ?? domainId;
+        const label = domainNameMap[domainId] ?? domainId;
         const current = acc[domainId] ?? { count: 0, label };
         acc[domainId] = {
           label,
@@ -32,7 +32,7 @@ const AnalyticsPanel: React.FC<AnalyticsPanelProps> = ({ modules }) => {
       }))
       .sort((a, b) => b.count - a.count)
       .slice(0, 6);
-  }, [modules]);
+  }, [domainNameMap, modules]);
 
   const chartProps: BarProps = {
     data,

--- a/src/components/EntityCreation.module.css
+++ b/src/components/EntityCreation.module.css
@@ -141,6 +141,9 @@
 .actions {
   display: flex;
   justify-content: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
 }
 
 .sidebar {

--- a/src/components/EntityCreation.module.css
+++ b/src/components/EntityCreation.module.css
@@ -1,0 +1,199 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  height: 100%;
+}
+
+.tabs {
+  align-self: flex-start;
+}
+
+.content {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  gap: 24px;
+  flex: 1;
+  min-height: 0;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px;
+  border-radius: 12px;
+  background: var(--color-bg-default);
+  box-shadow: var(--shadow-layer);
+  overflow: auto;
+}
+
+.formTitle {
+  margin: 0;
+}
+
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.label {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.input,
+.textarea {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--color-bg-border);
+  border-radius: 8px;
+  font: inherit;
+  background: var(--color-bg-default);
+  transition: border-color 0.2s ease;
+}
+
+.input:focus,
+.textarea:focus {
+  outline: none;
+  border-color: var(--color-control-bg-border-focus);
+}
+
+.textarea {
+  min-height: 96px;
+  resize: vertical;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.combobox {
+  width: 100%;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sectionTitle {
+  margin: 0;
+}
+
+.nestedGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.nestedRow {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 2fr) auto;
+  gap: 12px;
+  align-items: center;
+}
+
+.preview {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 12px;
+  background: var(--color-bg-ghost);
+}
+
+.previewList {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.previewItem {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.previewItem dt {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-control-typo-placeholder);
+}
+
+.previewItem dd {
+  margin: 0;
+  font-size: 14px;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+  border-radius: 12px;
+  background: var(--color-bg-default);
+  box-shadow: var(--shadow-layer);
+  overflow: auto;
+}
+
+.sidebarTitle {
+  margin: 0;
+}
+
+.submission {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.submissionHint {
+  margin: 0;
+}
+
+.submissionMeta {
+  display: flex;
+  justify-content: space-between;
+}
+
+.submissionJson {
+  margin: 0;
+  padding: 12px;
+  border-radius: 8px;
+  background: var(--color-bg-ghost);
+  font-size: 12px;
+  line-height: 1.5;
+  max-height: 320px;
+  overflow: auto;
+}
+
+@media (max-width: 1280px) {
+  .content {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    order: -1;
+  }
+
+  .nestedRow {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/src/components/EntityCreation.tsx
+++ b/src/components/EntityCreation.tsx
@@ -1,0 +1,865 @@
+import { Button } from '@consta/uikit/Button';
+import { Combobox } from '@consta/uikit/Combobox';
+import { Tabs } from '@consta/uikit/Tabs';
+import { Text } from '@consta/uikit/Text';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import type {
+  ArtifactNode,
+  DomainNode,
+  ModuleNode,
+  ModuleStatus,
+  ModuleInput,
+  ModuleOutput
+} from '../data';
+import styles from './EntityCreation.module.css';
+
+type EntityCreationProps = {
+  modules: ModuleNode[];
+  domains: DomainNode[];
+  artifacts: ArtifactNode[];
+};
+
+type CreationTab = 'module' | 'domain' | 'artifact';
+
+type ModuleInputDraft = {
+  id: string;
+  label: string;
+  sourceId: string | null;
+};
+
+type ModuleOutputDraft = {
+  id: string;
+  label: string;
+  consumerIds: string[];
+};
+
+type SubmissionState = {
+  mode: CreationTab;
+  payload: unknown;
+};
+
+const creationTabs = [
+  { label: 'Новый модуль', value: 'module' },
+  { label: 'Новый домен', value: 'domain' },
+  { label: 'Новый артефакт', value: 'artifact' }
+] as const satisfies readonly { label: string; value: CreationTab }[];
+
+const statusLabels: Record<ModuleStatus, string> = {
+  'in-dev': 'В разработке',
+  production: 'В эксплуатации',
+  deprecated: 'Устаревший'
+};
+
+const EntityCreation: React.FC<EntityCreationProps> = ({ modules, domains, artifacts }) => {
+  const [activeTab, setActiveTab] = useState<CreationTab>('module');
+  const [submission, setSubmission] = useState<SubmissionState | null>(null);
+
+  const domainLabelMap = useMemo(() => buildDomainLabelMap(domains), [domains]);
+  const domainItems = useMemo(
+    () => Object.keys(domainLabelMap).sort((a, b) => domainLabelMap[a].localeCompare(domainLabelMap[b], 'ru')),
+    [domainLabelMap]
+  );
+
+  const moduleLabelMap = useMemo(
+    () =>
+      modules
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name, 'ru'))
+        .reduce<Record<string, string>>((acc, module) => {
+          acc[module.id] = module.name;
+          return acc;
+        }, {}),
+    [modules]
+  );
+  const moduleItems = useMemo(() => Object.keys(moduleLabelMap), [moduleLabelMap]);
+
+  const artifactLabelMap = useMemo(
+    () =>
+      artifacts
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name, 'ru'))
+        .reduce<Record<string, string>>((acc, artifact) => {
+          acc[artifact.id] = artifact.name;
+          return acc;
+        }, {}),
+    [artifacts]
+  );
+  const artifactItems = useMemo(() => Object.keys(artifactLabelMap), [artifactLabelMap]);
+
+  useEffect(() => {
+    setSubmission(null);
+  }, [activeTab]);
+
+  const handleSubmit = (mode: CreationTab, payload: unknown) => {
+    setSubmission({ mode, payload });
+  };
+
+  return (
+    <div className={styles.container}>
+      <Tabs
+        size="s"
+        className={styles.tabs}
+        items={creationTabs}
+        value={creationTabs.find((tab) => tab.value === activeTab)}
+        getItemKey={(item) => item.value}
+        getItemLabel={(item) => item.label}
+        onChange={(tab) => setActiveTab(tab.value)}
+      />
+
+      <div className={styles.content}>
+        {activeTab === 'module' && (
+          <ModuleForm
+            onSubmit={handleSubmit}
+            domainItems={domainItems}
+            domainLabelMap={domainLabelMap}
+            moduleItems={moduleItems}
+            moduleLabelMap={moduleLabelMap}
+            artifactItems={artifactItems}
+            artifactLabelMap={artifactLabelMap}
+          />
+        )}
+
+        {activeTab === 'domain' && (
+          <DomainForm
+            onSubmit={handleSubmit}
+            domainItems={domainItems}
+            domainLabelMap={domainLabelMap}
+            moduleItems={moduleItems}
+            moduleLabelMap={moduleLabelMap}
+          />
+        )}
+
+        {activeTab === 'artifact' && (
+          <ArtifactForm
+            onSubmit={handleSubmit}
+            domainItems={domainItems}
+            domainLabelMap={domainLabelMap}
+            moduleItems={moduleItems}
+            moduleLabelMap={moduleLabelMap}
+          />
+        )}
+
+        <aside className={styles.sidebar}>
+          <Text size="s" weight="semibold" className={styles.sidebarTitle}>
+            Итоговая карточка
+          </Text>
+          {submission ? (
+            <div className={styles.submission}>
+              <Text size="xs" view="secondary" className={styles.submissionHint}>
+                Данные готовы к передаче в систему управления. Вы можете скопировать JSON
+                и сохранить карточку.
+              </Text>
+              <div className={styles.submissionMeta}>
+                <Text size="xs" weight="semibold">
+                  Тип: {submissionLabel(submission.mode)}
+                </Text>
+              </div>
+              <pre className={styles.submissionJson}>
+                {JSON.stringify(submission.payload, null, 2)}
+              </pre>
+            </div>
+          ) : (
+            <Text size="xs" view="secondary">
+              После заполнения формы нажмите «Сформировать карточку», чтобы получить
+              структурированное описание сущности.
+            </Text>
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+};
+
+type CommonFormProps = {
+  onSubmit: (mode: CreationTab, payload: unknown) => void;
+  domainItems: string[];
+  domainLabelMap: Record<string, string>;
+  moduleItems: string[];
+  moduleLabelMap: Record<string, string>;
+};
+
+type ModuleFormProps = CommonFormProps & {
+  artifactItems: string[];
+  artifactLabelMap: Record<string, string>;
+};
+
+const ModuleForm: React.FC<ModuleFormProps> = ({
+  onSubmit,
+  domainItems,
+  domainLabelMap,
+  moduleItems,
+  moduleLabelMap,
+  artifactItems,
+  artifactLabelMap
+}) => {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [productName, setProductName] = useState('');
+  const [team, setTeam] = useState('');
+  const [status, setStatus] = useState<ModuleStatus>('in-dev');
+  const [domains, setDomains] = useState<string[]>([]);
+  const [dependencies, setDependencies] = useState<string[]>([]);
+  const [produces, setProduces] = useState<string[]>([]);
+
+  const [inputs, setInputs] = useState<ModuleInputDraft[]>([
+    { id: 'input-0', label: '', sourceId: null }
+  ]);
+  const [outputs, setOutputs] = useState<ModuleOutputDraft[]>([
+    { id: 'output-0', label: '', consumerIds: [] }
+  ]);
+
+  const inputIdRef = useRef(1);
+  const outputIdRef = useRef(1);
+
+  const addInput = () => {
+    const nextId = `input-${inputIdRef.current++}`;
+    setInputs((prev) => [...prev, { id: nextId, label: '', sourceId: null }]);
+  };
+
+  const addOutput = () => {
+    const nextId = `output-${outputIdRef.current++}`;
+    setOutputs((prev) => [...prev, { id: nextId, label: '', consumerIds: [] }]);
+  };
+
+  const updateInput = (id: string, patch: Partial<ModuleInputDraft>) => {
+    setInputs((prev) => prev.map((input) => (input.id === id ? { ...input, ...patch } : input)));
+  };
+
+  const updateOutput = (id: string, patch: Partial<ModuleOutputDraft>) => {
+    setOutputs((prev) => prev.map((output) => (output.id === id ? { ...output, ...patch } : output)));
+  };
+
+  const removeInput = (id: string) => {
+    setInputs((prev) => (prev.length === 1 ? prev : prev.filter((input) => input.id !== id)));
+  };
+
+  const removeOutput = (id: string) => {
+    setOutputs((prev) => (prev.length === 1 ? prev : prev.filter((output) => output.id !== id)));
+  };
+
+  const preview = useMemo(
+    () => ({
+      name: name.trim() || 'Без названия',
+      description: description.trim() || '—',
+      productName: productName.trim() || '—',
+      team: team.trim() || '—',
+      status: statusLabels[status],
+      domains: domains.map((id) => domainLabelMap[id] ?? id),
+      dependencies: dependencies.map((id) => moduleLabelMap[id] ?? id),
+      produces: produces.map((id) => artifactLabelMap[id] ?? id),
+      dataIn: inputs.map((input) => ({
+        label: input.label.trim() || 'Без названия',
+        source: input.sourceId ? artifactLabelMap[input.sourceId] ?? input.sourceId : 'Не связано'
+      })),
+      dataOut: outputs.map((output) => ({
+        label: output.label.trim() || 'Без названия',
+        consumers: output.consumerIds.map((id) => moduleLabelMap[id] ?? id)
+      }))
+    }),
+    [
+      name,
+      description,
+      productName,
+      team,
+      status,
+      domains,
+      domainLabelMap,
+      dependencies,
+      moduleLabelMap,
+      produces,
+      artifactLabelMap,
+      inputs,
+      outputs
+    ]
+  );
+
+  const payload = useMemo(
+    () => ({
+      name: name.trim(),
+      description: description.trim(),
+      productName: productName.trim(),
+      team: team.trim(),
+      status,
+      domainIds: domains,
+      dependencyIds: dependencies,
+      producedArtifactIds: produces,
+      dataIn: inputs.map<ModuleInput>((input, index) => ({
+        id: input.id || `input-${index}`,
+        label: input.label.trim() || `Вход ${index + 1}`,
+        sourceId: input.sourceId ?? undefined
+      })),
+      dataOut: outputs.map<ModuleOutput>((output, index) => ({
+        id: output.id || `output-${index}`,
+        label: output.label.trim() || `Выход ${index + 1}`,
+        consumerIds: output.consumerIds
+      }))
+    }),
+    [name, description, productName, team, status, domains, dependencies, produces, inputs, outputs]
+  );
+
+  return (
+    <section className={styles.form}>
+      <Text size="s" weight="semibold" className={styles.formTitle}>
+        Описание модуля
+      </Text>
+
+      <div className={styles.fieldGroup}>
+        <label className={styles.field}>
+          <Text size="xs" weight="semibold" className={styles.label}>
+            Название
+          </Text>
+          <input
+            className={styles.input}
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="Например, Realtime Analytics Engine"
+          />
+        </label>
+
+        <label className={styles.field}>
+          <Text size="xs" weight="semibold" className={styles.label}>
+            Краткое описание
+          </Text>
+          <textarea
+            className={styles.textarea}
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder="Опишите назначение и ключевые сценарии использования"
+          />
+        </label>
+
+        <div className={styles.row}>
+          <label className={styles.field}>
+            <Text size="xs" weight="semibold" className={styles.label}>
+              Команда
+            </Text>
+            <input
+              className={styles.input}
+              value={team}
+              onChange={(event) => setTeam(event.target.value)}
+              placeholder="Команда сопровождения"
+            />
+          </label>
+
+          <label className={styles.field}>
+            <Text size="xs" weight="semibold" className={styles.label}>
+              Продукт
+            </Text>
+            <input
+              className={styles.input}
+              value={productName}
+              onChange={(event) => setProductName(event.target.value)}
+              placeholder="Название продукта"
+            />
+          </label>
+        </div>
+
+        <label className={styles.field}>
+          <Text size="xs" weight="semibold" className={styles.label}>
+            Статус
+          </Text>
+          <Combobox<ModuleStatus>
+            size="s"
+            placeholder="Выберите статус"
+            items={Object.keys(statusLabels) as ModuleStatus[]}
+            value={status}
+            getItemKey={(item) => item}
+            getItemLabel={(item) => statusLabels[item]}
+            onChange={(next) => setStatus(next ?? 'in-dev')}
+            className={styles.combobox}
+          />
+        </label>
+
+        <label className={styles.field}>
+          <Text size="xs" weight="semibold" className={styles.label}>
+            Доменные области
+          </Text>
+          <Combobox<string>
+            size="s"
+            placeholder="Добавьте домены"
+            items={domainItems}
+            value={domains}
+            multiple
+            selectAll
+            getItemKey={(item) => item}
+            getItemLabel={(item) => domainLabelMap[item] ?? item}
+            onChange={(next) => setDomains(next ?? [])}
+            className={styles.combobox}
+          />
+        </label>
+
+        <label className={styles.field}>
+          <Text size="xs" weight="semibold" className={styles.label}>
+            Зависит от модулей
+          </Text>
+          <Combobox<string>
+            size="s"
+            placeholder="Выберите зависимости"
+            items={moduleItems}
+            value={dependencies}
+            multiple
+            getItemKey={(item) => item}
+            getItemLabel={(item) => moduleLabelMap[item] ?? item}
+            onChange={(next) => setDependencies(next ?? [])}
+            className={styles.combobox}
+          />
+        </label>
+
+        <label className={styles.field}>
+          <Text size="xs" weight="semibold" className={styles.label}>
+            Производит артефакты
+          </Text>
+          <Combobox<string>
+            size="s"
+            placeholder="Выберите артефакты"
+            items={artifactItems}
+            value={produces}
+            multiple
+            getItemKey={(item) => item}
+            getItemLabel={(item) => artifactLabelMap[item] ?? item}
+            onChange={(next) => setProduces(next ?? [])}
+            className={styles.combobox}
+          />
+        </label>
+      </div>
+
+      <div className={styles.section}>
+        <Text size="xs" weight="semibold" className={styles.sectionTitle}>
+          Входные данные
+        </Text>
+        <div className={styles.nestedGroup}>
+          {inputs.map((input) => (
+            <div key={input.id} className={styles.nestedRow}>
+              <input
+                className={styles.input}
+                value={input.label}
+                onChange={(event) => updateInput(input.id, { label: event.target.value })}
+                placeholder="Название входного набора"
+              />
+              <Combobox<string>
+                size="s"
+                placeholder="Источник артефактов"
+                items={artifactItems}
+                value={input.sourceId}
+                getItemKey={(item) => item}
+                getItemLabel={(item) => artifactLabelMap[item] ?? item}
+                onChange={(next) => updateInput(input.id, { sourceId: next ?? null })}
+                className={styles.combobox}
+              />
+              <Button
+                size="xs"
+                view="ghost"
+                label="Удалить"
+                onClick={() => removeInput(input.id)}
+                disabled={inputs.length === 1}
+              />
+            </div>
+          ))}
+        </div>
+        <Button size="xs" view="secondary" label="Добавить вход" onClick={addInput} />
+      </div>
+
+      <div className={styles.section}>
+        <Text size="xs" weight="semibold" className={styles.sectionTitle}>
+          Выходные данные
+        </Text>
+        <div className={styles.nestedGroup}>
+          {outputs.map((output) => (
+            <div key={output.id} className={styles.nestedRow}>
+              <input
+                className={styles.input}
+                value={output.label}
+                onChange={(event) => updateOutput(output.id, { label: event.target.value })}
+                placeholder="Название выходного артефакта"
+              />
+              <Combobox<string>
+                size="s"
+                placeholder="Потребители"
+                items={moduleItems}
+                value={output.consumerIds}
+                multiple
+                getItemKey={(item) => item}
+                getItemLabel={(item) => moduleLabelMap[item] ?? item}
+                onChange={(next) => updateOutput(output.id, { consumerIds: next ?? [] })}
+                className={styles.combobox}
+              />
+              <Button
+                size="xs"
+                view="ghost"
+                label="Удалить"
+                onClick={() => removeOutput(output.id)}
+                disabled={outputs.length === 1}
+              />
+            </div>
+          ))}
+        </div>
+        <Button size="xs" view="secondary" label="Добавить выход" onClick={addOutput} />
+      </div>
+
+      <PreviewBlock preview={preview} />
+
+      <div className={styles.actions}>
+        <Button
+          size="s"
+          label="Сформировать карточку"
+          view="primary"
+          onClick={() => onSubmit('module', payload)}
+        />
+      </div>
+    </section>
+  );
+};
+
+type DomainFormProps = CommonFormProps;
+
+const DomainForm: React.FC<DomainFormProps> = ({
+  onSubmit,
+  domainItems,
+  domainLabelMap,
+  moduleItems,
+  moduleLabelMap
+}) => {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [parentId, setParentId] = useState<string | null>(null);
+  const [relatedModules, setRelatedModules] = useState<string[]>([]);
+
+  const preview = useMemo(
+    () => ({
+      name: name.trim() || 'Без названия',
+      description: description.trim() || '—',
+      parent: parentId ? domainLabelMap[parentId] ?? parentId : 'Корневой домен',
+      modules: relatedModules.map((id) => moduleLabelMap[id] ?? id)
+    }),
+    [name, description, parentId, relatedModules, domainLabelMap, moduleLabelMap]
+  );
+
+  const payload = useMemo(
+    () => ({
+      name: name.trim(),
+      description: description.trim(),
+      parentId: parentId ?? undefined,
+      moduleIds: relatedModules
+    }),
+    [name, description, parentId, relatedModules]
+  );
+
+  return (
+    <section className={styles.form}>
+      <Text size="s" weight="semibold" className={styles.formTitle}>
+        Описание домена
+      </Text>
+
+      <div className={styles.fieldGroup}>
+        <label className={styles.field}>
+          <Text size="xs" weight="semibold" className={styles.label}>
+            Название
+          </Text>
+          <input
+            className={styles.input}
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="Например, Мониторинг производственных объектов"
+          />
+        </label>
+
+        <label className={styles.field}>
+          <Text size="xs" weight="semibold" className={styles.label}>
+            Описание
+          </Text>
+          <textarea
+            className={styles.textarea}
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder="Раскройте границы домена и основные сценарии"
+          />
+        </label>
+
+        <label className={styles.field}>
+          <Text size="xs" weight="semibold" className={styles.label}>
+            Родительский домен
+          </Text>
+          <Combobox<string>
+            size="s"
+            placeholder="Корневой уровень"
+            items={domainItems}
+            value={parentId}
+            getItemKey={(item) => item}
+            getItemLabel={(item) => domainLabelMap[item] ?? item}
+            onChange={(next) => setParentId(next ?? null)}
+            className={styles.combobox}
+          />
+        </label>
+
+        <label className={styles.field}>
+          <Text size="xs" weight="semibold" className={styles.label}>
+            Связанные модули
+          </Text>
+          <Combobox<string>
+            size="s"
+            placeholder="Выберите модули"
+            items={moduleItems}
+            value={relatedModules}
+            multiple
+            getItemKey={(item) => item}
+            getItemLabel={(item) => moduleLabelMap[item] ?? item}
+            onChange={(next) => setRelatedModules(next ?? [])}
+            className={styles.combobox}
+          />
+        </label>
+      </div>
+
+      <PreviewBlock preview={preview} />
+
+      <div className={styles.actions}>
+        <Button
+          size="s"
+          label="Сформировать карточку"
+          view="primary"
+          onClick={() => onSubmit('domain', payload)}
+        />
+      </div>
+    </section>
+  );
+};
+
+type ArtifactFormProps = CommonFormProps;
+
+const ArtifactForm: React.FC<ArtifactFormProps> = ({
+  onSubmit,
+  domainItems,
+  domainLabelMap,
+  moduleItems,
+  moduleLabelMap
+}) => {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [domainId, setDomainId] = useState<string | null>(null);
+  const [producerId, setProducerId] = useState<string | null>(null);
+  const [consumerIds, setConsumerIds] = useState<string[]>([]);
+  const [dataType, setDataType] = useState('');
+  const [sampleUrl, setSampleUrl] = useState('');
+
+  const preview = useMemo(
+    () => ({
+      name: name.trim() || 'Без названия',
+      description: description.trim() || '—',
+      domain: domainId ? domainLabelMap[domainId] ?? domainId : 'Не выбран',
+      producedBy: producerId ? moduleLabelMap[producerId] ?? producerId : 'Не выбран',
+      consumers: consumerIds.map((id) => moduleLabelMap[id] ?? id),
+      dataType: dataType.trim() || '—',
+      sampleUrl: sampleUrl.trim() || '—'
+    }),
+    [name, description, domainId, producerId, consumerIds, dataType, sampleUrl, domainLabelMap, moduleLabelMap]
+  );
+
+  const payload = useMemo(
+    () => ({
+      name: name.trim(),
+      description: description.trim(),
+      domainId: domainId ?? undefined,
+      producedBy: producerId ?? undefined,
+      consumerIds,
+      dataType: dataType.trim(),
+      sampleUrl: sampleUrl.trim()
+    }),
+    [name, description, domainId, producerId, consumerIds, dataType, sampleUrl]
+  );
+
+  return (
+    <section className={styles.form}>
+      <Text size="s" weight="semibold" className={styles.formTitle}>
+        Описание артефакта
+      </Text>
+
+      <div className={styles.fieldGroup}>
+        <label className={styles.field}>
+          <Text size="xs" weight="semibold" className={styles.label}>
+            Название
+          </Text>
+          <input
+            className={styles.input}
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="Например, Пакет рекомендаций по оптимизации"
+          />
+        </label>
+
+        <label className={styles.field}>
+          <Text size="xs" weight="semibold" className={styles.label}>
+            Описание
+          </Text>
+          <textarea
+            className={styles.textarea}
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder="Опишите структуру и назначение артефакта"
+          />
+        </label>
+
+        <div className={styles.row}>
+          <label className={styles.field}>
+            <Text size="xs" weight="semibold" className={styles.label}>
+              Тип данных
+            </Text>
+            <input
+              className={styles.input}
+              value={dataType}
+              onChange={(event) => setDataType(event.target.value)}
+              placeholder="Например, Потоковые данные"
+            />
+          </label>
+
+          <label className={styles.field}>
+            <Text size="xs" weight="semibold" className={styles.label}>
+              Пример / ссылка
+            </Text>
+            <input
+              className={styles.input}
+              value={sampleUrl}
+              onChange={(event) => setSampleUrl(event.target.value)}
+              placeholder="https://..."
+            />
+          </label>
+        </div>
+
+        <label className={styles.field}>
+          <Text size="xs" weight="semibold" className={styles.label}>
+            Доменная область
+          </Text>
+          <Combobox<string>
+            size="s"
+            placeholder="Выберите домен"
+            items={domainItems}
+            value={domainId}
+            getItemKey={(item) => item}
+            getItemLabel={(item) => domainLabelMap[item] ?? item}
+            onChange={(next) => setDomainId(next ?? null)}
+            className={styles.combobox}
+          />
+        </label>
+
+        <label className={styles.field}>
+          <Text size="xs" weight="semibold" className={styles.label}>
+            Производящий модуль
+          </Text>
+          <Combobox<string>
+            size="s"
+            placeholder="Укажите источник"
+            items={moduleItems}
+            value={producerId}
+            getItemKey={(item) => item}
+            getItemLabel={(item) => moduleLabelMap[item] ?? item}
+            onChange={(next) => setProducerId(next ?? null)}
+            className={styles.combobox}
+          />
+        </label>
+
+        <label className={styles.field}>
+          <Text size="xs" weight="semibold" className={styles.label}>
+            Потребители
+          </Text>
+          <Combobox<string>
+            size="s"
+            placeholder="Выберите модули-потребители"
+            items={moduleItems}
+            value={consumerIds}
+            multiple
+            getItemKey={(item) => item}
+            getItemLabel={(item) => moduleLabelMap[item] ?? item}
+            onChange={(next) => setConsumerIds(next ?? [])}
+            className={styles.combobox}
+          />
+        </label>
+      </div>
+
+      <PreviewBlock preview={preview} />
+
+      <div className={styles.actions}>
+        <Button
+          size="s"
+          label="Сформировать карточку"
+          view="primary"
+          onClick={() => onSubmit('artifact', payload)}
+        />
+      </div>
+    </section>
+  );
+};
+
+type PreviewBlockProps = {
+  preview: Record<string, unknown>;
+};
+
+const PreviewBlock: React.FC<PreviewBlockProps> = ({ preview }) => {
+  return (
+    <div className={styles.preview}>
+      <Text size="xs" weight="semibold" className={styles.sectionTitle}>
+        Предпросмотр
+      </Text>
+      <dl className={styles.previewList}>
+        {Object.entries(preview).map(([key, value]) => (
+          <div key={key} className={styles.previewItem}>
+            <dt>{key}</dt>
+            <dd>{formatPreviewValue(value)}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+};
+
+function formatPreviewValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return '—';
+    }
+    return value
+      .map((item) => (typeof item === 'string' ? item : formatPreviewValue(item)))
+      .join(', ');
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.entries(value)
+      .map(([key, nestedValue]) => `${key}: ${formatPreviewValue(nestedValue)}`)
+      .join('; ');
+  }
+
+  if (typeof value === 'string') {
+    return value.length > 0 ? value : '—';
+  }
+
+  return String(value);
+}
+
+function buildDomainLabelMap(domains: DomainNode[]): Record<string, string> {
+  const labels: Record<string, string> = {};
+
+  const traverse = (nodes: DomainNode[], parents: string[]) => {
+    nodes.forEach((node) => {
+      const currentPath = [...parents, node.name];
+      labels[node.id] = currentPath.join(' / ');
+      if (node.children && node.children.length > 0) {
+        traverse(node.children, currentPath);
+      }
+    });
+  };
+
+  traverse(domains, []);
+  return labels;
+}
+
+function submissionLabel(mode: CreationTab): string {
+  switch (mode) {
+    case 'module':
+      return 'Модуль';
+    case 'domain':
+      return 'Домен';
+    case 'artifact':
+      return 'Артефакт';
+    default:
+      return mode;
+  }
+}
+
+export default EntityCreation;

--- a/src/components/GraphPersistenceControls.module.css
+++ b/src/components/GraphPersistenceControls.module.css
@@ -1,0 +1,34 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  margin-bottom: 24px;
+  border-radius: 12px;
+  background: var(--color-bg-default);
+  box-shadow: var(--shadow-layer);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.status {
+  font-size: 12px;
+}
+
+.statusSuccess {
+  color: var(--color-typo-success);
+}
+
+.statusError {
+  color: var(--color-typo-alert);
+}

--- a/src/components/GraphPersistenceControls.tsx
+++ b/src/components/GraphPersistenceControls.tsx
@@ -1,0 +1,167 @@
+import { Button } from '@consta/uikit/Button';
+import { Text } from '@consta/uikit/Text';
+import React, { useMemo, useRef, useState } from 'react';
+import type { ArtifactNode, DomainNode, ModuleNode } from '../data';
+import styles from './GraphPersistenceControls.module.css';
+
+type StatusMessage =
+  | { type: 'success'; message: string }
+  | { type: 'error'; message: string };
+
+const SNAPSHOT_VERSION = 1;
+
+export type GraphSnapshotPayload = {
+  version: number;
+  exportedAt?: string;
+  modules: ModuleNode[];
+  domains: DomainNode[];
+  artifacts: ArtifactNode[];
+};
+
+type GraphPersistenceControlsProps = {
+  modules: ModuleNode[];
+  domains: DomainNode[];
+  artifacts: ArtifactNode[];
+  onImport: (snapshot: GraphSnapshotPayload) => void;
+};
+
+const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
+  modules,
+  domains,
+  artifacts,
+  onImport
+}) => {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [status, setStatus] = useState<StatusMessage | null>(null);
+
+  const snapshot = useMemo<GraphSnapshotPayload>(
+    () => ({
+      version: SNAPSHOT_VERSION,
+      exportedAt: new Date().toISOString(),
+      modules,
+      domains,
+      artifacts
+    }),
+    [modules, domains, artifacts]
+  );
+
+  const handleExport = () => {
+    try {
+      const data = JSON.stringify(snapshot, null, 2);
+      const blob = new Blob([data], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      const timestamp = snapshot.exportedAt?.replace(/[:.]/g, '-') ?? 'snapshot';
+      link.href = url;
+      link.download = `graph-snapshot-${timestamp}.json`;
+      document.body.append(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+      setStatus({ type: 'success', message: 'Экспорт выполнен. Файл сохранён.' });
+    } catch (error) {
+      setStatus({ type: 'error', message: 'Не удалось сформировать файл экспорта.' });
+    }
+  };
+
+  const handleTriggerImport = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    const file = event.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const text = reader.result;
+        if (typeof text !== 'string') {
+          throw new Error('Неверный формат файла');
+        }
+
+        const parsed = JSON.parse(text);
+        if (!isGraphSnapshotPayload(parsed)) {
+          throw new Error('Файл не соответствует структуре графа');
+        }
+
+        onImport(parsed);
+        const moduleCount = parsed.modules.length;
+        const domainCount = parsed.domains.length;
+        const artifactCount = parsed.artifacts.length;
+        setStatus({
+          type: 'success',
+          message: `Импорт завершён. Модулей: ${moduleCount}, доменов: ${domainCount}, артефактов: ${artifactCount}.`
+        });
+      } catch (error) {
+        setStatus({
+          type: 'error',
+          message:
+            error instanceof Error ? error.message : 'Не удалось прочитать данные из файла.'
+        });
+      }
+    };
+    reader.onerror = () => {
+      setStatus({ type: 'error', message: 'Ошибка чтения файла.' });
+    };
+    reader.readAsText(file);
+    event.target.value = '';
+  };
+
+  return (
+    <section className={styles.wrapper} aria-label="Сохранение графа">
+      <div className={styles.header}>
+        <Text size="s" weight="semibold">
+          Экспорт и импорт графа
+        </Text>
+        <Text size="xs" view="secondary">
+          Сохраните текущее состояние экосистемы в JSON и загрузите его позже, чтобы восстановить
+          добавленные сущности.
+        </Text>
+      </div>
+      <div className={styles.actions}>
+        <Button size="s" label="Экспортировать граф" onClick={handleExport} />
+        <Button size="s" view="secondary" label="Импортировать граф" onClick={handleTriggerImport} />
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/json"
+          hidden
+          onChange={handleFileChange}
+        />
+      </div>
+      {status && (
+        <Text
+          size="xs"
+          className={`${styles.status} ${
+            status.type === 'success' ? styles.statusSuccess : styles.statusError
+          }`}
+        >
+          {status.message}
+        </Text>
+      )}
+    </section>
+  );
+};
+
+function isGraphSnapshotPayload(value: unknown): value is GraphSnapshotPayload {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<GraphSnapshotPayload>;
+  if (!Array.isArray(candidate.modules) || !Array.isArray(candidate.domains) || !Array.isArray(candidate.artifacts)) {
+    return false;
+  }
+
+  if (candidate.version !== undefined && typeof candidate.version !== 'number') {
+    return false;
+  }
+
+  return true;
+}
+
+export default GraphPersistenceControls;

--- a/src/components/StatsDashboard.tsx
+++ b/src/components/StatsDashboard.tsx
@@ -7,7 +7,6 @@ import { Text } from '@consta/uikit/Text';
 import { useMemo } from 'react';
 import {
   artifacts as allArtifacts,
-  domainNameById,
   domainTree as allDomains,
   modules as allModules,
   type ArtifactNode,
@@ -74,6 +73,7 @@ const StatsDashboard = ({
   artifacts = defaultArtifacts,
   reuseHistory
 }: StatsDashboardProps) => {
+  const domainNameMap = useMemo(() => buildDomainNameMap(domains), [domains]);
   const systems = useMemo(() => {
     const map = new Map<string, SystemRow>();
 
@@ -415,7 +415,7 @@ const StatsDashboard = ({
             ) : (
               domainWithoutModules.map((domain) => (
                 <span key={domain.id} className={styles.domainPill}>
-                  {domainNameById[domain.id] ?? domain.name}
+                  {domainNameMap[domain.id] ?? domain.name}
                 </span>
               ))
             )}
@@ -520,6 +520,22 @@ function formatPeriod(period: string): string {
 
   const monthNames = ['янв', 'фев', 'мар', 'апр', 'май', 'июн', 'июл', 'авг', 'сен', 'окт', 'ноя', 'дек'];
   return `${monthNames[monthIndex - 1]} ${year}`;
+}
+
+function buildDomainNameMap(domains: DomainNode[]): Record<string, string> {
+  const map: Record<string, string> = {};
+
+  const traverse = (nodes: DomainNode[]) => {
+    nodes.forEach((domain) => {
+      map[domain.id] = domain.name;
+      if (domain.children) {
+        traverse(domain.children);
+      }
+    });
+  };
+
+  traverse(domains);
+  return map;
 }
 
 function average(values: number[]): number {


### PR DESCRIPTION
## Summary
- add a creation workspace with forms for modules, domains, and artifacts that link to existing graph data
- provide live previews and JSON export of drafted entities alongside the creation workflow
- integrate the new workspace into the main navigation and add supporting layout styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ea3f767fb88332b55f46d4c6c3113b