### PR TITLE
Improve graph connectivity and layout for new nodes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -429,6 +429,15 @@ function App() {
 
     if (showAllConnections) {
       filteredModules.forEach((module) => {
+        module.dependencies.forEach((dependencyId) => {
+          extraModuleIds.add(dependencyId);
+        });
+
+        const dependents = moduleDependents.get(module.id);
+        dependents?.forEach((dependentId) => {
+          extraModuleIds.add(dependentId);
+        });
+
         module.produces.forEach((artifactId) => {
           const artifact = artifactMap.get(artifactId);
           artifact?.consumerIds.forEach((consumerId) => extraModuleIds.add(consumerId));
@@ -465,7 +474,14 @@ function App() {
     });
 
     return extended;
-  }, [filteredModules, contextModuleIds, moduleById, showAllConnections, artifactMap]);
+  }, [
+    filteredModules,
+    contextModuleIds,
+    moduleById,
+    showAllConnections,
+    artifactMap,
+    moduleDependents
+  ]);
 
   const relevantDomainIds = useMemo(() => {
     const ids = new Set<string>();
@@ -793,7 +809,9 @@ function App() {
     (positions: Record<string, GraphLayoutNodePosition>) => {
       setLayoutPositions((prev) => {
         const merged = mergeLayoutPositions(prev, positions);
-        const pruned = pruneLayoutPositions(merged, activeNodeIds);
+        const ensuredActiveIds = new Set(activeNodeIds);
+        Object.keys(positions).forEach((id) => ensuredActiveIds.add(id));
+        const pruned = pruneLayoutPositions(merged, ensuredActiveIds);
         return layoutsEqual(prev, pruned) ? prev : pruned;
       });
     },

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -139,6 +139,9 @@ const GraphView: React.FC<GraphViewProps> = ({
     [nodes, links]
   );
 
+  const nodeCount = nodes.length;
+  const linkCount = links.length;
+
   useEffect(() => {
     if (!highlightedNode || !graphRef.current) {
       return;
@@ -163,6 +166,20 @@ const GraphView: React.FC<GraphViewProps> = ({
       (window as typeof window & { __forceGraphRef?: ForceGraphMethods }).__forceGraphRef = graphRef.current;
     }
   }, [graphData]);
+
+  useEffect(() => {
+    if (!graphRef.current) {
+      return;
+    }
+
+    const reheat = (graphRef.current as ForceGraphMethods & {
+      d3ReheatSimulation?: () => void;
+    }).d3ReheatSimulation;
+
+    if (typeof reheat === 'function') {
+      reheat();
+    }
+  }, [nodeCount, linkCount]);
 
   const emitLayoutUpdate = useCallback(() => {
     if (!onLayoutChange) {


### PR DESCRIPTION
## Summary
- include dependency and dependent modules when showing all connections so cross-product links render
- retain layout positions for freshly created nodes by keeping them active during updates
- reheat the force simulation whenever the node/link counts change to make new items draggable immediately

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68eb77dbb0988332a7b0b7a9e3a417b9