### PR TITLE
feat: support multi-graph management

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -67,6 +67,65 @@
   max-width: 720px;
 }
 
+.graphSelector {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.graphSelectorHeading {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: baseline;
+}
+
+.graphSelectorControls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.graphBadge {
+  white-space: nowrap;
+}
+
+.graphCreatePanel {
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px solid var(--color-bg-border);
+  border-radius: 8px;
+  background: var(--color-bg-stripe);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.graphCreateRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.graphCopyOptions {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.graphSourceBadge {
+  align-self: flex-start;
+  white-space: nowrap;
+}
+
+.graphCreateActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
 .main {
   display: grid;
   grid-template-columns: 320px 1fr 320px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1964,7 +1964,7 @@ function App() {
                   placeholder="Например, Экспериментальный"
                   value={graphNameDraft}
                   disabled={isGraphActionInProgress}
-                  onChange={({ value }) => setGraphNameDraft(value ?? '')}
+                  onChange={(value) => setGraphNameDraft(value ?? '')}
                 />
                 <Select<{ label: string; value: string }>
                   size="s"

--- a/src/components/GraphPersistenceControls.module.css
+++ b/src/components/GraphPersistenceControls.module.css
@@ -21,6 +21,37 @@
   gap: 12px;
 }
 
+.copySection {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-bg-border);
+}
+
+.copyHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.copyControls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.copyBadge {
+  white-space: nowrap;
+}
+
+.copyOptions {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
 .status {
   font-size: 12px;
 }

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -26,3 +26,18 @@ export type GraphSyncStatus =
   | { state: 'idle'; message?: string }
   | { state: 'saving'; message?: string }
   | { state: 'error'; message: string };
+
+export type GraphSummary = {
+  id: string;
+  name: string;
+  isDefault: boolean;
+  createdAt: string;
+  updatedAt?: string;
+};
+
+export type GraphCopyRequest = {
+  graphId: string;
+  includeDomains: boolean;
+  includeModules: boolean;
+  includeArtifacts: boolean;
+};


### PR DESCRIPTION
## Summary
- add backend support for multiple graphs, including creation, deletion, and migration of stored data
- update the UI to surface a prominent graph selector with creation and deletion controls and per-graph stats
- extend persistence controls to import data from other graphs with category toggles and copy support

## Testing
- npm run lint
- npm run test:server

------
https://chatgpt.com/codex/tasks/task_e_68ec220c8c1c8332b38a3240672159af