### PR TITLE
Add R&D expert explorer view

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -218,6 +218,15 @@
   overflow-y: auto;
 }
 
+.expertMain {
+  padding: 24px;
+  box-sizing: border-box;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+}
+
 .creationMain {
   padding: 24px;
   box-sizing: border-box;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import {
 import type { CSSProperties } from 'react';
 import AnalyticsPanel from './components/AnalyticsPanel';
 import DomainTree from './components/DomainTree';
+import ExpertExplorer from './components/ExpertExplorer';
 import AdminPanel, {
   type ArtifactDraftPayload,
   type DomainDraftPayload,
@@ -51,6 +52,7 @@ import {
   domainTree as initialDomainTree,
   modules as initialModules,
   reuseIndexHistory,
+  expertProfiles,
   type ArtifactNode,
   type DomainNode,
   type GraphLink,
@@ -71,6 +73,7 @@ const StatsDashboard = lazy(async () => ({
 const viewTabs = [
   { label: 'Связи', value: 'graph' },
   { label: 'Статистика', value: 'stats' },
+  { label: 'Эксперты', value: 'experts' },
   { label: 'Администрирование', value: 'admin' }
 ] as const;
 
@@ -2148,6 +2151,7 @@ function App() {
   const activeViewTab = viewTabs.find((tab) => tab.value === viewMode) ?? viewTabs[0];
   const isGraphActive = viewMode === 'graph';
   const isStatsActive = viewMode === 'stats';
+  const isExpertsActive = viewMode === 'experts';
   const isAdminActive = viewMode === 'admin';
 
   const headerTitle = (() => {
@@ -2156,6 +2160,9 @@ function App() {
     }
     if (isStatsActive) {
       return 'Статистика экосистемы решений';
+    }
+    if (isExpertsActive) {
+      return 'Экспертная панель R&D';
     }
     return 'Панель администрирования экосистемы';
   })();
@@ -2166,6 +2173,9 @@ function App() {
     }
     if (isStatsActive) {
       return 'Обзор ключевых метрик по системам, модулям и обмену данными для планирования развития.';
+    }
+    if (isExpertsActive) {
+      return 'Изучайте экспертизу R&D-команды, их проектные достижения и консалтинговые навыки для подбора специалистов.';
     }
     return 'Управляйте данными графа: обновляйте карточки модулей, доменов и артефактов, а также удаляйте устаревшие связи.';
   })();
@@ -2522,6 +2532,14 @@ function App() {
           </Suspense>
         </main>
       )}
+      <main
+        className={styles.expertMain}
+        hidden={!isExpertsActive}
+        aria-hidden={!isExpertsActive}
+        style={{ display: isExpertsActive ? undefined : 'none' }}
+      >
+        <ExpertExplorer experts={expertProfiles} modules={moduleData} domains={domainData} />
+      </main>
       <main
         className={styles.creationMain}
         hidden={!isAdminActive}

--- a/src/components/ExpertExplorer.module.css
+++ b/src/components/ExpertExplorer.module.css
@@ -1,0 +1,287 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  height: 100%;
+  min-height: 0;
+}
+
+.filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  align-items: end;
+}
+
+.searchField {
+  grid-column: span 2;
+  min-width: 240px;
+}
+
+.filtersActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.content {
+  display: flex;
+  gap: 24px;
+  flex: 1;
+  min-height: 0;
+}
+
+.listPanel {
+  flex: 0 0 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
+.listHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.listHeaderTitle {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-right: 4px;
+}
+
+.expertCard {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border: 1px solid var(--color-bg-border);
+  border-radius: 12px;
+  padding: 12px;
+  background: var(--color-bg-default, #fff);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.expertCard:hover {
+  border-color: var(--color-control-bg-border-focus, rgba(63, 135, 252, 0.55));
+  box-shadow: 0 0 0 2px rgba(63, 135, 252, 0.25);
+}
+
+.expertCardActive {
+  border-color: var(--color-control-bg-border-focus, rgba(63, 135, 252, 0.85));
+  box-shadow: 0 0 0 3px rgba(63, 135, 252, 0.35);
+}
+
+.cardTitle {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.cardMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tagRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.detailPanel {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  border: 1px solid var(--color-bg-border);
+  border-radius: 16px;
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  background: var(--color-bg-default, #fff);
+}
+
+.detailScroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding-right: 4px;
+}
+
+.detailHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.detailHeaderTop {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.titleBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.focusTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sectionHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+}
+
+.itemHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.badgeRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.highlightList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.highlightItem {
+  border: 1px solid var(--color-bg-border);
+  border-radius: 12px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.highlightMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.relatedList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.relatedItem {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+  border: 1px solid var(--color-bg-border);
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+.muted {
+  color: var(--color-typo-secondary);
+}
+
+.emptyState {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--color-bg-border);
+  border-radius: 12px;
+  padding: 24px;
+}
+
+.consultingList {
+  display: grid;
+  gap: 12px;
+}
+
+.consultingItem {
+  border-radius: 10px;
+  background: var(--color-bg-stripe);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.metricsRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+}
+
+.metricsRow span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.divider {
+  height: 1px;
+  background: var(--color-bg-border);
+  margin: 8px 0;
+}
+
+@media (max-width: 1200px) {
+  .content {
+    flex-direction: column;
+  }
+
+  .listPanel {
+    flex: initial;
+    width: 100%;
+  }
+
+  .detailPanel {
+    width: 100%;
+  }
+}

--- a/src/components/ExpertExplorer.tsx
+++ b/src/components/ExpertExplorer.tsx
@@ -1,0 +1,630 @@
+import { Badge } from '@consta/uikit/Badge';
+import { Button } from '@consta/uikit/Button';
+import { Combobox } from '@consta/uikit/Combobox';
+import { Tag } from '@consta/uikit/Tag';
+import { Text } from '@consta/uikit/Text';
+import { TextField } from '@consta/uikit/TextField';
+import clsx from 'clsx';
+import React, { useEffect, useMemo, useState } from 'react';
+import type {
+  DomainNode,
+  ExpertProfile,
+  ModuleNode,
+  ModuleStatus,
+  ExpertCompetencyLevel
+} from '../data';
+import styles from './ExpertExplorer.module.css';
+
+type Option = {
+  id: string;
+  label: string;
+};
+
+type ExpertExplorerProps = {
+  experts: ExpertProfile[];
+  modules: ModuleNode[];
+  domains: DomainNode[];
+};
+
+const availabilityLabels: Record<ExpertProfile['availability'], string> = {
+  open: 'Свободен для вовлечения',
+  limited: 'Ограниченная доступность',
+  booked: 'Занят на проектах'
+};
+
+const availabilityStatus: Record<ExpertProfile['availability'], 'success' | 'warning' | 'alert'> = {
+  open: 'success',
+  limited: 'warning',
+  booked: 'alert'
+};
+
+const competencyLevelMeta: Record<ExpertCompetencyLevel, { label: string; status: 'system' | 'warning' | 'success' }> = {
+  foundation: { label: 'Базовый уровень', status: 'system' },
+  advanced: { label: 'Продвинутый уровень', status: 'warning' },
+  expert: { label: 'Лидер экспертизы', status: 'success' }
+};
+
+const moduleStatusBadge: Record<ModuleStatus, 'success' | 'warning' | 'alert'> = {
+  production: 'success',
+  'in-dev': 'warning',
+  deprecated: 'alert'
+};
+
+const availabilityOrder: Record<ExpertProfile['availability'], number> = {
+  open: 0,
+  limited: 1,
+  booked: 2
+};
+
+const ExpertExplorer: React.FC<ExpertExplorerProps> = ({ experts, modules, domains }) => {
+  const [search, setSearch] = useState('');
+  const [selectedExpertId, setSelectedExpertId] = useState<string | null>(() => experts[0]?.id ?? null);
+  const [selectedDomainOptions, setSelectedDomainOptions] = useState<Option[]>([]);
+  const [selectedCompetencyOptions, setSelectedCompetencyOptions] = useState<Option[]>([]);
+  const [selectedConsultingOptions, setSelectedConsultingOptions] = useState<Option[]>([]);
+
+  const domainOptions = useMemo<Option[]>(() => {
+    const unique = new Map<string, Option>();
+    flattenDomains(domains).forEach((domain) => {
+      if (domain.isCatalogRoot) {
+        return;
+      }
+      if (!unique.has(domain.id)) {
+        unique.set(domain.id, { id: domain.id, label: domain.name });
+      }
+    });
+    return Array.from(unique.values()).sort((a, b) => a.label.localeCompare(b.label, 'ru'));
+  }, [domains]);
+
+  const competencyOptions = useMemo<Option[]>(() => {
+    const unique = new Map<string, Option>();
+    experts.forEach((expert) => {
+      expert.competencies.forEach((competency) => {
+        if (!unique.has(competency.id)) {
+          unique.set(competency.id, { id: competency.id, label: competency.name });
+        }
+      });
+    });
+    return Array.from(unique.values()).sort((a, b) => a.label.localeCompare(b.label, 'ru'));
+  }, [experts]);
+
+  const competencyLabelById = useMemo(() => {
+    const map = new Map<string, string>();
+    competencyOptions.forEach((option) => {
+      map.set(option.id, option.label);
+    });
+    return map;
+  }, [competencyOptions]);
+
+  const consultingOptions = useMemo<Option[]>(() => {
+    const unique = new Map<string, Option>();
+    experts.forEach((expert) => {
+      expert.consultingSkills.forEach((skill) => {
+        if (!unique.has(skill.id)) {
+          unique.set(skill.id, { id: skill.id, label: skill.name });
+        }
+      });
+    });
+    return Array.from(unique.values()).sort((a, b) => a.label.localeCompare(b.label, 'ru'));
+  }, [experts]);
+
+  const domainNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    flattenDomains(domains).forEach((domain) => {
+      map.set(domain.id, domain.name);
+    });
+    return map;
+  }, [domains]);
+
+  const moduleMap = useMemo(() => {
+    const map = new Map<string, ModuleNode>();
+    modules.forEach((module) => {
+      map.set(module.id, module);
+    });
+    return map;
+  }, [modules]);
+
+  const selectedDomainIds = useMemo(() => new Set(selectedDomainOptions.map((option) => option.id)), [selectedDomainOptions]);
+  const selectedCompetencyIds = useMemo(
+    () => new Set(selectedCompetencyOptions.map((option) => option.id)),
+    [selectedCompetencyOptions]
+  );
+  const selectedConsultingIds = useMemo(
+    () => new Set(selectedConsultingOptions.map((option) => option.id)),
+    [selectedConsultingOptions]
+  );
+
+  const filteredExperts = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+
+    return experts
+      .filter((expert) => {
+        const matchesSearch = (() => {
+          if (!normalizedSearch) {
+            return true;
+          }
+          if (expert.fullName.toLowerCase().includes(normalizedSearch)) {
+            return true;
+          }
+          if (expert.title.toLowerCase().includes(normalizedSearch)) {
+            return true;
+          }
+          if (expert.summary.toLowerCase().includes(normalizedSearch)) {
+            return true;
+          }
+          if (expert.focusAreas.some((focus) => focus.toLowerCase().includes(normalizedSearch))) {
+            return true;
+          }
+          if (expert.competencies.some((competency) => competency.name.toLowerCase().includes(normalizedSearch))) {
+            return true;
+          }
+          if (expert.consultingSkills.some((skill) => skill.name.toLowerCase().includes(normalizedSearch))) {
+            return true;
+          }
+          return false;
+        })();
+
+        const matchesDomains =
+          selectedDomainIds.size === 0 || expert.domainIds.some((domainId) => selectedDomainIds.has(domainId));
+        const matchesCompetencies =
+          selectedCompetencyIds.size === 0 || expert.competencies.some((competency) => selectedCompetencyIds.has(competency.id));
+        const matchesConsulting =
+          selectedConsultingIds.size === 0 || expert.consultingSkills.some((skill) => selectedConsultingIds.has(skill.id));
+
+        return matchesSearch && matchesDomains && matchesCompetencies && matchesConsulting;
+      })
+      .sort((a, b) => {
+        const availabilityDiff = availabilityOrder[a.availability] - availabilityOrder[b.availability];
+        if (availabilityDiff !== 0) {
+          return availabilityDiff;
+        }
+        return b.experienceYears - a.experienceYears;
+      });
+  }, [experts, search, selectedDomainIds, selectedCompetencyIds, selectedConsultingIds]);
+
+  useEffect(() => {
+    if (filteredExperts.length === 0) {
+      setSelectedExpertId(null);
+      return;
+    }
+    if (!selectedExpertId || !filteredExperts.some((expert) => expert.id === selectedExpertId)) {
+      setSelectedExpertId(filteredExperts[0].id);
+    }
+  }, [filteredExperts, selectedExpertId]);
+
+  useEffect(() => {
+    if (!selectedExpertId && experts.length > 0) {
+      setSelectedExpertId(experts[0].id);
+    }
+  }, [experts, selectedExpertId]);
+
+  const selectedExpert = useMemo(() => {
+    if (filteredExperts.length === 0) {
+      return null;
+    }
+    if (!selectedExpertId) {
+      return filteredExperts[0];
+    }
+    return filteredExperts.find((expert) => expert.id === selectedExpertId) ?? filteredExperts[0];
+  }, [filteredExperts, selectedExpertId]);
+
+  const relatedExperts = useMemo(() => {
+    if (!selectedExpert) {
+      return [];
+    }
+
+    const domainSet = new Set(selectedExpert.domainIds);
+    const moduleSet = new Set(selectedExpert.moduleIds);
+    const competencySet = new Set(selectedExpert.competencies.map((competency) => competency.id));
+
+    return experts
+      .filter((expert) => expert.id !== selectedExpert.id)
+      .map((expert) => {
+        const sharedDomains = expert.domainIds.filter((domainId) => domainSet.has(domainId));
+        const sharedModules = expert.moduleIds.filter((moduleId) => moduleSet.has(moduleId));
+        const sharedCompetencies = expert.competencies
+          .map((competency) => competency.id)
+          .filter((competencyId) => competencySet.has(competencyId));
+        const score = sharedDomains.length * 3 + sharedModules.length * 4 + sharedCompetencies.length * 2;
+        return { expert, sharedDomains, sharedModules, sharedCompetencies, score };
+      })
+      .filter((item) => item.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 4);
+  }, [experts, selectedExpert]);
+
+  const resetFilters = () => {
+    setSearch('');
+    setSelectedDomainOptions([]);
+    setSelectedCompetencyOptions([]);
+    setSelectedConsultingOptions([]);
+  };
+
+  const formatConnection = (
+    sharedDomains: string[],
+    sharedModules: string[],
+    sharedCompetencies: string[]
+  ): string => {
+    const parts: string[] = [];
+    if (sharedModules.length > 0) {
+      const moduleLabels = sharedModules
+        .map((moduleId) => moduleMap.get(moduleId)?.name ?? moduleId)
+        .join(', ');
+      parts.push(`модули: ${moduleLabels}`);
+    }
+    if (sharedDomains.length > 0) {
+      const domainLabels = sharedDomains
+        .map((domainId) => domainNameMap.get(domainId) ?? domainId)
+        .join(', ');
+      parts.push(`домены: ${domainLabels}`);
+    }
+    if (sharedCompetencies.length > 0) {
+      const competencyLabels = sharedCompetencies
+        .map((competencyId) => competencyLabelById.get(competencyId) ?? competencyId)
+        .join(', ');
+      parts.push(`компетенции: ${competencyLabels}`);
+    }
+    return parts.join(' • ');
+  };
+
+  return (
+    <div className={styles.root}>
+      <section className={styles.filters}>
+        <div className={clsx(styles.searchField)}>
+          <Text size="s" weight="semibold">
+            Поиск
+          </Text>
+          <TextField
+            size="s"
+            value={search}
+            placeholder="Имя, компетенция или модуль"
+            onChange={(value) => setSearch(value ?? '')}
+          />
+        </div>
+        <div>
+          <Text size="s" weight="semibold">
+            Домены
+          </Text>
+          <Combobox<Option>
+            size="s"
+            placeholder="Все домены"
+            items={domainOptions}
+            value={selectedDomainOptions}
+            getItemKey={(item) => item.id}
+            getItemLabel={(item) => item.label}
+            multiple
+            onChange={(items) => setSelectedDomainOptions(items ?? [])}
+          />
+        </div>
+        <div>
+          <Text size="s" weight="semibold">
+            Компетенции
+          </Text>
+          <Combobox<Option>
+            size="s"
+            placeholder="Все компетенции"
+            items={competencyOptions}
+            value={selectedCompetencyOptions}
+            getItemKey={(item) => item.id}
+            getItemLabel={(item) => item.label}
+            multiple
+            onChange={(items) => setSelectedCompetencyOptions(items ?? [])}
+          />
+        </div>
+        <div>
+          <Text size="s" weight="semibold">
+            Консалтинговые навыки
+          </Text>
+          <Combobox<Option>
+            size="s"
+            placeholder="Все навыки"
+            items={consultingOptions}
+            value={selectedConsultingOptions}
+            getItemKey={(item) => item.id}
+            getItemLabel={(item) => item.label}
+            multiple
+            onChange={(items) => setSelectedConsultingOptions(items ?? [])}
+          />
+        </div>
+        <div className={styles.filtersActions}>
+          <Button size="s" view="secondary" label="Сбросить фильтры" onClick={resetFilters} />
+          <Text size="xs" view="secondary">
+            Подходят {filteredExperts.length} из {experts.length}
+          </Text>
+        </div>
+      </section>
+      <div className={styles.content}>
+        <aside className={styles.listPanel}>
+          <div className={styles.listHeader}>
+            <div className={styles.listHeaderTitle}>
+              <Text size="s" weight="semibold">
+                Эксперты
+              </Text>
+              <Text size="xs" view="secondary">
+                {filteredExperts.length > 0 ? 'Выберите эксперта, чтобы увидеть профиль' : 'Совпадений не найдено'}
+              </Text>
+            </div>
+            <Badge size="s" view="filled" status="system" label={`Всего ${experts.length}`} />
+          </div>
+          <div className={styles.list}>
+            {filteredExperts.map((expert) => {
+              const moduleCount = expert.moduleIds.length;
+              const domainBadges = expert.domainIds.slice(0, 3);
+              const extraDomains = Math.max(0, expert.domainIds.length - domainBadges.length);
+              const topCompetencies = expert.competencies.slice(0, 2);
+              const isActive = selectedExpert?.id === expert.id;
+              return (
+                <button
+                  type="button"
+                  key={expert.id}
+                  className={clsx(styles.expertCard, { [styles.expertCardActive]: isActive })}
+                  onClick={() => setSelectedExpertId(expert.id)}
+                >
+                  <div className={styles.cardTitle}>
+                    <Text size="s" weight="semibold">
+                      {expert.fullName}
+                    </Text>
+                    <Text size="xs" view="secondary">
+                      {expert.title}
+                    </Text>
+                  </div>
+                  <div className={styles.cardMeta}>
+                    <Badge
+                      size="xs"
+                      view="filled"
+                      status={availabilityStatus[expert.availability]}
+                      label={availabilityLabels[expert.availability]}
+                    />
+                    <Badge
+                      size="xs"
+                      view="stroked"
+                      status="system"
+                      label={`${expert.experienceYears}+ лет опыта`}
+                    />
+                    <Badge size="xs" view="stroked" status="system" label={`Модулей: ${moduleCount}`} />
+                  </div>
+                  <div className={styles.tagRow}>
+                    {domainBadges.map((domainId) => (
+                      <Tag key={domainId} label={domainNameMap.get(domainId) ?? domainId} size="xs" />
+                    ))}
+                    {extraDomains > 0 && <Tag label={`+${extraDomains}`} size="xs" />}
+                  </div>
+                  <div className={styles.tagRow}>
+                    {topCompetencies.map((competency) => (
+                      <Badge key={competency.id} size="xs" view="stroked" status="system" label={competency.name} />
+                    ))}
+                  </div>
+                </button>
+              );
+            })}
+            {filteredExperts.length === 0 && (
+              <div className={styles.emptyState}>
+                <Text size="s" view="secondary">
+                  Измените фильтры или запрос, чтобы увидеть экспертов.
+                </Text>
+              </div>
+            )}
+          </div>
+        </aside>
+        <section className={styles.detailPanel}>
+          {selectedExpert ? (
+            <div className={styles.detailScroll}>
+              <header className={styles.detailHeader}>
+                <div className={styles.detailHeaderTop}>
+                  <div className={styles.titleBlock}>
+                    <Text size="xl" weight="bold">
+                      {selectedExpert.fullName}
+                    </Text>
+                    <Text size="s" view="secondary">
+                      {selectedExpert.title}
+                    </Text>
+                  </div>
+                  <Badge
+                    size="m"
+                    view="filled"
+                    status={availabilityStatus[selectedExpert.availability]}
+                    label={availabilityLabels[selectedExpert.availability]}
+                  />
+                </div>
+                <div className={styles.metricsRow}>
+                  <span>
+                    <Badge size="s" view="stroked" status="system" label={`${selectedExpert.experienceYears}+ лет опыта`} />
+                  </span>
+                  <span className={styles.muted}>Домены: {selectedExpert.domainIds.length}</span>
+                  <span className={styles.muted}>Модули: {selectedExpert.moduleIds.length}</span>
+                  <span className={styles.muted}>Компетенции: {selectedExpert.competencies.length}</span>
+                </div>
+                {selectedExpert.focusAreas.length > 0 && (
+                  <div className={styles.focusTags}>
+                    {selectedExpert.focusAreas.map((focus) => (
+                      <Tag key={focus} label={focus} size="s" />
+                    ))}
+                  </div>
+                )}
+                <Text size="s">{selectedExpert.summary}</Text>
+              </header>
+
+              <div className={styles.section}>
+                <div className={styles.sectionHeader}>
+                  <Text size="s" weight="semibold">
+                    Активные домены и модули
+                  </Text>
+                  <Text size="xs" view="secondary">
+                    {selectedExpert.moduleIds.length} модулей • {selectedExpert.domainIds.length} доменов
+                  </Text>
+                </div>
+                <div className={styles.badgeRow}>
+                  {selectedExpert.domainIds.map((domainId) => (
+                    <Tag key={domainId} label={domainNameMap.get(domainId) ?? domainId} size="xs" />
+                  ))}
+                </div>
+                <div className={styles.badgeRow}>
+                  {selectedExpert.moduleIds.map((moduleId) => {
+                    const module = moduleMap.get(moduleId);
+                    if (!module) {
+                      return (
+                        <Badge key={moduleId} size="s" view="stroked" status="system" label={moduleId} />
+                      );
+                    }
+                    return (
+                      <Badge
+                        key={module.id}
+                        size="s"
+                        view="stroked"
+                        status={moduleStatusBadge[module.status]}
+                        label={module.name}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+
+              {selectedExpert.projectHighlights.length > 0 && (
+                <div className={styles.section}>
+                  <Text size="s" weight="semibold">
+                    Проектные достижения
+                  </Text>
+                  <div className={styles.highlightList}>
+                    {selectedExpert.projectHighlights.map((highlight, index) => {
+                      const module = moduleMap.get(highlight.moduleId);
+                      return (
+                        <div className={styles.highlightItem} key={`${highlight.moduleId}-${index}`}>
+                          <div className={styles.highlightMeta}>
+                            <Badge
+                              size="xs"
+                              view="filled"
+                              status={module ? moduleStatusBadge[module.status] : 'system'}
+                              label={module?.name ?? highlight.moduleId}
+                            />
+                            <Text size="xs" view="secondary">
+                              {module?.productName}
+                            </Text>
+                          </div>
+                          <Text size="s" weight="semibold">
+                            {highlight.contribution}
+                          </Text>
+                          <Text size="s" view="secondary">
+                            {highlight.impact}
+                          </Text>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+
+              <div className={styles.section}>
+                <Text size="s" weight="semibold">
+                  Основные компетенции
+                </Text>
+                <div className={styles.consultingList}>
+                  {selectedExpert.competencies.map((competency) => {
+                    const level = competencyLevelMeta[competency.level];
+                    return (
+                      <div className={styles.consultingItem} key={competency.id}>
+                        <div className={styles.itemHeader}>
+                          <Text size="s" weight="semibold">
+                            {competency.name}
+                          </Text>
+                          <Badge size="xs" view="filled" status={level.status} label={level.label} />
+                        </div>
+                        <Text size="xs" view="secondary">
+                          {competency.category}
+                        </Text>
+                        <Text size="s">{competency.description}</Text>
+                        {competency.evidenceModules && competency.evidenceModules.length > 0 && (
+                          <div className={styles.tagRow}>
+                            {competency.evidenceModules.map((moduleId) => (
+                              <Tag key={moduleId} label={moduleMap.get(moduleId)?.name ?? moduleId} size="xs" />
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className={styles.section}>
+                <Text size="s" weight="semibold">
+                  Консалтинговые навыки
+                </Text>
+                <div className={styles.consultingList}>
+                  {selectedExpert.consultingSkills.map((skill) => (
+                    <div className={styles.consultingItem} key={skill.id}>
+                      <Text size="s" weight="semibold">
+                        {skill.name}
+                      </Text>
+                      <Text size="s" view="secondary">
+                        {skill.description}
+                      </Text>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className={styles.section}>
+                <div className={styles.sectionHeader}>
+                  <Text size="s" weight="semibold">
+                    Менторство и развитие
+                  </Text>
+                  <Text size="xs" view="secondary">
+                    Темы: {selectedExpert.mentoringTopics.length} • Интересы: {selectedExpert.learningInterests.length}
+                  </Text>
+                </div>
+                <div className={styles.pills}>
+                  {selectedExpert.mentoringTopics.map((topic) => (
+                    <Tag key={`mentor-${topic}`} label={`Менторство: ${topic}`} size="xs" />
+                  ))}
+                </div>
+                <div className={styles.pills}>
+                  {selectedExpert.learningInterests.map((interest) => (
+                    <Tag key={`interest-${interest}`} label={`Интерес: ${interest}`} size="xs" />
+                  ))}
+                </div>
+              </div>
+
+              {relatedExperts.length > 0 && (
+                <div className={styles.section}>
+                  <Text size="s" weight="semibold">
+                    Связанные эксперты
+                  </Text>
+                  <div className={styles.relatedList}>
+                    {relatedExperts.map(({ expert, sharedDomains, sharedModules, sharedCompetencies }) => (
+                      <div className={styles.relatedItem} key={expert.id}>
+                        <div>
+                          <Text size="s" weight="semibold">
+                            {expert.fullName}
+                          </Text>
+                          <Text size="xs" view="secondary">
+                            {expert.title}
+                          </Text>
+                          <Text size="xs" className={styles.muted}>
+                            {formatConnection(sharedDomains, sharedModules, sharedCompetencies)}
+                          </Text>
+                        </div>
+                        <Button size="xs" view="secondary" label="Показать" onClick={() => setSelectedExpertId(expert.id)} />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className={styles.emptyState}>
+              <Text size="s" view="secondary">
+                Нет эксперта, удовлетворяющего текущим фильтрам.
+              </Text>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+function flattenDomains(domains: DomainNode[]): DomainNode[] {
+  return domains.flatMap((domain) => [domain, ...(domain.children ? flattenDomains(domain.children) : [])]);
+}
+
+export default ExpertExplorer;

--- a/src/data.ts
+++ b/src/data.ts
@@ -42,6 +42,46 @@ export type TeamMember = {
   role: TeamRole;
 };
 
+export type ExpertCompetencyLevel = 'foundation' | 'advanced' | 'expert';
+
+export type ExpertCompetency = {
+  id: string;
+  name: string;
+  category: string;
+  level: ExpertCompetencyLevel;
+  description: string;
+  evidenceModules?: string[];
+};
+
+export type ExpertConsultingSkill = {
+  id: string;
+  name: string;
+  description: string;
+};
+
+export type ExpertProjectHighlight = {
+  moduleId: string;
+  contribution: string;
+  impact: string;
+};
+
+export type ExpertProfile = {
+  id: string;
+  fullName: string;
+  title: string;
+  summary: string;
+  experienceYears: number;
+  domainIds: string[];
+  moduleIds: string[];
+  competencies: ExpertCompetency[];
+  consultingSkills: ExpertConsultingSkill[];
+  focusAreas: string[];
+  availability: 'open' | 'limited' | 'booked';
+  projectHighlights: ExpertProjectHighlight[];
+  mentoringTopics: string[];
+  learningInterests: string[];
+};
+
 export type RidOwner = {
   company: string;
   division: string;
@@ -1129,6 +1169,426 @@ export const moduleNameById: Record<string, string> = modules.reduce((acc, modul
   acc[module.id] = module.name;
   return acc;
 }, {} as Record<string, string>);
+
+export const expertProfiles: ExpertProfile[] = [
+  {
+    id: 'expert-viktoria-berezhnaya',
+    fullName: 'Виктория Бережная',
+    title: 'Ведущий эксперт по инженерным данным',
+    summary:
+      '12 лет выстраивает конвейеры подготовки инженерных данных и отвечает за методологию обмена между проектными офисами и производственными площадками.',
+    experienceYears: 12,
+    domainIds: ['data-preparation', 'layout-optimization', 'resource-evaluation'],
+    moduleIds: ['module-infraplan-datahub', 'module-infraplan-layout', 'module-dtwin-optimizer'],
+    competencies: [
+      {
+        id: 'infra-data-normalization',
+        name: 'Нормализация инфраструктурных данных',
+        category: 'Инженерия данных',
+        level: 'expert',
+        description:
+          'Проектирует пайплайны очистки и семантического выравнивания инженерных атрибутов, внедряет автоматические проверки качества.',
+        evidenceModules: ['module-infraplan-datahub']
+      },
+      {
+        id: 'infrastructure-scenario-planning',
+        name: 'Сценарное моделирование обустройства',
+        category: 'Инфраструктурное моделирование',
+        level: 'advanced',
+        description:
+          'Настраивает совместную работу инструментов INFRAPLAN и DIGITAL TWIN для анализа вариантов размещения и режимов эксплуатации.',
+        evidenceModules: ['module-infraplan-layout', 'module-dtwin-optimizer']
+      },
+      {
+        id: 'data-governance-quality',
+        name: 'Управление качеством инженерных данных',
+        category: 'Data governance',
+        level: 'advanced',
+        description:
+          'Формирует контрольные точки качества и регламенты онбординга новых источников телеметрии.',
+        evidenceModules: ['module-infraplan-datahub']
+      }
+    ],
+    consultingSkills: [
+      {
+        id: 'consulting-data-governance',
+        name: 'Построение data governance',
+        description:
+          'Фасилитирует запуск советов по данным и выстраивает роли стюардов в функциональных заказчиках.'
+      },
+      {
+        id: 'consulting-discovery',
+        name: 'Дискавери промышленных проектов',
+        description:
+          'Проводит экспресс-обследования месторождений и формирует дорожные карты цифровизации по данным.'
+      }
+    ],
+    focusAreas: ['Онбординг телеметрии и геоданных', 'Каталоги инженерных метрик'],
+    availability: 'open',
+    projectHighlights: [
+      {
+        moduleId: 'module-infraplan-datahub',
+        contribution:
+          'Организовала единый словарь атрибутов и автоматизировала контроль порогов качества на этапе загрузки.',
+        impact: 'Время ввода нового актива сократилось с 4 недель до 9 дней.'
+      },
+      {
+        moduleId: 'module-infraplan-layout',
+        contribution:
+          'Настроила обмен с геомоделями и адаптировала пайплайны под сложный рельеф арктических месторождений.',
+        impact: 'Число итераций согласования схем снизилось на 35%.'
+      }
+    ],
+    mentoringTopics: ['Каталоги инженерных данных', 'Организация обмена между ЦОД и полем'],
+    learningInterests: ['Построение knowledge-graph для инжиниринга', 'Автоматическое обогащение IoT-данных']
+  },
+  {
+    id: 'expert-anton-vlasov',
+    fullName: 'Антон Власов',
+    title: 'Руководитель направления технико-экономической оценки',
+    summary:
+      'Отвечает за финансовые модели в INFRAPLAN и консультирует по оценке эффективности цифровых инвестиций для upstream проектов.',
+    experienceYears: 14,
+    domainIds: ['economic-evaluation', 'development-scenarios', 'layout-optimization'],
+    moduleIds: ['module-infraplan-economics', 'module-infraplan-datahub', 'module-wwo-analytics'],
+    competencies: [
+      {
+        id: 'infrastructure-scenario-planning',
+        name: 'Сценарное моделирование обустройства',
+        category: 'Инвестиционное планирование',
+        level: 'expert',
+        description:
+          'Формализует альтернативные сценарии развития инфраструктуры и связывает их с финансовыми ограничениями.',
+        evidenceModules: ['module-infraplan-economics']
+      },
+      {
+        id: 'economic-scenarios',
+        name: 'Экономическая оценка капитальных программ',
+        category: 'Финансовое моделирование',
+        level: 'expert',
+        description:
+          'Проектирует расчёт NPV/IRR для портфелей и внедряет stress-test библиотеки.',
+        evidenceModules: ['module-infraplan-economics', 'module-wwo-analytics']
+      },
+      {
+        id: 'value-engineering',
+        name: 'Ценообразование цифровых инициатив',
+        category: 'Value management',
+        level: 'advanced',
+        description:
+          'Помогает заказчикам пересчитывать эффект от цифровых инициатив в экономические показатели и KPI.',
+        evidenceModules: ['module-infraplan-economics']
+      }
+    ],
+    consultingSkills: [
+      {
+        id: 'consulting-portfolio',
+        name: 'Портфельное управление продуктами',
+        description:
+          'Выстраивает стратегические сессии и формирует карты ценности между функциями и продуктами.'
+      },
+      {
+        id: 'consulting-change-management',
+        name: 'Управление изменениями',
+        description:
+          'Сопровождает внедрение решений, адаптируя KPI подразделений и систему мотивации.'
+      }
+    ],
+    focusAreas: ['Единая модель экономических данных', 'Интеграция с ERP-ланшафтом заказчика'],
+    availability: 'limited',
+    projectHighlights: [
+      {
+        moduleId: 'module-infraplan-economics',
+        contribution:
+          'Запустил расчёт вариантов обустройства по портфелям и внедрил stress-test сценариев CAPEX/OPEX.',
+        impact: 'Время подготовки инвестиционного досье сократилось на 45%.'
+      },
+      {
+        moduleId: 'module-wwo-analytics',
+        contribution: 'Сформировал витрину экономических KPI для анализа эффективности ремонтов.',
+        impact: 'Позволило выявить скрытый эффект на 280 млн ₽ в год.'
+      }
+    ],
+    mentoringTopics: ['Оценка цифровых инициатив', 'Согласование KPI между IT и бизнесом'],
+    learningInterests: ['ESG-метрики в добыче', 'Автоматизация стресс-тестирования моделей']
+  },
+  {
+    id: 'expert-raisa-chistyakova',
+    fullName: 'Раиса Чистякова',
+    title: 'Архитектор телеметрических платформ',
+    summary:
+      'Специализируется на потоковой обработке данных и построении отказоустойчивых витрин для цифровых двойников и лабораторий.',
+    experienceYears: 11,
+    domainIds: ['real-time-monitoring', 'pipeline-monitoring', 'production-optimization'],
+    moduleIds: ['module-dtwin-monitoring', 'module-dtwin-optimizer', 'module-lab-experiments'],
+    competencies: [
+      {
+        id: 'real-time-architecture',
+        name: 'Архитектура потоковой обработки',
+        category: 'Промышленная телеметрия',
+        level: 'expert',
+        description:
+          'Проектирует ingestion-конвейеры, балансирует нагрузку Kafka и настраивает SLA по доставке данных.',
+        evidenceModules: ['module-dtwin-monitoring']
+      },
+      {
+        id: 'stream-observability',
+        name: 'Наблюдаемость стриминговых платформ',
+        category: 'Site Reliability',
+        level: 'advanced',
+        description:
+          'Внедряет мониторинг задержек и контроль деградаций в real-time цепочках.',
+        evidenceModules: ['module-dtwin-monitoring', 'module-lab-experiments']
+      },
+      {
+        id: 'edge-integration',
+        name: 'Интеграция edge-оборудования',
+        category: 'Промышленный IoT',
+        level: 'advanced',
+        description:
+          'Выстраивает безопасные каналы связи с полевыми устройствами и унифицирует протоколы.',
+        evidenceModules: ['module-dtwin-monitoring']
+      }
+    ],
+    consultingSkills: [
+      {
+        id: 'consulting-ops-excellence',
+        name: 'Операционная эффективность',
+        description:
+          'Проводит сессии по оптимизации производственных процессов на основе потоковых метрик.'
+      },
+      {
+        id: 'consulting-safety',
+        name: 'Управление промышленной безопасностью',
+        description:
+          'Помогает внедрять цифровые регламенты по предотвращению аварий и контролю утечек.'
+      }
+    ],
+    focusAreas: ['Снижение задержек телеметрии', 'Безопасное подключение новых активов'],
+    availability: 'limited',
+    projectHighlights: [
+      {
+        moduleId: 'module-dtwin-monitoring',
+        contribution: 'Выстроила ingestion-стек на Kafka с активным перераспределением нагрузки между кластерами.',
+        impact: 'Время доставки телеметрии сократилось с 90 до 18 секунд.'
+      },
+      {
+        moduleId: 'module-lab-experiments',
+        contribution: 'Организовала безопасный канал обмена с лабораторией и автоматизировала публикацию экспериментов.',
+        impact: 'Количество проведённых экспериментов выросло в 2,3 раза.'
+      }
+    ],
+    mentoringTopics: ['Kafka и ClickHouse в промышленности', 'Обеспечение отказоустойчивости телеметрии'],
+    learningInterests: ['Edge AI', 'Adaptive streaming для IoT']
+  },
+  {
+    id: 'expert-elizar-kopylov',
+    fullName: 'Елизар Копылов',
+    title: 'Лид инженерных рекомендаций DIGITAL TWIN',
+    summary:
+      'Комбинирует моделирование процессов, машинное обучение и дистанционное управление для повышения добычи и снижения рисков.',
+    experienceYears: 10,
+    domainIds: ['production-optimization', 'remote-control', 'real-time-monitoring'],
+    moduleIds: ['module-dtwin-optimizer', 'module-dtwin-remote-control', 'module-lab-experiments'],
+    competencies: [
+      {
+        id: 'optimization-ml',
+        name: 'Оптимизация режимов с помощью ML',
+        category: 'Математическое моделирование',
+        level: 'expert',
+        description:
+          'Создаёт гибридные модели и orchestrator стратегий, учитывая физические ограничения и бизнес-метрики.',
+        evidenceModules: ['module-dtwin-optimizer']
+      },
+      {
+        id: 'real-time-architecture',
+        name: 'Архитектура потоковой обработки',
+        category: 'Промышленная телеметрия',
+        level: 'advanced',
+        description:
+          'Формирует контуры обратной связи и следит за качеством данных, поступающих в оптимизатор.',
+        evidenceModules: ['module-dtwin-optimizer', 'module-dtwin-remote-control']
+      },
+      {
+        id: 'control-loop-design',
+        name: 'Проектирование контуров управления',
+        category: 'Промышленная автоматизация',
+        level: 'advanced',
+        description:
+          'Настраивает дистанционные команды и проверку их выполнения на производственных площадках.',
+        evidenceModules: ['module-dtwin-remote-control']
+      }
+    ],
+    consultingSkills: [
+      {
+        id: 'consulting-automation-bootcamp',
+        name: 'Автоматизация производственных решений',
+        description:
+          'Проводит воркшопы по интеграции цифрового двойника в операционный контур.'
+      },
+      {
+        id: 'consulting-discovery',
+        name: 'Дискавери промышленных проектов',
+        description:
+          'Помогает выявлять точки роста добычи и оценивать эффект от дистанционного управления.'
+      }
+    ],
+    focusAreas: ['Замыкание контура управления', 'Повышение производительности скважин'],
+    availability: 'open',
+    projectHighlights: [
+      {
+        moduleId: 'module-dtwin-optimizer',
+        contribution: 'Построил гибридную модель оптимизации режимов и автоматизировал выбор стратегий запуска.',
+        impact: 'Дополнительная добыча +3,5% без увеличения энергоиздержек.'
+      },
+      {
+        moduleId: 'module-dtwin-remote-control',
+        contribution: 'Организовал дистанционное исполнение команд с контролем безопасности.',
+        impact: 'Сократил время реакции операторов на 40%.'
+      }
+    ],
+    mentoringTopics: ['Гибридные ML/physics модели', 'Организация дистанционного управления'],
+    learningInterests: ['Reinforcement learning в производстве', 'Explainable AI для операторов']
+  },
+  {
+    id: 'expert-margarita-kurganskaya',
+    fullName: 'Маргарита Курганская',
+    title: 'Практик цифрового полевого исполнения',
+    summary:
+      'Объединяет мобильные решения, работу бригад и контроль безопасности при выполнении внутрискважинных операций.',
+    experienceYears: 9,
+    domainIds: ['field-execution', 'workover-planning', 'quality-analytics'],
+    moduleIds: ['module-wwo-execution', 'module-wwo-planner', 'module-wwo-analytics'],
+    competencies: [
+      {
+        id: 'workover-process',
+        name: 'Операционные процессы ВИР',
+        category: 'Field operations',
+        level: 'expert',
+        description:
+          'Регламентирует работу бригад, формирует контрольные списки и цифровые наряды.',
+        evidenceModules: ['module-wwo-execution', 'module-wwo-planner']
+      },
+      {
+        id: 'field-data-collection',
+        name: 'Цифровой сбор полевых данных',
+        category: 'Мобильные решения',
+        level: 'advanced',
+        description:
+          'Внедряет оффлайн-сценарии и синхронизацию с центральным хранилищем.',
+        evidenceModules: ['module-wwo-execution']
+      },
+      {
+        id: 'safety-compliance',
+        name: 'Контроль промышленной безопасности',
+        category: 'HSE',
+        level: 'advanced',
+        description:
+          'Настраивает цифровые допуски и автоматическую проверку соответствия регламентам.',
+        evidenceModules: ['module-wwo-execution']
+      }
+    ],
+    consultingSkills: [
+      {
+        id: 'consulting-ops-excellence',
+        name: 'Операционная эффективность',
+        description:
+          'Диагностирует узкие места в полевых процессах и помогает выстроить систему показателей.'
+      },
+      {
+        id: 'consulting-safety',
+        name: 'Управление промышленной безопасностью',
+        description:
+          'Обучает бригады цифровым стандартам безопасности и контролю рисков.'
+      }
+    ],
+    focusAreas: ['Цифровые наряды-допуски', 'Интеграция с системами охраны труда'],
+    availability: 'booked',
+    projectHighlights: [
+      {
+        moduleId: 'module-wwo-execution',
+        contribution: 'Настроила оффлайн-режим и автоматическую синхронизацию отчётности с центральной системой.',
+        impact: 'Время закрытия наряда сократилось до 2 часов вместо 16.'
+      },
+      {
+        moduleId: 'module-wwo-planner',
+        contribution: 'Связала планы ремонтов с оперативной ситуацией и расписанием бригад.',
+        impact: 'Повысила соблюдение графика работ до 96%.'
+      }
+    ],
+    mentoringTopics: ['Онбординг полевых команд', 'Цифровые регламенты безопасности'],
+    learningInterests: ['Дополненная реальность для ВИР', 'Автоматизированный контроль охраны труда']
+  },
+  {
+    id: 'expert-denis-laptev',
+    fullName: 'Денис Лаптев',
+    title: 'Лид аналитической лаборатории WWO',
+    summary:
+      'Строит витрины эффективности внутрискважинных работ и соединяет операционные показатели с экономическими эффектами.',
+    experienceYears: 13,
+    domainIds: ['quality-analytics', 'workover-planning', 'production-optimization'],
+    moduleIds: ['module-wwo-analytics', 'module-wwo-planner', 'module-infraplan-economics'],
+    competencies: [
+      {
+        id: 'quality-analytics',
+        name: 'Аналитика качества ремонтов',
+        category: 'Производственная аналитика',
+        level: 'expert',
+        description:
+          'Формирует KPI по качеству ремонтов и создает интерактивные панели мониторинга.',
+        evidenceModules: ['module-wwo-analytics']
+      },
+      {
+        id: 'value-engineering',
+        name: 'Ценообразование цифровых инициатив',
+        category: 'Value management',
+        level: 'advanced',
+        description:
+          'Связывает операционные показатели с экономическими эффектами и бюджетированием.',
+        evidenceModules: ['module-infraplan-economics', 'module-wwo-analytics']
+      },
+      {
+        id: 'workover-process',
+        name: 'Операционные процессы ВИР',
+        category: 'Field operations',
+        level: 'advanced',
+        description:
+          'Анализирует длительность циклов и выявляет узкие места в производственных процессах.',
+        evidenceModules: ['module-wwo-planner', 'module-wwo-analytics']
+      }
+    ],
+    consultingSkills: [
+      {
+        id: 'consulting-portfolio',
+        name: 'Портфельное управление продуктами',
+        description:
+          'Помогает заказчику балансировать инвестиции в цифровизацию и операционный эффект.'
+      },
+      {
+        id: 'consulting-data-governance',
+        name: 'Построение data governance',
+        description:
+          'Организует совместную работу аналитиков, бизнес-пользователей и ИТ-команд.'
+      }
+    ],
+    focusAreas: ['Сквозные KPI по ремонту фонда', 'Интеграция с экономическими витринами'],
+    availability: 'limited',
+    projectHighlights: [
+      {
+        moduleId: 'module-wwo-analytics',
+        contribution: 'Настроил дашборды эффективности, объединяющие операционные и экономические метрики.',
+        impact: 'Руководители фондов получают отчёт в режиме T+1 вместо T+7.'
+      },
+      {
+        moduleId: 'module-infraplan-economics',
+        contribution: 'Синхронизировал экономические модели с фактическими данными ремонтов.',
+        impact: 'Снизил расхождение план/факт до 4%.'
+      }
+    ],
+    mentoringTopics: ['Настройка витрин показателей', 'Совместная работа аналитики и производства'],
+    learningInterests: ['Data mesh в производственных компаниях', 'Продвинутая визуализация KPI']
+  }
+];
 
 export type ArtifactNode = {
   id: string;


### PR DESCRIPTION
## Summary
- add structured R&D expert profiles with competencies, consulting skills, and project highlights
- create an ExpertExplorer view with filters, relationship insights, and detailed profile sections
- expose a new "Эксперты" tab in the main app layout and supporting styles for the new view

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f02e7a2a288332b1ac2ff11d1c4ecb