### PR TITLE
Fix layout height to keep sidebar scrollable

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,9 +1,10 @@
 .app {
   width: 100%;
-  height: 100%;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   min-height: 0;
+  overflow: hidden;
 }
 
 .loadingState {


### PR DESCRIPTION
## Summary
- ensure the top-level layout is constrained to the viewport height so the sidebar uses its own scroll area

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eebf2cdae08332b8f3ff4e2518f4cf