### PR TITLE
Add initiatives support to graph snapshots and persistence

### DIFF
--- a/server/graphStore.test.ts
+++ b/server/graphStore.test.ts
@@ -20,6 +20,7 @@ import {
 import {
   artifacts as initialArtifacts,
   domainTree as initialDomainTree,
+  initiatives as initialInitiatives,
   modules as initialModules,
   type ArtifactNode,
   type DomainNode,
@@ -55,6 +56,7 @@ test('seeds initial data when database is empty by default', { concurrency: fals
   assert.equal(snapshot.modules.length, initialModules.length);
   assert.equal(snapshot.domains.length, initialDomainTree.length);
   assert.equal(snapshot.artifacts.length, initialArtifacts.length);
+  assert.equal(snapshot.initiatives.length, initialInitiatives.length);
 });
 
 test('persists snapshots and reloads them from disk', { concurrency: false }, async () => {
@@ -173,6 +175,31 @@ test('persists snapshots and reloads them from disk', { concurrency: false }, as
         sampleUrl: 'https://example.com/sample.json'
       }
     ],
+    initiatives: [
+      {
+        id: 'initiative-alpha',
+        name: 'Initiative Alpha',
+        description: 'Первый пилот по объединению модулей.',
+        status: 'pilot',
+        owner: 'Product Office',
+        domainIds: ['root-domain'],
+        moduleIds: ['module-alpha'],
+        startDate: '2024-Q1',
+        targetDate: '2024-Q3',
+        expectedImpact: 'Повышение эффективности обмена данными'
+      },
+      {
+        id: 'initiative-beta',
+        name: 'Initiative Beta',
+        description: 'Масштабирование решения на смежные домены.',
+        status: 'idea',
+        owner: 'Digital Lab',
+        domainIds: ['child-domain'],
+        moduleIds: ['module-beta'],
+        startDate: '2024-Q2',
+        expectedImpact: 'Расширение набора аналитических сценариев'
+      }
+    ],
     layout: {
       nodes: {
         'module-alpha': { x: 10, y: 20, fx: 10, fy: 20 },
@@ -189,6 +216,7 @@ test('persists snapshots and reloads them from disk', { concurrency: false }, as
   assert.deepEqual(loaded.modules, storedSnapshot.modules);
   assert.deepEqual(loaded.domains, storedSnapshot.domains);
   assert.deepEqual(loaded.artifacts, storedSnapshot.artifacts);
+  assert.deepEqual(loaded.initiatives, storedSnapshot.initiatives);
   assert.deepEqual(loaded.layout, storedSnapshot.layout);
 
   closeGraphStore();
@@ -199,6 +227,7 @@ test('persists snapshots and reloads them from disk', { concurrency: false }, as
   assert.deepEqual(reloaded.modules, storedSnapshot.modules);
   assert.deepEqual(reloaded.domains, storedSnapshot.domains);
   assert.deepEqual(reloaded.artifacts, storedSnapshot.artifacts);
+  assert.deepEqual(reloaded.initiatives, storedSnapshot.initiatives);
   assert.deepEqual(reloaded.layout, storedSnapshot.layout);
 });
 
@@ -214,7 +243,8 @@ test('creates and deletes graphs with optional data copy', { concurrency: false 
     sourceGraphId: sourceGraph.id,
     includeDomains: true,
     includeModules: false,
-    includeArtifacts: true
+    includeArtifacts: true,
+    includeInitiatives: false
   });
 
   const graphsAfterCreate = listGraphs();
@@ -226,6 +256,8 @@ test('creates and deletes graphs with optional data copy', { concurrency: false 
   assert.equal(clonedSnapshot.domains.length > 0, true);
   assert.equal(clonedSnapshot.modules.length, 0);
   assert.equal(clonedSnapshot.artifacts.length, sourceSnapshot.artifacts.length);
+  assert.equal(sourceSnapshot.initiatives.length > 0, true);
+  assert.equal(clonedSnapshot.initiatives.length, 0);
 
   deleteGraph(clone.id);
   const graphsAfterDelete = listGraphs();
@@ -241,6 +273,7 @@ test('normalizes invalid layout entries on persist', { concurrency: false }, asy
     domains: [],
     modules: [],
     artifacts: [],
+    initiatives: [],
     layout: {
       nodes: {
         valid: { x: 1, y: 2, fx: Number.NaN, fy: 3 },
@@ -349,6 +382,7 @@ test('supports complex graph authoring flows', { concurrency: false }, async () 
     domains: [...snapshot.domains, newDomain],
     modules: [...snapshot.modules, newModule],
     artifacts: [...snapshot.artifacts, newArtifact],
+    initiatives: snapshot.initiatives,
     layout: {
       nodes: {
         ...snapshot.layout?.nodes,
@@ -387,6 +421,7 @@ test('removes persisted layout metadata when positions are absent', { concurrenc
     domains: [],
     modules: [],
     artifacts: [],
+    initiatives: [],
     layout: { nodes: {} }
   };
 

--- a/server/graphStore.ts
+++ b/server/graphStore.ts
@@ -4,10 +4,11 @@ import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { ArtifactNode, DomainNode, ModuleNode } from '../src/data';
+import type { ArtifactNode, DomainNode, InitiativeNode, ModuleNode } from '../src/data';
 import {
   artifacts as initialArtifacts,
   domainTree as initialDomainTree,
+  initiatives as initialInitiatives,
   modules as initialModules
 } from '../src/data';
 import {
@@ -55,6 +56,13 @@ type ModuleRow = {
 };
 
 type ArtifactRow = {
+  graph_id: string;
+  id: string;
+  data: string;
+  position: number;
+};
+
+type InitiativeRow = {
   graph_id: string;
   id: string;
   data: string;
@@ -122,6 +130,7 @@ export function createGraph(options: {
   includeDomains: boolean;
   includeModules: boolean;
   includeArtifacts: boolean;
+  includeInitiatives: boolean;
 }): GraphSummary {
   const database = assertDatabase();
   const now = new Date().toISOString();
@@ -141,6 +150,7 @@ export function createGraph(options: {
         domains: options.includeDomains ? sourceSnapshot.domains : [],
         modules: options.includeModules ? sourceSnapshot.modules : [],
         artifacts: options.includeArtifacts ? sourceSnapshot.artifacts : [],
+        initiatives: options.includeInitiatives ? sourceSnapshot.initiatives : [],
         layout:
           options.includeModules && sourceSnapshot.layout
             ? normalizeLayout(sourceSnapshot.layout)
@@ -260,6 +270,26 @@ export function loadSnapshot(graphId: string): GraphSnapshotPayload {
     artifactStatement.free();
   }
 
+  const initiativeStatement = database.prepare(
+    'SELECT graph_id, id, data, position FROM initiative_rows WHERE graph_id = ? ORDER BY position'
+  );
+  const initiativeRows: InitiativeRow[] = [];
+
+  try {
+    initiativeStatement.bind([graphId]);
+    while (initiativeStatement.step()) {
+      const row = initiativeStatement.getAsObject() as InitiativeRow;
+      initiativeRows.push({
+        graph_id: String(row.graph_id),
+        id: String(row.id),
+        data: String(row.data),
+        position: Number(row.position)
+      });
+    }
+  } finally {
+    initiativeStatement.free();
+  }
+
   const version = readMetadata(graphId, 'snapshotVersion');
   const exportedAt = readMetadata(graphId, 'updatedAt');
   const layoutRaw = readMetadata(graphId, 'layout');
@@ -271,6 +301,7 @@ export function loadSnapshot(graphId: string): GraphSnapshotPayload {
     domains: buildDomainTree(domainRows),
     modules: moduleRows.map((row) => JSON.parse(row.data) as ModuleNode),
     artifacts: artifactRows.map((row) => JSON.parse(row.data) as ArtifactNode),
+    initiatives: initiativeRows.map((row) => JSON.parse(row.data) as InitiativeNode),
     layout
   };
 }
@@ -306,7 +337,8 @@ export function isGraphSnapshotPayload(value: unknown): value is GraphSnapshotPa
   if (
     !Array.isArray(candidate.domains) ||
     !Array.isArray(candidate.modules) ||
-    !Array.isArray(candidate.artifacts)
+    !Array.isArray(candidate.artifacts) ||
+    (candidate.initiatives !== undefined && !Array.isArray(candidate.initiatives))
   ) {
     return false;
   }
@@ -380,6 +412,14 @@ function initializeSchema(): void {
     );
 
     CREATE TABLE IF NOT EXISTS artifacts (
+      graph_id TEXT NOT NULL REFERENCES graphs(id) ON DELETE CASCADE,
+      id TEXT NOT NULL,
+      position INTEGER NOT NULL,
+      data TEXT NOT NULL,
+      PRIMARY KEY (graph_id, id)
+    );
+
+    CREATE TABLE IF NOT EXISTS initiative_rows (
       graph_id TEXT NOT NULL REFERENCES graphs(id) ON DELETE CASCADE,
       id TEXT NOT NULL,
       position INTEGER NOT NULL,
@@ -482,8 +522,9 @@ function seedInitialData(): boolean {
   const domainCount = countRows(DEFAULT_GRAPH_ID, 'domains');
   const moduleCount = countRows(DEFAULT_GRAPH_ID, 'modules');
   const artifactCount = countRows(DEFAULT_GRAPH_ID, 'artifacts');
+  const initiativeCount = countRows(DEFAULT_GRAPH_ID, 'initiative_rows');
 
-  if (domainCount > 0 || moduleCount > 0 || artifactCount > 0) {
+  if (domainCount > 0 || moduleCount > 0 || artifactCount > 0 || initiativeCount > 0) {
     return false;
   }
 
@@ -492,14 +533,18 @@ function seedInitialData(): boolean {
     exportedAt: new Date().toISOString(),
     domains: initialDomainTree,
     modules: initialModules,
-    artifacts: initialArtifacts
+    artifacts: initialArtifacts,
+    initiatives: initialInitiatives
   };
 
   persistSnapshot(DEFAULT_GRAPH_ID, snapshot);
   return true;
 }
 
-function countRows(graphId: string, table: 'domains' | 'modules' | 'artifacts'): number {
+function countRows(
+  graphId: string,
+  table: 'domains' | 'modules' | 'artifacts' | 'initiative_rows'
+): number {
   const database = assertDatabase();
   const statement = database.prepare(`SELECT COUNT(*) as count FROM ${table} WHERE graph_id = ?`);
 
@@ -681,6 +726,7 @@ function writeSnapshot(database: SqlJsDatabase, graphId: string, snapshot: Graph
   database.run('DELETE FROM domains WHERE graph_id = ?', [graphId]);
   database.run('DELETE FROM modules WHERE graph_id = ?', [graphId]);
   database.run('DELETE FROM artifacts WHERE graph_id = ?', [graphId]);
+  database.run('DELETE FROM initiative_rows WHERE graph_id = ?', [graphId]);
 
   const domainRows = flattenDomains(snapshot.domains);
   const insertDomain = database.prepare(
@@ -724,6 +770,18 @@ function writeSnapshot(database: SqlJsDatabase, graphId: string, snapshot: Graph
     });
   } finally {
     insertArtifact.free();
+  }
+
+  const insertInitiative = database.prepare(
+    'INSERT INTO initiative_rows (graph_id, id, position, data) VALUES (?, ?, ?, ?)'
+  );
+
+  try {
+    (snapshot.initiatives ?? []).forEach((initiative, index) => {
+      insertInitiative.run([graphId, initiative.id, index, JSON.stringify(initiative)]);
+    });
+  } finally {
+    insertInitiative.free();
   }
 
   upsertMetadata(graphId, 'snapshotVersion', String(snapshot.version ?? GRAPH_SNAPSHOT_VERSION), database);

--- a/server/index.ts
+++ b/server/index.ts
@@ -28,7 +28,14 @@ app.get('/api/graphs', (_req: Request, res: Response) => {
 });
 
 app.post('/api/graphs', (req: Request, res: Response) => {
-  const { name, sourceGraphId, includeDomains, includeModules, includeArtifacts } = req.body ?? {};
+  const {
+    name,
+    sourceGraphId,
+    includeDomains,
+    includeModules,
+    includeArtifacts,
+    includeInitiatives
+  } = req.body ?? {};
 
   if (typeof name !== 'string') {
     res.status(400).json({ message: 'Название графа обязательно.' });
@@ -40,7 +47,8 @@ app.post('/api/graphs', (req: Request, res: Response) => {
     sourceGraphId: typeof sourceGraphId === 'string' && sourceGraphId.length > 0 ? sourceGraphId : undefined,
     includeDomains: Boolean(includeDomains ?? true),
     includeModules: Boolean(includeModules ?? true),
-    includeArtifacts: Boolean(includeArtifacts ?? true)
+    includeArtifacts: Boolean(includeArtifacts ?? true),
+    includeInitiatives: Boolean(includeInitiatives ?? true)
   } as const;
 
   try {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,11 +50,13 @@ import {
   artifacts as initialArtifacts,
   domainTree as initialDomainTree,
   experts as initialExperts,
+  initiatives as initialInitiatives,
   modules as initialModules,
   reuseIndexHistory,
   type ArtifactNode,
   type DomainNode,
   type GraphLink,
+  type InitiativeNode,
   type ModuleMetrics,
   type ModuleNode,
   type ModuleStatus,
@@ -95,6 +97,7 @@ function App() {
     recalculateReuseScores(initialModules)
   );
   const [artifactData, setArtifactData] = useState<ArtifactNode[]>(initialArtifacts);
+  const [initiativeData, setInitiativeData] = useState<InitiativeNode[]>(initialInitiatives);
   const [expertProfiles] = useState(initialExperts);
   const [selectedDomains, setSelectedDomains] = useState<Set<string>>(
     () => new Set(flattenDomainTree(initialDomainTree).map((domain) => domain.id))
@@ -138,8 +141,8 @@ function App() {
   const [graphNameDraft, setGraphNameDraft] = useState('');
   const [graphSourceIdDraft, setGraphSourceIdDraft] = useState<string | null>(null);
   const [graphCopyOptions, setGraphCopyOptions] = useState<
-    Set<'domains' | 'modules' | 'artifacts'>
-  >(() => new Set(['domains', 'modules', 'artifacts']));
+    Set<'domains' | 'modules' | 'artifacts' | 'initiatives'>
+  >(() => new Set(['domains', 'modules', 'artifacts', 'initiatives']));
   const [isGraphActionInProgress, setIsGraphActionInProgress] = useState(false);
   const [graphActionStatus, setGraphActionStatus] = useState<
     { type: 'success' | 'error'; message: string } | null
@@ -229,6 +232,7 @@ function App() {
       setDomainData(snapshot.domains);
       setModuleDataState(recalculateReuseScores(snapshot.modules));
       setArtifactData(snapshot.artifacts);
+      setInitiativeData(snapshot.initiatives ?? []);
       setSelectedNode(null);
       setSearch('');
       setStatusFilters(new Set(allStatuses));
@@ -632,6 +636,7 @@ function App() {
         modules: moduleData,
         domains: domainData,
         artifacts: artifactData,
+        initiatives: initiativeData,
         layout: { nodes: layoutPositions }
       },
       controller.signal
@@ -669,6 +674,7 @@ function App() {
     };
   }, [
     artifactData,
+    initiativeData,
     domainData,
     moduleData,
     isSyncAvailable,
@@ -752,7 +758,8 @@ function App() {
       [
         { id: 'domains' as const, label: 'Домены' },
         { id: 'modules' as const, label: 'Модули' },
-        { id: 'artifacts' as const, label: 'Артефакты' }
+        { id: 'artifacts' as const, label: 'Артефакты' },
+        { id: 'initiatives' as const, label: 'Инициативы' }
       ],
     []
   );
@@ -2000,6 +2007,7 @@ function App() {
       includeDomains: boolean;
       includeModules: boolean;
       includeArtifacts: boolean;
+      includeInitiatives: boolean;
     }) => {
       try {
         const snapshot = await importGraphFromSource(request);
@@ -2010,7 +2018,8 @@ function App() {
         return {
           domains: snapshot.domains.length,
           modules: snapshot.modules.length,
-          artifacts: snapshot.artifacts.length
+          artifacts: snapshot.artifacts.length,
+          initiatives: snapshot.initiatives.length
         };
       } catch (error) {
         const message =
@@ -2054,8 +2063,15 @@ function App() {
     const includeDomains = graphCopyOptions.has('domains');
     const includeModules = graphCopyOptions.has('modules');
     const includeArtifacts = graphCopyOptions.has('artifacts');
+    const includeInitiatives = graphCopyOptions.has('initiatives');
 
-    if (graphSourceIdDraft && !includeDomains && !includeModules && !includeArtifacts) {
+    if (
+      graphSourceIdDraft &&
+      !includeDomains &&
+      !includeModules &&
+      !includeArtifacts &&
+      !includeInitiatives
+    ) {
       setGraphActionStatus({
         type: 'error',
         message: 'Выберите хотя бы один тип данных для копирования из выбранного графа.'
@@ -2070,7 +2086,8 @@ function App() {
         sourceGraphId: graphSourceIdDraft ?? undefined,
         includeDomains,
         includeModules,
-        includeArtifacts
+        includeArtifacts,
+        includeInitiatives
       });
       setGraphActionStatus({
         type: 'success',
@@ -2078,7 +2095,7 @@ function App() {
       });
       setGraphNameDraft('');
       setGraphSourceIdDraft(null);
-      setGraphCopyOptions(new Set(['domains', 'modules', 'artifacts']));
+      setGraphCopyOptions(new Set(['domains', 'modules', 'artifacts', 'initiatives']));
       setIsCreatePanelOpen(false);
       await refreshGraphs(created.id, { preserveSelection: false });
       showAdminNotice('success', `Граф «${created.name}» создан.`);
@@ -2564,6 +2581,7 @@ function App() {
           modules={moduleData}
           domains={domainData}
           artifacts={artifactData}
+          initiatives={initiativeData}
           onImport={handleImportGraph}
           onImportFromGraph={handleImportFromExistingGraph}
           graphs={graphs}

--- a/src/components/GraphPersistenceControls.tsx
+++ b/src/components/GraphPersistenceControls.tsx
@@ -4,7 +4,7 @@ import { CheckboxGroup } from '@consta/uikit/CheckboxGroup';
 import { Select } from '@consta/uikit/Select';
 import { Text } from '@consta/uikit/Text';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { ArtifactNode, DomainNode, ModuleNode } from '../data';
+import type { ArtifactNode, DomainNode, InitiativeNode, ModuleNode } from '../data';
 import { normalizeLayoutSnapshot } from '../services/graphStorage';
 import {
   GRAPH_SNAPSHOT_VERSION,
@@ -23,13 +23,20 @@ type GraphPersistenceControlsProps = {
   modules: ModuleNode[];
   domains: DomainNode[];
   artifacts: ArtifactNode[];
+  initiatives: InitiativeNode[];
   onImport: (snapshot: GraphSnapshotPayload) => void;
   onImportFromGraph?: (request: {
     graphId: string;
     includeDomains: boolean;
     includeModules: boolean;
     includeArtifacts: boolean;
-  }) => Promise<{ domains: number; modules: number; artifacts: number }>;
+    includeInitiatives: boolean;
+  }) => Promise<{
+    domains: number;
+    modules: number;
+    artifacts: number;
+    initiatives: number;
+  }>;
   graphs?: GraphSummary[];
   activeGraphId?: string | null;
   isGraphListLoading?: boolean;
@@ -41,6 +48,7 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
   modules,
   domains,
   artifacts,
+  initiatives,
   onImport,
   onImportFromGraph,
   graphs,
@@ -52,8 +60,9 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [status, setStatus] = useState<StatusMessage | null>(null);
   const [sourceGraphId, setSourceGraphId] = useState<string | null>(null);
-  const [copyOptions, setCopyOptions] = useState<Set<'domains' | 'modules' | 'artifacts'>>(
-    () => new Set(['domains', 'modules', 'artifacts'])
+  const [copyOptions, setCopyOptions] = useState<
+    Set<'domains' | 'modules' | 'artifacts' | 'initiatives'>
+  >(() => new Set(['domains', 'modules', 'artifacts', 'initiatives']))
   );
   const [isGraphImporting, setIsGraphImporting] = useState(false);
 
@@ -65,9 +74,10 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
       modules,
       domains,
       artifacts,
+      initiatives,
       layout: sanitizedLayout
     };
-  }, [artifacts, domains, layout, modules]);
+  }, [artifacts, domains, initiatives, layout, modules]);
 
   const handleExport = () => {
     try {
@@ -119,9 +129,10 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
         const moduleCount = normalized.modules.length;
         const domainCount = normalized.domains.length;
         const artifactCount = normalized.artifacts.length;
+        const initiativeCount = normalized.initiatives.length;
         setStatus({
           type: 'success',
-          message: `Импорт завершён. Модулей: ${moduleCount}, доменов: ${domainCount}, артефактов: ${artifactCount}.`
+          message: `Импорт завершён. Модулей: ${moduleCount}, доменов: ${domainCount}, артефактов: ${artifactCount}, инициатив: ${initiativeCount}.`
         });
       } catch (error) {
         setStatus({
@@ -169,7 +180,8 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
       [
         { id: 'domains' as const, label: 'Домены' },
         { id: 'modules' as const, label: 'Модули' },
-        { id: 'artifacts' as const, label: 'Артефакты' }
+        { id: 'artifacts' as const, label: 'Артефакты' },
+        { id: 'initiatives' as const, label: 'Инициативы' }
       ],
     []
   );
@@ -204,12 +216,13 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
         graphId: sourceGraphId,
         includeDomains: copyOptions.has('domains'),
         includeModules: copyOptions.has('modules'),
-        includeArtifacts: copyOptions.has('artifacts')
+        includeArtifacts: copyOptions.has('artifacts'),
+        includeInitiatives: copyOptions.has('initiatives')
       });
       const graphName = graphs?.find((graph) => graph.id === sourceGraphId)?.name ?? 'выбранного графа';
       setStatus({
         type: 'success',
-        message: `Импорт завершён из графа «${graphName}». Модулей: ${result.modules}, доменов: ${result.domains}, артефактов: ${result.artifacts}.`
+        message: `Импорт завершён из графа «${graphName}». Модулей: ${result.modules}, доменов: ${result.domains}, артефактов: ${result.artifacts}, инициатив: ${result.initiatives}.`
       });
     } catch (error) {
       setStatus({
@@ -361,6 +374,7 @@ type GraphSnapshotLike = {
   modules: ModuleNode[];
   domains: DomainNode[];
   artifacts: ArtifactNode[];
+  initiatives?: InitiativeNode[];
   layout?: GraphSnapshotPayload['layout'];
 };
 
@@ -370,7 +384,12 @@ function isGraphSnapshotLike(value: unknown): value is GraphSnapshotLike {
   }
 
   const candidate = value as Partial<GraphSnapshotPayload>;
-  if (!Array.isArray(candidate.modules) || !Array.isArray(candidate.domains) || !Array.isArray(candidate.artifacts)) {
+  if (
+    !Array.isArray(candidate.modules) ||
+    !Array.isArray(candidate.domains) ||
+    !Array.isArray(candidate.artifacts) ||
+    (candidate.initiatives !== undefined && !Array.isArray(candidate.initiatives))
+  ) {
     return false;
   }
 
@@ -391,6 +410,7 @@ function normalizeImportedSnapshot(snapshot: GraphSnapshotLike): GraphSnapshotPa
     modules: snapshot.modules,
     domains: snapshot.domains,
     artifacts: snapshot.artifacts,
+    initiatives: Array.isArray(snapshot.initiatives) ? snapshot.initiatives : [],
     layout: normalizeLayoutSnapshot(snapshot.layout) ?? undefined
   };
 }

--- a/src/data.ts
+++ b/src/data.ts
@@ -128,6 +128,21 @@ export type ModuleNode = {
   nonFunctional: NonFunctionalRequirements;
 };
 
+export type InitiativeStatus = 'idea' | 'pilot' | 'scale';
+
+export type InitiativeNode = {
+  id: string;
+  name: string;
+  description: string;
+  status: InitiativeStatus;
+  owner: string;
+  domainIds: string[];
+  moduleIds: string[];
+  startDate: string;
+  targetDate?: string;
+  expectedImpact: string;
+};
+
 export const domainTree: DomainNode[] = [
   {
     id: 'upstream',
@@ -1599,6 +1614,34 @@ export const artifacts: ArtifactNode[] = [
     consumerIds: [],
     dataType: 'Power BI',
     sampleUrl: 'https://storage.nedra.digital/samples/wwo-performance-dashboard.pdf'
+  }
+];
+
+export const initiatives: InitiativeNode[] = [
+  {
+    id: 'initiative-ai-exploration',
+    name: 'ML-разведка новых месторождений',
+    description:
+      'Пилотный проект по внедрению ML-моделей для интерпретации геолого-геофизических данных и ускоренного выявления перспективных участков.',
+    status: 'pilot',
+    owner: 'Дирекция цифровой трансформации',
+    domainIds: ['seismic-interpretation', 'resource-evaluation'],
+    moduleIds: ['module-infraplan-datahub', 'module-infraplan-layout'],
+    startDate: '2024-Q1',
+    targetDate: '2024-Q4',
+    expectedImpact: 'Сокращение цикла анализа запасов на 30%'
+  },
+  {
+    id: 'initiative-digital-twin-expansion',
+    name: 'Расширение цифровых двойников добычи',
+    description:
+      'Масштабирование платформы цифровых двойников на новые промыслы с интеграцией мониторинга и предиктивной аналитики.',
+    status: 'scale',
+    owner: 'Проектный офис производственной эффективности',
+    domainIds: ['development-scenarios'],
+    moduleIds: ['module-dtwin-monitoring', 'module-dtwin-optimizer'],
+    startDate: '2023-Q3',
+    expectedImpact: 'Рост производственной эффективности на 12%'
   }
 ];
 

--- a/src/services/graphStorage.ts
+++ b/src/services/graphStorage.ts
@@ -32,6 +32,7 @@ export async function createGraph(
     includeDomains: boolean;
     includeModules: boolean;
     includeArtifacts: boolean;
+    includeInitiatives: boolean;
   },
   signal?: AbortSignal
 ): Promise<GraphSummary> {
@@ -84,6 +85,7 @@ export async function fetchGraphSnapshot(
     modules: snapshot.modules,
     domains: snapshot.domains,
     artifacts: snapshot.artifacts,
+    initiatives: snapshot.initiatives ?? [],
     layout: normalizeLayoutSnapshot(snapshot.layout)
   };
 }
@@ -160,6 +162,7 @@ export async function importGraphFromSource(
     domains: request.includeDomains ? snapshot.domains : [],
     modules: request.includeModules ? snapshot.modules : [],
     artifacts: request.includeArtifacts ? snapshot.artifacts : [],
+    initiatives: request.includeInitiatives ? snapshot.initiatives ?? [] : [],
     layout:
       request.includeModules && snapshot.layout
         ? normalizeLayoutSnapshot(snapshot.layout) ?? undefined

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -1,6 +1,6 @@
-import type { ArtifactNode, DomainNode, ModuleNode } from '../data';
+import type { ArtifactNode, DomainNode, InitiativeNode, ModuleNode } from '../data';
 
-export const GRAPH_SNAPSHOT_VERSION = 1;
+export const GRAPH_SNAPSHOT_VERSION = 2;
 
 export type GraphLayoutNodePosition = {
   x: number;
@@ -19,6 +19,7 @@ export type GraphSnapshotPayload = {
   modules: ModuleNode[];
   domains: DomainNode[];
   artifacts: ArtifactNode[];
+  initiatives: InitiativeNode[];
   layout?: GraphLayoutSnapshot;
 };
 
@@ -40,4 +41,5 @@ export type GraphCopyRequest = {
   includeDomains: boolean;
   includeModules: boolean;
   includeArtifacts: boolean;
+  includeInitiatives: boolean;
 };


### PR DESCRIPTION
## Summary
- add initiative data to the graph snapshot schema and seed data
- extend the graph store and REST API to persist and copy initiatives alongside other entities
- update client import/export flows to handle initiative lists when working with snapshots

## Testing
- npm run test:server

------
https://chatgpt.com/codex/tasks/task_e_68f51cb9963c833289c277c63feeff05