### PR TITLE
Normalize graph snapshot export/import

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -19,6 +19,14 @@
   border-bottom: 1px solid var(--color-bg-border);
 }
 
+.errorBannerContent {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
 .header {
   display: flex;
   align-items: center;

--- a/src/services/graphStorage.ts
+++ b/src/services/graphStorage.ts
@@ -21,7 +21,7 @@ export async function fetchGraphSnapshot(signal?: AbortSignal): Promise<GraphSna
     modules: snapshot.modules,
     domains: snapshot.domains,
     artifacts: snapshot.artifacts,
-    layout: normalizeLayout(snapshot.layout)
+    layout: normalizeLayoutSnapshot(snapshot.layout)
   };
 }
 
@@ -44,7 +44,9 @@ export async function persistGraphSnapshot(
   }
 }
 
-function normalizeLayout(layout: GraphSnapshotPayload['layout']): GraphLayoutSnapshot | undefined {
+export function normalizeLayoutSnapshot(
+  layout: GraphSnapshotPayload['layout']
+): GraphLayoutSnapshot | undefined {
   if (!layout || typeof layout !== 'object' || !layout.nodes) {
     return undefined;
   }


### PR DESCRIPTION
## Summary
- sanitize graph layout positions when exporting snapshots and reuse a shared normalizer
- validate imported graph snapshots before applying them and coerce metadata to safe defaults
- reuse the layout normalization helper inside the graph storage client API

## Testing
- npm run lint
- npm run test:server
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68eb106f4a0c8332b6cf49ef0f6609ad