### PR TITLE
feat: add company-specific filters and usage breakdown

### DIFF
--- a/server/graphStore.test.ts
+++ b/server/graphStore.test.ts
@@ -78,7 +78,7 @@ test('persists snapshots and reloads them from disk', { concurrency: false }, as
         technologyStack: [],
         localization: 'ru',
         ridOwner: { company: 'Test Co', division: 'Digital' },
-        userStats: { companies: 1, licenses: 10 },
+        userStats: { companies: [{ name: 'Test Energy', licenses: 10 }] },
         status: 'production',
         repository: 'https://example.com/repo',
         api: 'https://example.com/api',
@@ -121,7 +121,7 @@ test('persists snapshots and reloads them from disk', { concurrency: false }, as
         technologyStack: [],
         localization: 'ru',
         ridOwner: { company: 'Test Co', division: 'R&D' },
-        userStats: { companies: 1, licenses: 5 },
+        userStats: { companies: [{ name: 'Test Energy', licenses: 5 }] },
         status: 'in-dev',
         repository: undefined,
         api: undefined,
@@ -262,7 +262,12 @@ test('supports complex graph authoring flows', { concurrency: false }, async () 
     technologyStack: ['PyTorch', 'FastAPI'],
     localization: 'ru',
     ridOwner: { company: 'АО «Nedra Digital»', division: 'AI Лаборатория' },
-    userStats: { companies: 2, licenses: 25 },
+    userStats: {
+      companies: [
+        { name: 'Alpha Oil', licenses: 10 },
+        { name: 'Beta Industries', licenses: 15 }
+      ]
+    },
     status: 'in-dev',
     repository: 'https://git.nedra.digital/ai/orchestrator',
     api: 'REST /api/v1/orchestrator',

--- a/src/components/AdminPanel.module.css
+++ b/src/components/AdminPanel.module.css
@@ -107,6 +107,10 @@
   resize: vertical;
 }
 
+.select {
+  width: 100%;
+}
+
 .textarea {
   min-height: 96px;
 }
@@ -131,6 +135,19 @@
   gap: 12px;
   flex-wrap: wrap;
   align-items: center;
+}
+
+.companyInlineForm {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+  width: 100%;
+}
+
+.companyInlineButtons {
+  display: flex;
+  gap: 8px;
 }
 
 .chipList {

--- a/src/components/FiltersPanel.tsx
+++ b/src/components/FiltersPanel.tsx
@@ -19,6 +19,9 @@ type FiltersPanelProps = {
   products: string[];
   productFilter: string[];
   onProductChange: (products: string[]) => void;
+  companies: string[];
+  companyFilter: string | null;
+  onCompanyChange: (company: string | null) => void;
   showAllConnections: boolean;
   onToggleConnections: (value: boolean) => void;
 };
@@ -43,6 +46,9 @@ const FiltersPanel: React.FC<FiltersPanelProps> = ({
   products,
   productFilter,
   onProductChange,
+  companies,
+  companyFilter,
+  onCompanyChange,
   showAllConnections,
   onToggleConnections
 }) => {
@@ -146,6 +152,23 @@ const FiltersPanel: React.FC<FiltersPanelProps> = ({
         />
       </div>
 
+      <div className={styles.field}>
+        <Text size="s" weight="semibold">
+          Компания
+        </Text>
+        <Combobox
+          placeholder="Все компании"
+          size="s"
+          items={companies}
+          value={companyFilter}
+          getItemKey={(item) => item}
+          getItemLabel={(item) => item}
+          onChange={(value) => onCompanyChange(value ?? null)}
+          form="default"
+          className={styles.combobox}
+        />
+      </div>
+
       <div className={styles.switchRow}>
         <Switch
           checked={showAllConnections}
@@ -160,6 +183,7 @@ const FiltersPanel: React.FC<FiltersPanelProps> = ({
           onClick={() => {
             onSearchChange('');
             onProductChange(products);
+            onCompanyChange(null);
             statuses.forEach((status) => {
               if (!activeStatuses.has(status)) {
                 onToggleStatus(status);

--- a/src/components/NodeDetails.module.css
+++ b/src/components/NodeDetails.module.css
@@ -131,6 +131,23 @@
   gap: 2px;
 }
 
+.companyList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.companyListItem {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
 .teamRoster {
   display: flex;
   flex-direction: column;

--- a/src/components/NodeDetails.tsx
+++ b/src/components/NodeDetails.tsx
@@ -211,6 +211,10 @@ const NodeDetails: React.FC<NodeDetailsProps> = ({
     );
   }
 
+  const companyUsage = node.userStats.companies;
+  const totalCompanies = companyUsage.length;
+  const totalLicenses = companyUsage.reduce((sum, company) => sum + company.licenses, 0);
+
   const sections: { id: SectionId; title: string; content: React.ReactNode }[] = [
     {
       id: 'general',
@@ -246,10 +250,30 @@ const NodeDetails: React.FC<NodeDetailsProps> = ({
           <InfoRow label="Локализация функции">
             <Text size="s">{node.localization}</Text>
           </InfoRow>
-          <InfoRow label="Количество пользователей">
-            <Text size="s">
-              {node.userStats.companies} компаний, {node.userStats.licenses} лицензий
-            </Text>
+          <InfoRow label="Использование компаниями">
+            {companyUsage.length === 0 ? (
+              <Text size="s" view="secondary">
+                Нет данных о компаниях
+              </Text>
+            ) : (
+              <>
+                <Text size="s">
+                  {formatCompanyCount(totalCompanies)}, всего {formatNumber(totalLicenses)} {formatLicenseCount(totalLicenses)}
+                </Text>
+                <ul className={styles.companyList}>
+                  {companyUsage.map((company) => (
+                    <li key={company.name} className={styles.companyListItem}>
+                      <Text size="s" weight="semibold">
+                        {company.name}
+                      </Text>
+                      <Text size="s" view="secondary">
+                        {formatNumber(company.licenses)} {formatLicenseCount(company.licenses)}
+                      </Text>
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
           </InfoRow>
           <InfoRow label="Стек технологий">
             <div className={styles.tagList}>
@@ -476,6 +500,36 @@ function statusLabel(status: GraphNode & { type: 'module' }['status']) {
 
 function formatNumber(value: number): string {
   return new Intl.NumberFormat('ru-RU').format(value);
+}
+
+const companyPluralRules = new Intl.PluralRules('ru');
+
+function formatCompanyCount(count: number): string {
+  const category = companyPluralRules.select(count);
+
+  switch (category) {
+    case 'one':
+      return `${count} компания`;
+    case 'few':
+      return `${count} компании`;
+    default:
+      return `${count} компаний`;
+  }
+}
+
+const licensePluralRules = new Intl.PluralRules('ru');
+
+function formatLicenseCount(count: number): string {
+  const category = licensePluralRules.select(count);
+
+  switch (category) {
+    case 'one':
+      return 'лицензия';
+    case 'few':
+      return 'лицензии';
+    default:
+      return 'лицензий';
+  }
 }
 
 const teamCountPluralRules = new Intl.PluralRules('ru');

--- a/src/data.ts
+++ b/src/data.ts
@@ -48,9 +48,13 @@ export type LibraryDependency = {
   version: string;
 };
 
-export type UserStats = {
-  companies: number;
+export type CompanyUsage = {
+  name: string;
   licenses: number;
+};
+
+export type UserStats = {
+  companies: CompanyUsage[];
 };
 
 export type ModuleMetrics = {
@@ -212,7 +216,15 @@ export const modules: ModuleNode[] = [
       company: 'АО «Nedra Digital»',
       division: 'Дирекция концептуального проектирования'
     },
-    userStats: { companies: 14, licenses: 620 },
+    userStats: {
+      companies: [
+        { name: 'АО «Западнефть Разработка»', licenses: 180 },
+        { name: 'ООО «Цифровая Добыча»', licenses: 140 },
+        { name: 'АО «Восток Инжиниринг»', licenses: 120 },
+        { name: 'АО «УралТех Сервис»', licenses: 100 },
+        { name: 'ООО «Арктик Ойл»', licenses: 80 }
+      ]
+    },
     status: 'production',
     repository: 'https://git.nedra.digital/infraplan/data-hub',
     api: 'REST /api/v2/infraplan/source-packs',
@@ -288,7 +300,14 @@ export const modules: ModuleNode[] = [
       company: 'АО «Nedra Digital»',
       division: 'Дирекция концептуального проектирования'
     },
-    userStats: { companies: 9, licenses: 380 },
+    userStats: {
+      companies: [
+        { name: 'АО «Западнефть Разработка»', licenses: 120 },
+        { name: 'ПАО «СибНефть Добыча»', licenses: 100 },
+        { name: 'АО «Восток Инжиниринг»', licenses: 90 },
+        { name: 'ООО «Каспий ГеоСервис»', licenses: 70 }
+      ]
+    },
     status: 'production',
     repository: 'https://git.nedra.digital/infraplan/layout-engine',
     api: 'REST /api/v1/infraplan/layouts',
@@ -361,7 +380,15 @@ export const modules: ModuleNode[] = [
       company: 'АО «Nedra Digital»',
       division: 'Дирекция концептуального проектирования'
     },
-    userStats: { companies: 11, licenses: 450 },
+    userStats: {
+      companies: [
+        { name: 'АО «Западнефть Разработка»', licenses: 120 },
+        { name: 'ООО «Цифровая Добыча»', licenses: 100 },
+        { name: 'ПАО «СибНефть Добыча»', licenses: 90 },
+        { name: 'АО «Байкал Нефтехим»', licenses: 80 },
+        { name: 'АО «Волжская Эксплуатация»', licenses: 60 }
+      ]
+    },
     status: 'production',
     repository: 'https://git.nedra.digital/infraplan/economics',
     api: 'REST /api/v1/infraplan/economics',
@@ -435,7 +462,16 @@ export const modules: ModuleNode[] = [
       company: 'АО «Nedra Digital»',
       division: 'Операционный центр цифровых двойников'
     },
-    userStats: { companies: 12, licenses: 2100 },
+    userStats: {
+      companies: [
+        { name: 'ПАО «СибНефть Добыча»', licenses: 480 },
+        { name: 'АО «СеверЭнерго Бурение»', licenses: 420 },
+        { name: 'ООО «Каспий ГеоСервис»', licenses: 360 },
+        { name: 'АО «Байкал Нефтехим»', licenses: 340 },
+        { name: 'ООО «Нордик Потенциал»', licenses: 300 },
+        { name: 'АО «Волжская Эксплуатация»', licenses: 200 }
+      ]
+    },
     status: 'production',
     repository: 'https://git.nedra.digital/dtwin/monitoring',
     api: 'gRPC dtwin.Telemetry/Stream',
@@ -511,7 +547,15 @@ export const modules: ModuleNode[] = [
       company: 'АО «Nedra Digital»',
       division: 'Операционный центр цифровых двойников'
     },
-    userStats: { companies: 10, licenses: 1500 },
+    userStats: {
+      companies: [
+        { name: 'ПАО «СибНефть Добыча»', licenses: 400 },
+        { name: 'АО «СеверЭнерго Бурение»', licenses: 350 },
+        { name: 'ООО «Цифровая Добыча»', licenses: 300 },
+        { name: 'АО «Восток Инжиниринг»', licenses: 250 },
+        { name: 'АО «Прикамский Промысел»', licenses: 200 }
+      ]
+    },
     status: 'production',
     repository: 'https://git.nedra.digital/dtwin/optimizer',
     api: 'REST /api/v1/dtwin/optimization-orders',
@@ -589,7 +633,14 @@ export const modules: ModuleNode[] = [
       company: 'АО «Nedra Digital»',
       division: 'Операционный центр цифровых двойников'
     },
-    userStats: { companies: 5, licenses: 420 },
+    userStats: {
+      companies: [
+        { name: 'АО «СеверЭнерго Бурение»', licenses: 140 },
+        { name: 'ООО «Арктик Ойл»', licenses: 110 },
+        { name: 'АО «УралТех Сервис»', licenses: 90 },
+        { name: 'ООО «Тюменский Ресурс»', licenses: 80 }
+      ]
+    },
     status: 'in-dev',
     repository: 'https://git.nedra.digital/dtwin/remote-ops',
     api: 'gRPC dtwin.RemoteControl/Dispatch',
@@ -662,7 +713,15 @@ export const modules: ModuleNode[] = [
       company: 'АО «Nedra Digital»',
       division: 'Центр внутрискважинных операций'
     },
-    userStats: { companies: 8, licenses: 730 },
+    userStats: {
+      companies: [
+        { name: 'АО «Западнефть Разработка»', licenses: 180 },
+        { name: 'АО «УралТех Сервис»', licenses: 160 },
+        { name: 'АО «Прикамский Промысел»', licenses: 150 },
+        { name: 'ООО «Енисей ТехИнтеграция»', licenses: 130 },
+        { name: 'АО «Полярное Бурение»', licenses: 110 }
+      ]
+    },
     status: 'production',
     repository: 'https://git.nedra.digital/wwo/planner',
     api: 'REST /api/v1/wwo/plans',
@@ -735,7 +794,14 @@ export const modules: ModuleNode[] = [
       company: 'АО «Nedra Digital»',
       division: 'Центр внутрискважинных операций'
     },
-    userStats: { companies: 6, licenses: 1250 },
+    userStats: {
+      companies: [
+        { name: 'АО «Прикамский Промысел»', licenses: 360 },
+        { name: 'ООО «Енисей ТехИнтеграция»', licenses: 320 },
+        { name: 'АО «Полярное Бурение»', licenses: 300 },
+        { name: 'ООО «Тюменский Ресурс»', licenses: 270 }
+      ]
+    },
     status: 'production',
     repository: 'https://git.nedra.digital/wwo/execution',
     api: 'REST /api/v1/wwo/operations-log',
@@ -808,7 +874,14 @@ export const modules: ModuleNode[] = [
       company: 'АО «Nedra Digital»',
       division: 'Центр внутрискважинных операций'
     },
-    userStats: { companies: 7, licenses: 980 },
+    userStats: {
+      companies: [
+        { name: 'АО «УралТех Сервис»', licenses: 260 },
+        { name: 'ООО «Енисей ТехИнтеграция»', licenses: 240 },
+        { name: 'АО «Полярное Бурение»', licenses: 240 },
+        { name: 'АО «Волжская Эксплуатация»', licenses: 240 }
+      ]
+    },
     status: 'in-dev',
     repository: 'https://git.nedra.digital/wwo/analytics',
     api: 'GraphQL /wwo/analytics',
@@ -879,7 +952,13 @@ export const modules: ModuleNode[] = [
     technologyStack: ['TypeScript', 'FastAPI', 'Apache Kafka', 'ClickHouse'],
     localization: 'ru',
     ridOwner: { company: 'АО «Nedra Digital»', division: 'Дирекция цифровых операций' },
-    userStats: { companies: 3, licenses: 140 },
+    userStats: {
+      companies: [
+        { name: 'ООО «Нордик Потенциал»', licenses: 60 },
+        { name: 'ООО «Каспий ГеоСервис»', licenses: 50 },
+        { name: 'АО «Полярное Бурение»', licenses: 30 }
+      ]
+    },
     status: 'in-dev',
     repository: 'https://git.nedra.digital/labs/digital-experiments',
     api: 'gRPC telemetry.TelemetryService',


### PR DESCRIPTION
## Summary
- replace module user statistics counts with per-company license breakdowns in data and UI
- add a company selector filter that scopes modules and artifacts while leaving domain filters untouched
- update admin module form and persistence tests to work with the new structure

## Testing
- npm run test:server

------
https://chatgpt.com/codex/tasks/task_e_68ec09ad3b20833298e612cf2b37f159