### PR TITLE
Add expert skills structure and aggregation helpers

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -49,6 +49,28 @@ export type RidOwner = {
 
 export type ExpertAvailability = 'available' | 'partial' | 'busy';
 
+export type SkillLevel = 'A' | 'B' | 'C' | 'D' | 'E';
+
+export type SkillEvidenceStatus = 'verified' | 'in-review' | 'self-reported';
+
+export type SkillInterestLevel = 'high' | 'medium' | 'low';
+
+export type SkillUsage = {
+  from: string;
+  to?: string;
+  description?: string;
+};
+
+export type ExpertSkill = {
+  id: string;
+  level: SkillLevel;
+  proofStatus: SkillEvidenceStatus;
+  usage?: SkillUsage;
+  artifacts: string[];
+  interest: SkillInterestLevel;
+  availableFte: number;
+};
+
 export type ExpertProfile = {
   id: string;
   fullName: string;
@@ -66,6 +88,7 @@ export type ExpertProfile = {
   notableProjects: string[];
   availability: ExpertAvailability;
   availabilityComment: string;
+  skills: ExpertSkill[];
 };
 
 export type LibraryDependency = {
@@ -1183,7 +1206,47 @@ export const experts: ExpertProfile[] = [
       'Выстроила мониторинг качества источников в ПАО «СибНефть Добыча»'
     ],
     availability: 'available',
-    availabilityComment: 'Может подключиться к 1–2 консалтинговым инициативам в квартал'
+    availabilityComment: 'Может подключиться к 1–2 консалтинговым инициативам в квартал',
+    skills: [
+      {
+        id: 'data-normalization',
+        level: 'A',
+        proofStatus: 'verified',
+        usage: {
+          from: '2023-01-15',
+          to: '2024-04-01',
+          description: 'Стандартизация инженерных датасетов для DataHub на месторождениях «Северный купол» и «Арктика»'
+        },
+        artifacts: ['artifact-infraplan-source-pack'],
+        interest: 'high',
+        availableFte: 0.4
+      },
+      {
+        id: 'streaming-pipelines',
+        level: 'B',
+        proofStatus: 'verified',
+        usage: {
+          from: '2022-09-01',
+          to: '2024-02-20',
+          description: 'Поддержка Kafka-пайплайнов телеметрии для ситуационных центров Nedra.Production'
+        },
+        artifacts: ['artifact-dtwin-telemetry-cube'],
+        interest: 'medium',
+        availableFte: 0.3
+      },
+      {
+        id: 'data-governance',
+        level: 'B',
+        proofStatus: 'in-review',
+        usage: {
+          from: '2023-05-01',
+          description: 'Разработка матрицы владения инженерными данными и процессов каталогизации'
+        },
+        artifacts: [],
+        interest: 'high',
+        availableFte: 0.2
+      }
+    ]
   },
   {
     id: 'expert-pavel-kolosov',
@@ -1219,7 +1282,47 @@ export const experts: ExpertProfile[] = [
       'Сопровождал масштабирование INFRAPLAN в холдинге «Западнефть Разработка»'
     ],
     availability: 'partial',
-    availabilityComment: 'Загружен проектами на 60%, доступен для стратегических консультаций'
+    availabilityComment: 'Загружен проектами на 60%, доступен для стратегических консультаций',
+    skills: [
+      {
+        id: 'layout-optimization',
+        level: 'A',
+        proofStatus: 'verified',
+        usage: {
+          from: '2022-02-01',
+          to: '2024-03-15',
+          description: 'Оптимизация размещения объектов обустройства с использованием OptaPlanner'
+        },
+        artifacts: ['artifact-infraplan-layout'],
+        interest: 'high',
+        availableFte: 0.25
+      },
+      {
+        id: 'geo-apis',
+        level: 'B',
+        proofStatus: 'self-reported',
+        usage: {
+          from: '2021-07-01',
+          to: '2023-12-10',
+          description: 'Проектирование API для геосервисов и интеграции с подрядчиками ЛИДАР'
+        },
+        artifacts: ['artifact-infraplan-layout'],
+        interest: 'medium',
+        availableFte: 0.15
+      },
+      {
+        id: 'infrastructure-economics',
+        level: 'C',
+        proofStatus: 'in-review',
+        usage: {
+          from: '2023-06-01',
+          description: 'Совместные расчёты экономических эффектов для сценариев размещения'
+        },
+        artifacts: ['artifact-infraplan-economic-report'],
+        interest: 'low',
+        availableFte: 0.1
+      }
+    ]
   },
   {
     id: 'expert-anton-vlasov',
@@ -1255,7 +1358,47 @@ export const experts: ExpertProfile[] = [
       'Сопровождал сделки по покупке активов в Арктическом регионе'
     ],
     availability: 'busy',
-    availabilityComment: 'Свободные слоты с ноября, возможна точечная экспертиза документов'
+    availabilityComment: 'Свободные слоты с ноября, возможна точечная экспертиза документов',
+    skills: [
+      {
+        id: 'financial-modeling',
+        level: 'A',
+        proofStatus: 'verified',
+        usage: {
+          from: '2022-01-01',
+          to: '2024-04-20',
+          description: 'Подготовка инвестиционных моделей для масштабирования INFRAPLAN'
+        },
+        artifacts: ['artifact-infraplan-economic-report'],
+        interest: 'high',
+        availableFte: 0.1
+      },
+      {
+        id: 'scenario-planning',
+        level: 'B',
+        proofStatus: 'verified',
+        usage: {
+          from: '2023-03-01',
+          to: '2024-01-30',
+          description: 'Сценарный анализ инвестиционных программ для портфеля месторождений'
+        },
+        artifacts: ['artifact-infraplan-economic-report'],
+        interest: 'medium',
+        availableFte: 0.05
+      },
+      {
+        id: 'ma-support',
+        level: 'C',
+        proofStatus: 'in-review',
+        usage: {
+          from: '2022-11-01',
+          description: 'Экспертиза сделок по покупке активов в Арктическом регионе'
+        },
+        artifacts: [],
+        interest: 'medium',
+        availableFte: 0.05
+      }
+    ]
   },
   {
     id: 'expert-raisa-chistyakova',
@@ -1293,7 +1436,47 @@ export const experts: ExpertProfile[] = [
       'Создала стандарт подключения подрядчиков IoT к Digital Twin'
     ],
     availability: 'partial',
-    availabilityComment: 'Доступна для аудитов и предпроектной диагностики на 2–3 дня в месяц'
+    availabilityComment: 'Доступна для аудитов и предпроектной диагностики на 2–3 дня в месяц',
+    skills: [
+      {
+        id: 'telemetry-streaming',
+        level: 'A',
+        proofStatus: 'verified',
+        usage: {
+          from: '2022-04-01',
+          to: '2024-03-01',
+          description: 'Поддержка ClickHouse и Kafka пайплайнов с нагрузкой 500k сообщений/сек'
+        },
+        artifacts: ['artifact-dtwin-telemetry-cube'],
+        interest: 'high',
+        availableFte: 0.2
+      },
+      {
+        id: 'iot-integration',
+        level: 'B',
+        proofStatus: 'in-review',
+        usage: {
+          from: '2023-02-01',
+          description: 'Интеграция промышленного IoT с ситуационными центрами и Digital Twin'
+        },
+        artifacts: ['artifact-dtwin-telemetry-cube'],
+        interest: 'medium',
+        availableFte: 0.15
+      },
+      {
+        id: 'sre-monitoring',
+        level: 'B',
+        proofStatus: 'self-reported',
+        usage: {
+          from: '2021-11-01',
+          to: '2023-10-01',
+          description: 'Настройка SLO/SLI для событийных систем мониторинга'
+        },
+        artifacts: [],
+        interest: 'high',
+        availableFte: 0.1
+      }
+    ]
   },
   {
     id: 'expert-elizar-kopylov',
@@ -1330,7 +1513,47 @@ export const experts: ExpertProfile[] = [
       'Внедрил процесс MLOps для Nedra.Production в пяти регионах'
     ],
     availability: 'available',
-    availabilityComment: 'Готов подключиться к пилотам и пресейлам, приоритет — оптимизация добычи'
+    availabilityComment: 'Готов подключиться к пилотам и пресейлам, приоритет — оптимизация добычи',
+    skills: [
+      {
+        id: 'production-ml',
+        level: 'A',
+        proofStatus: 'verified',
+        usage: {
+          from: '2022-08-01',
+          to: '2024-02-15',
+          description: 'Обучение и внедрение ML-моделей оптимизации добычи на 5 активах'
+        },
+        artifacts: ['artifact-dtwin-optimization-orders'],
+        interest: 'high',
+        availableFte: 0.35
+      },
+      {
+        id: 'mlops-production',
+        level: 'B',
+        proofStatus: 'verified',
+        usage: {
+          from: '2023-01-10',
+          to: '2024-03-10',
+          description: 'Организация конвейера MLOps для Digital Twin'
+        },
+        artifacts: ['artifact-dtwin-optimization-orders'],
+        interest: 'medium',
+        availableFte: 0.25
+      },
+      {
+        id: 'value-discovery',
+        level: 'C',
+        proofStatus: 'in-review',
+        usage: {
+          from: '2023-06-01',
+          description: 'Фасилитация discovery-сессий с производством по выбору сценариев'
+        },
+        artifacts: [],
+        interest: 'high',
+        availableFte: 0.2
+      }
+    ]
   },
   {
     id: 'expert-igor-shamov',
@@ -1366,7 +1589,47 @@ export const experts: ExpertProfile[] = [
       'Разработал стандарт интеграции Remote Ops с подрядчиками HSE'
     ],
     availability: 'partial',
-    availabilityComment: 'Находится в проектах внедрения, доступен для очных воркшопов раз в месяц'
+    availabilityComment: 'Находится в проектах внедрения, доступен для очных воркшопов раз в месяц',
+    skills: [
+      {
+        id: 'remote-ops-integration',
+        level: 'A',
+        proofStatus: 'verified',
+        usage: {
+          from: '2021-09-01',
+          to: '2024-02-28',
+          description: 'Интеграция SCADA, MES и дистанционного управления на кустовых площадках'
+        },
+        artifacts: ['artifact-dtwin-remote-commands'],
+        interest: 'high',
+        availableFte: 0.2
+      },
+      {
+        id: 'remote-ops-security',
+        level: 'B',
+        proofStatus: 'in-review',
+        usage: {
+          from: '2022-05-01',
+          description: 'Оценка и настройка кибербезопасности дистанционных операций'
+        },
+        artifacts: [],
+        interest: 'medium',
+        availableFte: 0.15
+      },
+      {
+        id: 'change-management',
+        level: 'C',
+        proofStatus: 'self-reported',
+        usage: {
+          from: '2023-04-01',
+          to: '2024-01-10',
+          description: 'Организация change management при внедрении Remote Ops'
+        },
+        artifacts: [],
+        interest: 'medium',
+        availableFte: 0.1
+      }
+    ]
   },
   {
     id: 'expert-vladimir-romanov',
@@ -1403,7 +1666,47 @@ export const experts: ExpertProfile[] = [
       'Внедрил цифровые регламенты взаимодействия с подрядчиками в трёх промыслах'
     ],
     availability: 'available',
-    availabilityComment: 'Готов вести консалтинговые треки и наставничество по WWO-процессам'
+    availabilityComment: 'Готов вести консалтинговые треки и наставничество по WWO-процессам',
+    skills: [
+      {
+        id: 'wwo-planning',
+        level: 'A',
+        proofStatus: 'verified',
+        usage: {
+          from: '2021-03-01',
+          to: '2024-02-01',
+          description: 'Оптимизация и согласование программ ГТМ для 3 промыслов'
+        },
+        artifacts: ['artifact-wwo-plan'],
+        interest: 'high',
+        availableFte: 0.3
+      },
+      {
+        id: 'contractor-management',
+        level: 'B',
+        proofStatus: 'verified',
+        usage: {
+          from: '2022-05-01',
+          to: '2024-03-20',
+          description: 'Выстраивание взаимодействия с подрядчиками и SLA по ремонтам'
+        },
+        artifacts: [],
+        interest: 'medium',
+        availableFte: 0.25
+      },
+      {
+        id: 'process-digitization',
+        level: 'C',
+        proofStatus: 'in-review',
+        usage: {
+          from: '2023-09-01',
+          description: 'Перевод регламентов WWO в цифровые шаблоны'
+        },
+        artifacts: ['artifact-wwo-operations-log'],
+        interest: 'high',
+        availableFte: 0.2
+      }
+    ]
   },
   {
     id: 'expert-margarita-kurganskaya',
@@ -1439,7 +1742,47 @@ export const experts: ExpertProfile[] = [
       'Сформировала программу обучения операторов цифровым инструментам WWO'
     ],
     availability: 'busy',
-    availabilityComment: 'Полная загрузка текущими внедрениями, возможны дистанционные консультации'
+    availabilityComment: 'Полная загрузка текущими внедрениями, возможны дистанционные консультации',
+    skills: [
+      {
+        id: 'field-dispatching',
+        level: 'A',
+        proofStatus: 'verified',
+        usage: {
+          from: '2022-06-01',
+          to: '2024-04-05',
+          description: 'Диспетчеризация бригад и контроль исполнения ремонтов'
+        },
+        artifacts: ['artifact-wwo-operations-log'],
+        interest: 'high',
+        availableFte: 0.05
+      },
+      {
+        id: 'mobile-solutions',
+        level: 'B',
+        proofStatus: 'in-review',
+        usage: {
+          from: '2023-01-01',
+          description: 'Внедрение мобильных приложений для полевых сотрудников'
+        },
+        artifacts: [],
+        interest: 'medium',
+        availableFte: 0.05
+      },
+      {
+        id: 'hse-compliance',
+        level: 'C',
+        proofStatus: 'self-reported',
+        usage: {
+          from: '2022-09-01',
+          to: '2023-12-01',
+          description: 'Контроль соблюдения HSE требований во время ремонтов'
+        },
+        artifacts: [],
+        interest: 'medium',
+        availableFte: 0.05
+      }
+    ]
   },
   {
     id: 'expert-denis-laptev',
@@ -1475,7 +1818,47 @@ export const experts: ExpertProfile[] = [
       'Организовал программу развития аналитиков WWO Academy'
     ],
     availability: 'partial',
-    availabilityComment: 'Может вести до двух параллельных консалтинговых треков'
+    availabilityComment: 'Может вести до двух параллельных консалтинговых треков',
+    skills: [
+      {
+        id: 'wwo-analytics',
+        level: 'A',
+        proofStatus: 'verified',
+        usage: {
+          from: '2022-03-01',
+          to: '2024-03-25',
+          description: 'Разработка BI-дашбордов эффективности ремонтов'
+        },
+        artifacts: ['artifact-wwo-performance-dashboard'],
+        interest: 'high',
+        availableFte: 0.25
+      },
+      {
+        id: 'forecasting',
+        level: 'B',
+        proofStatus: 'in-review',
+        usage: {
+          from: '2023-02-01',
+          to: '2024-01-15',
+          description: 'Прогнозирование производственных эффектов от ремонтов'
+        },
+        artifacts: [],
+        interest: 'medium',
+        availableFte: 0.2
+      },
+      {
+        id: 'data-storytelling',
+        level: 'B',
+        proofStatus: 'self-reported',
+        usage: {
+          from: '2021-10-01',
+          description: 'Обучение аналитиков storytelling и презентации данных'
+        },
+        artifacts: [],
+        interest: 'high',
+        availableFte: 0.15
+      }
+    ]
   }
 ];
 

--- a/src/services/expertSkills.ts
+++ b/src/services/expertSkills.ts
@@ -1,0 +1,71 @@
+import type {
+  ExpertProfile,
+  ExpertSkill,
+  SkillEvidenceStatus
+} from '../data';
+
+/**
+ * Возвращает последнюю дату использования навыка.
+ * При наличии периода приоритет отдаётся дате окончания, иначе — дате начала.
+ */
+export const getSkillLastUsedDate = (skill: ExpertSkill): string | undefined => {
+  if (!skill.usage) {
+    return undefined;
+  }
+
+  const candidates = [skill.usage.to, skill.usage.from].filter(
+    (value): value is string => Boolean(value)
+  );
+
+  if (!candidates.length) {
+    return undefined;
+  }
+
+  const validDate = candidates.find((value) => !Number.isNaN(Date.parse(value)));
+  return validDate ?? candidates[0];
+};
+
+/**
+ * Определяет самую свежую дату применения навыков эксперта.
+ */
+export const getExpertLatestSkillFreshness = (
+  expert: ExpertProfile
+): string | undefined => {
+  const dates = expert.skills
+    .map(getSkillLastUsedDate)
+    .filter((value): value is string => Boolean(value))
+    .map((value) => ({
+      raw: value,
+      timestamp: Date.parse(value)
+    }))
+    .filter((value) => !Number.isNaN(value.timestamp));
+
+  if (!dates.length) {
+    return undefined;
+  }
+
+  return dates.sort((a, b) => b.timestamp - a.timestamp)[0].raw;
+};
+
+/**
+ * Фильтрует навыки по статусу подтверждения.
+ */
+export const filterSkillsByEvidenceStatus = (
+  skills: ExpertSkill[],
+  status: SkillEvidenceStatus | SkillEvidenceStatus[]
+): ExpertSkill[] => {
+  const statuses = Array.isArray(status) ? status : [status];
+  const uniqueStatuses = new Set(statuses);
+
+  return skills.filter((skill) => uniqueStatuses.has(skill.proofStatus));
+};
+
+/**
+ * Проверяет, есть ли у эксперта навыки с указанным статусом подтверждения.
+ */
+export const expertHasSkillsWithStatus = (
+  expert: ExpertProfile,
+  status: SkillEvidenceStatus | SkillEvidenceStatus[]
+): boolean => {
+  return filterSkillsByEvidenceStatus(expert.skills, status).length > 0;
+};


### PR DESCRIPTION
## Summary
- extend expert profiles with detailed skill metadata and sample usage data
- enrich the expert dataset with pilot skill entries including availability and evidence details
- add utilities to compute skill freshness and filter by evidence status

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f51cb89ac88332bbad23c77187f6f2