### PR TITLE
Maintain graph viewport state and add zoom controls

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -139,10 +139,20 @@
 .sidebar {
   display: flex;
   flex-direction: column;
-  gap: 16px;
   padding-right: 8px;
-  overflow-y: auto;
   min-height: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+.sidebarScrollArea {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-right: 4px;
 }
 
 .sidebarTitle {

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -142,12 +142,15 @@
 }
 
 .sidebar {
+  --domain-header-reserve: 48px;
+  --filters-reserve: 72px;
+  --sidebar-reserve: calc(var(--domain-header-reserve) + 2 * var(--filters-reserve));
   display: flex;
   flex-direction: column;
   padding-right: 8px;
   min-height: 0;
   height: 100%;
-  max-height: max(0px, calc(100% - 48px));
+  max-height: max(0px, calc(100% - var(--sidebar-reserve)));
   overflow: hidden;
 }
 
@@ -159,11 +162,17 @@
   flex-direction: column;
   gap: 16px;
   padding-right: 4px;
+  padding-top: 4px;
 }
 
-.sidebarTitle {
+.domainCollapse {
   margin-top: 8px;
 }
+
+.domainCollapseContent {
+  padding-top: 12px;
+}
+
 
 .filtersCollapse {
   margin-top: 8px;

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -133,6 +133,7 @@
   padding: 24px;
   height: calc(100% - 92px);
   box-sizing: border-box;
+  min-height: 0;
 }
 
 .sidebar {
@@ -141,6 +142,7 @@
   gap: 16px;
   padding-right: 8px;
   overflow-y: auto;
+  min-height: 0;
 }
 
 .sidebarTitle {
@@ -149,12 +151,16 @@
 
 .graphSection {
   display: grid;
-  grid-template-rows: 1fr auto;
+  grid-template-rows: minmax(0, 1fr) auto;
   gap: 16px;
+  height: 100%;
+  min-height: 0;
 }
 
 .graphContainer {
-  min-height: 420px;
+  height: 100%;
+  min-height: 0;
+  display: flex;
 }
 
 .analytics {
@@ -169,6 +175,7 @@
   border-radius: 12px;
   box-shadow: var(--shadow-layer);
   overflow: auto;
+  min-height: 0;
 }
 
 .statsMain {

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,6 +1,9 @@
 .app {
   width: 100%;
   height: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .loadingState {
@@ -58,6 +61,7 @@
   flex-wrap: wrap;
   padding: 24px;
   border-bottom: 1px solid var(--color-bg-border);
+  flex-shrink: 0;
 }
 
 .headerContent {
@@ -131,9 +135,10 @@
   grid-template-columns: 320px 1fr 320px;
   gap: 24px;
   padding: 24px;
-  height: calc(100% - 92px);
   box-sizing: border-box;
+  flex: 1;
   min-height: 0;
+  overflow: hidden;
 }
 
 .sidebar {
@@ -190,15 +195,17 @@
 
 .statsMain {
   padding: 24px;
-  height: calc(100% - 92px);
   box-sizing: border-box;
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
 }
 
 .creationMain {
   padding: 24px;
-  height: calc(100% - 92px);
   box-sizing: border-box;
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
 }
 
@@ -212,6 +219,7 @@
   .main {
     grid-template-columns: 1fr;
     grid-template-rows: auto auto auto;
+    overflow: auto;
   }
 
   .sidebar {

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -142,16 +142,14 @@
 }
 
 .sidebar {
-  --domain-header-reserve: 48px;
-  --filters-reserve: 72px;
-  --sidebar-reserve: calc(var(--domain-header-reserve) + 2 * var(--filters-reserve));
   display: flex;
   flex-direction: column;
   padding-right: 8px;
   min-height: 0;
   height: 100%;
-  max-height: max(0px, calc(100% - var(--sidebar-reserve)));
+  max-height: var(--sidebar-max-height, 100%);
   overflow: hidden;
+  align-self: start;
 }
 
 .sidebarScrollArea {

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -147,6 +147,7 @@
   padding-right: 8px;
   min-height: 0;
   height: 100%;
+  max-height: max(0px, calc(100% - 48px));
   overflow: hidden;
 }
 
@@ -162,6 +163,14 @@
 
 .sidebarTitle {
   margin-top: 8px;
+}
+
+.filtersCollapse {
+  margin-top: 8px;
+}
+
+.filtersCollapseContent {
+  padding-top: 12px;
 }
 
 .graphSection {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2230,50 +2230,52 @@ function App() {
         style={{ display: isGraphActive ? undefined : 'none' }}
       >
           <aside className={styles.sidebar}>
-            <Text size="s" weight="semibold" className={styles.sidebarTitle}>
-              Домены
-            </Text>
-            <DomainTree
-              tree={domainData}
-              selected={selectedDomains}
-              onToggle={handleDomainToggle}
-              descendants={domainDescendants}
-            />
-            <Text size="s" weight="semibold" className={styles.sidebarTitle}>
-              Фильтры
-            </Text>
-            <FiltersPanel
-              search={search}
-              onSearchChange={setSearch}
-              statuses={allStatuses}
-              activeStatuses={statusFilters}
-              onToggleStatus={(status) => {
-                setSelectedNode(null);
-                setStatusFilters((prev) => {
-                  const next = new Set(prev);
-                  if (next.has(status)) {
-                    next.delete(status);
-                  } else {
-                    next.add(status);
-                  }
-                  return next;
-                });
-              }}
-              products={products}
-              productFilter={productFilter}
-              onProductChange={(nextProducts) => {
-                setSelectedNode(null);
-                setProductFilter(nextProducts);
-              }}
-              companies={companies}
-              companyFilter={companyFilter}
-              onCompanyChange={(nextCompany) => {
-                setSelectedNode(null);
-                setCompanyFilter(nextCompany);
-              }}
-              showAllConnections={showAllConnections}
-              onToggleConnections={(value) => setShowAllConnections(value)}
-            />
+            <div className={styles.sidebarScrollArea}>
+              <Text size="s" weight="semibold" className={styles.sidebarTitle}>
+                Домены
+              </Text>
+              <DomainTree
+                tree={domainData}
+                selected={selectedDomains}
+                onToggle={handleDomainToggle}
+                descendants={domainDescendants}
+              />
+              <Text size="s" weight="semibold" className={styles.sidebarTitle}>
+                Фильтры
+              </Text>
+              <FiltersPanel
+                search={search}
+                onSearchChange={setSearch}
+                statuses={allStatuses}
+                activeStatuses={statusFilters}
+                onToggleStatus={(status) => {
+                  setSelectedNode(null);
+                  setStatusFilters((prev) => {
+                    const next = new Set(prev);
+                    if (next.has(status)) {
+                      next.delete(status);
+                    } else {
+                      next.add(status);
+                    }
+                    return next;
+                  });
+                }}
+                products={products}
+                productFilter={productFilter}
+                onProductChange={(nextProducts) => {
+                  setSelectedNode(null);
+                  setProductFilter(nextProducts);
+                }}
+                companies={companies}
+                companyFilter={companyFilter}
+                onCompanyChange={(nextCompany) => {
+                  setSelectedNode(null);
+                  setCompanyFilter(nextCompany);
+                }}
+                showAllConnections={showAllConnections}
+                onToggleConnections={(value) => setShowAllConnections(value)}
+              />
+            </div>
           </aside>
           <section className={styles.graphSection}>
             <div className={styles.graphContainer}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,7 +92,8 @@ function App() {
   const [showAllConnections, setShowAllConnections] = useState(false);
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>('graph');
-  const [areFiltersOpen, setAreFiltersOpen] = useState(false);
+  const [isDomainTreeOpen, setIsDomainTreeOpen] = useState(false);
+  const [areFiltersOpen, setAreFiltersOpen] = useState(true);
   const [adminNotice, setAdminNotice] = useState<AdminNotice | null>(null);
   const highlightedDomainId = selectedNode?.type === 'domain' ? selectedNode.id : null;
   const [statsActivated, setStatsActivated] = useState(() => viewMode === 'stats');
@@ -2233,15 +2234,27 @@ function App() {
       >
           <aside className={styles.sidebar}>
             <div className={styles.sidebarScrollArea}>
-              <Text size="s" weight="semibold" className={styles.sidebarTitle}>
-                Домены
-              </Text>
-              <DomainTree
-                tree={domainData}
-                selected={selectedDomains}
-                onToggle={handleDomainToggle}
-                descendants={domainDescendants}
-              />
+              <Collapse
+                label={
+                  <Text size="s" weight="semibold">
+                    Домены
+                  </Text>
+                }
+                isOpen={isDomainTreeOpen}
+                onClick={() => setIsDomainTreeOpen((prev) => !prev)}
+                className={styles.domainCollapse}
+              >
+                <div className={styles.domainCollapseContent}>
+                  {isDomainTreeOpen ? (
+                    <DomainTree
+                      tree={domainData}
+                      selected={selectedDomains}
+                      onToggle={handleDomainToggle}
+                      descendants={domainDescendants}
+                    />
+                  ) : null}
+                </div>
+              </Collapse>
               <Collapse
                 label={
                   <Text size="s" weight="semibold">
@@ -2253,40 +2266,38 @@ function App() {
                 className={styles.filtersCollapse}
               >
                 <div className={styles.filtersCollapseContent}>
-                  {areFiltersOpen ? (
-                    <FiltersPanel
-                      search={search}
-                      onSearchChange={setSearch}
-                      statuses={allStatuses}
-                      activeStatuses={statusFilters}
-                      onToggleStatus={(status) => {
-                        setSelectedNode(null);
-                        setStatusFilters((prev) => {
-                          const next = new Set(prev);
-                          if (next.has(status)) {
-                            next.delete(status);
-                          } else {
-                            next.add(status);
-                          }
-                          return next;
-                        });
-                      }}
-                      products={products}
-                      productFilter={productFilter}
-                      onProductChange={(nextProducts) => {
-                        setSelectedNode(null);
-                        setProductFilter(nextProducts);
-                      }}
-                      companies={companies}
-                      companyFilter={companyFilter}
-                      onCompanyChange={(nextCompany) => {
-                        setSelectedNode(null);
-                        setCompanyFilter(nextCompany);
-                      }}
-                      showAllConnections={showAllConnections}
-                      onToggleConnections={(value) => setShowAllConnections(value)}
-                    />
-                  ) : null}
+                  <FiltersPanel
+                    search={search}
+                    onSearchChange={setSearch}
+                    statuses={allStatuses}
+                    activeStatuses={statusFilters}
+                    onToggleStatus={(status) => {
+                      setSelectedNode(null);
+                      setStatusFilters((prev) => {
+                        const next = new Set(prev);
+                        if (next.has(status)) {
+                          next.delete(status);
+                        } else {
+                          next.add(status);
+                        }
+                        return next;
+                      });
+                    }}
+                    products={products}
+                    productFilter={productFilter}
+                    onProductChange={(nextProducts) => {
+                      setSelectedNode(null);
+                      setProductFilter(nextProducts);
+                    }}
+                    companies={companies}
+                    companyFilter={companyFilter}
+                    onCompanyChange={(nextCompany) => {
+                      setSelectedNode(null);
+                      setCompanyFilter(nextCompany);
+                    }}
+                    showAllConnections={showAllConnections}
+                    onToggleConnections={(value) => setShowAllConnections(value)}
+                  />
                 </div>
               </Collapse>
             </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Badge } from '@consta/uikit/Badge';
 import { Button } from '@consta/uikit/Button';
 import { CheckboxGroup } from '@consta/uikit/CheckboxGroup';
+import { Collapse } from '@consta/uikit/Collapse';
 import { Layout } from '@consta/uikit/Layout';
 import { Loader } from '@consta/uikit/Loader';
 import { Select } from '@consta/uikit/Select';
@@ -91,6 +92,7 @@ function App() {
   const [showAllConnections, setShowAllConnections] = useState(false);
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>('graph');
+  const [areFiltersOpen, setAreFiltersOpen] = useState(false);
   const [adminNotice, setAdminNotice] = useState<AdminNotice | null>(null);
   const highlightedDomainId = selectedNode?.type === 'domain' ? selectedNode.id : null;
   const [statsActivated, setStatsActivated] = useState(() => viewMode === 'stats');
@@ -2240,41 +2242,51 @@ function App() {
                 onToggle={handleDomainToggle}
                 descendants={domainDescendants}
               />
-              <Text size="s" weight="semibold" className={styles.sidebarTitle}>
-                Фильтры
-              </Text>
-              <FiltersPanel
-                search={search}
-                onSearchChange={setSearch}
-                statuses={allStatuses}
-                activeStatuses={statusFilters}
-                onToggleStatus={(status) => {
-                  setSelectedNode(null);
-                  setStatusFilters((prev) => {
-                    const next = new Set(prev);
-                    if (next.has(status)) {
-                      next.delete(status);
-                    } else {
-                      next.add(status);
-                    }
-                    return next;
-                  });
-                }}
-                products={products}
-                productFilter={productFilter}
-                onProductChange={(nextProducts) => {
-                  setSelectedNode(null);
-                  setProductFilter(nextProducts);
-                }}
-                companies={companies}
-                companyFilter={companyFilter}
-                onCompanyChange={(nextCompany) => {
-                  setSelectedNode(null);
-                  setCompanyFilter(nextCompany);
-                }}
-                showAllConnections={showAllConnections}
-                onToggleConnections={(value) => setShowAllConnections(value)}
-              />
+              <Collapse
+                label={
+                  <Text size="s" weight="semibold">
+                    Фильтры
+                  </Text>
+                }
+                isOpen={areFiltersOpen}
+                onClick={() => setAreFiltersOpen((prev) => !prev)}
+                className={styles.filtersCollapse}
+              >
+                <div className={styles.filtersCollapseContent}>
+                  <FiltersPanel
+                    search={search}
+                    onSearchChange={setSearch}
+                    statuses={allStatuses}
+                    activeStatuses={statusFilters}
+                    onToggleStatus={(status) => {
+                      setSelectedNode(null);
+                      setStatusFilters((prev) => {
+                        const next = new Set(prev);
+                        if (next.has(status)) {
+                          next.delete(status);
+                        } else {
+                          next.add(status);
+                        }
+                        return next;
+                      });
+                    }}
+                    products={products}
+                    productFilter={productFilter}
+                    onProductChange={(nextProducts) => {
+                      setSelectedNode(null);
+                      setProductFilter(nextProducts);
+                    }}
+                    companies={companies}
+                    companyFilter={companyFilter}
+                    onCompanyChange={(nextCompany) => {
+                      setSelectedNode(null);
+                      setCompanyFilter(nextCompany);
+                    }}
+                    showAllConnections={showAllConnections}
+                    onToggleConnections={(value) => setShowAllConnections(value)}
+                  />
+                </div>
+              </Collapse>
             </div>
           </aside>
           <section className={styles.graphSection}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2253,38 +2253,40 @@ function App() {
                 className={styles.filtersCollapse}
               >
                 <div className={styles.filtersCollapseContent}>
-                  <FiltersPanel
-                    search={search}
-                    onSearchChange={setSearch}
-                    statuses={allStatuses}
-                    activeStatuses={statusFilters}
-                    onToggleStatus={(status) => {
-                      setSelectedNode(null);
-                      setStatusFilters((prev) => {
-                        const next = new Set(prev);
-                        if (next.has(status)) {
-                          next.delete(status);
-                        } else {
-                          next.add(status);
-                        }
-                        return next;
-                      });
-                    }}
-                    products={products}
-                    productFilter={productFilter}
-                    onProductChange={(nextProducts) => {
-                      setSelectedNode(null);
-                      setProductFilter(nextProducts);
-                    }}
-                    companies={companies}
-                    companyFilter={companyFilter}
-                    onCompanyChange={(nextCompany) => {
-                      setSelectedNode(null);
-                      setCompanyFilter(nextCompany);
-                    }}
-                    showAllConnections={showAllConnections}
-                    onToggleConnections={(value) => setShowAllConnections(value)}
-                  />
+                  {areFiltersOpen ? (
+                    <FiltersPanel
+                      search={search}
+                      onSearchChange={setSearch}
+                      statuses={allStatuses}
+                      activeStatuses={statusFilters}
+                      onToggleStatus={(status) => {
+                        setSelectedNode(null);
+                        setStatusFilters((prev) => {
+                          const next = new Set(prev);
+                          if (next.has(status)) {
+                            next.delete(status);
+                          } else {
+                            next.add(status);
+                          }
+                          return next;
+                        });
+                      }}
+                      products={products}
+                      productFilter={productFilter}
+                      onProductChange={(nextProducts) => {
+                        setSelectedNode(null);
+                        setProductFilter(nextProducts);
+                      }}
+                      companies={companies}
+                      companyFilter={companyFilter}
+                      onCompanyChange={(nextCompany) => {
+                        setSelectedNode(null);
+                        setCompanyFilter(nextCompany);
+                      }}
+                      showAllConnections={showAllConnections}
+                      onToggleConnections={(value) => setShowAllConnections(value)}
+                    />
+                  ) : null}
                 </div>
               </Collapse>
             </div>

--- a/src/components/DomainTree.tsx
+++ b/src/components/DomainTree.tsx
@@ -21,7 +21,7 @@ type TreeItemProps = {
 };
 
 const TreeItem: React.FC<TreeItemProps> = ({ node, selected, descendants, onToggle, depth = 0 }) => {
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(false);
   const hasChildren = node.children && node.children.length > 0;
   const paddingLeft = useMemo(() => depth * 16, [depth]);
   const cascade = useMemo(() => descendants.get(node.id) ?? [node.id], [descendants, node.id]);

--- a/src/components/GraphView.module.css
+++ b/src/components/GraphView.module.css
@@ -6,6 +6,8 @@
   background: var(--color-bg-default);
   border: 1px solid var(--color-bg-border);
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .legend {

--- a/src/components/GraphView.module.css
+++ b/src/components/GraphView.module.css
@@ -17,3 +17,32 @@
   z-index: 2;
 }
 
+.viewControls {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: flex;
+  gap: 8px;
+  z-index: 2;
+}
+
+.controlButton {
+  border: 1px solid var(--color-bg-border);
+  background: var(--color-bg-ghost);
+  color: var(--color-typo-primary);
+  padding: 4px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.controlButton:hover {
+  background: var(--color-bg-secondary);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.controlButton:active {
+  background: var(--color-bg-default);
+}
+


### PR DESCRIPTION
## Summary
- preserve and restore the graph camera so user positioning survives selections and live updates
- only recenter highlighted nodes when they leave the visible area and reduce default link distances for tighter layouts
- add double-click and button controls to toggle focused zoom levels while keeping text legible

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ee950690808332aebc6b4d3fa646f4