### PR TITLE
Add initiatives to the graph and update node details

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,11 +50,13 @@ import {
   artifacts as initialArtifacts,
   domainTree as initialDomainTree,
   experts as initialExperts,
+  initiatives as initialInitiatives,
   modules as initialModules,
   reuseIndexHistory,
   type ArtifactNode,
   type DomainNode,
   type GraphLink,
+  type InitiativeNode,
   type ModuleMetrics,
   type ModuleNode,
   type ModuleStatus,
@@ -95,6 +97,7 @@ function App() {
     recalculateReuseScores(initialModules)
   );
   const [artifactData, setArtifactData] = useState<ArtifactNode[]>(initialArtifacts);
+  const [initiativeData, setInitiativeData] = useState<InitiativeNode[]>(initialInitiatives);
   const [expertProfiles] = useState(initialExperts);
   const [selectedDomains, setSelectedDomains] = useState<Set<string>>(
     () => new Set(flattenDomainTree(initialDomainTree).map((domain) => domain.id))
@@ -138,8 +141,8 @@ function App() {
   const [graphNameDraft, setGraphNameDraft] = useState('');
   const [graphSourceIdDraft, setGraphSourceIdDraft] = useState<string | null>(null);
   const [graphCopyOptions, setGraphCopyOptions] = useState<
-    Set<'domains' | 'modules' | 'artifacts'>
-  >(() => new Set(['domains', 'modules', 'artifacts']));
+    Set<'domains' | 'modules' | 'artifacts' | 'initiatives'>
+  >(() => new Set(['domains', 'modules', 'artifacts', 'initiatives']));
   const [isGraphActionInProgress, setIsGraphActionInProgress] = useState(false);
   const [graphActionStatus, setGraphActionStatus] = useState<
     { type: 'success' | 'error'; message: string } | null
@@ -225,10 +228,12 @@ function App() {
       const activeNodeIds = new Set<string>([...domainIds]);
       snapshot.modules.forEach((module) => activeNodeIds.add(module.id));
       snapshot.artifacts.forEach((artifact) => activeNodeIds.add(artifact.id));
+      (snapshot.initiatives ?? []).forEach((initiative) => activeNodeIds.add(initiative.id));
 
       setDomainData(snapshot.domains);
       setModuleDataState(recalculateReuseScores(snapshot.modules));
       setArtifactData(snapshot.artifacts);
+      setInitiativeData(snapshot.initiatives ?? []);
       setSelectedNode(null);
       setSearch('');
       setStatusFilters(new Set(allStatuses));
@@ -632,6 +637,7 @@ function App() {
         modules: moduleData,
         domains: domainData,
         artifacts: artifactData,
+        initiatives: initiativeData,
         layout: { nodes: layoutPositions }
       },
       controller.signal
@@ -669,6 +675,7 @@ function App() {
     };
   }, [
     artifactData,
+    initiativeData,
     domainData,
     moduleData,
     isSyncAvailable,
@@ -752,7 +759,8 @@ function App() {
       [
         { id: 'domains' as const, label: 'Домены' },
         { id: 'modules' as const, label: 'Модули' },
-        { id: 'artifacts' as const, label: 'Артефакты' }
+        { id: 'artifacts' as const, label: 'Артефакты' },
+        { id: 'initiatives' as const, label: 'Инициативы' }
       ],
     []
   );
@@ -846,6 +854,11 @@ function App() {
       return ids;
     }
 
+    if (selectedNode.type === 'initiative') {
+      selectedNode.plannedModuleIds.forEach((moduleId) => ids.add(moduleId));
+      return ids;
+    }
+
     if (selectedNode.type === 'domain') {
       moduleData.forEach((module) => {
         if (module.domains.includes(selectedNode.id)) {
@@ -888,6 +901,20 @@ function App() {
       });
     }
 
+    initiativeData.forEach((initiative) => {
+      const matchesSelectedDomain = initiative.domains.some((domainId) =>
+        selectedDomains.has(domainId)
+      );
+
+      if (!matchesSelectedDomain) {
+        return;
+      }
+
+      initiative.plannedModuleIds.forEach((moduleId) => {
+        extraModuleIds.add(moduleId);
+      });
+    });
+
     if (extraModuleIds.size === 0) {
       return filteredModules;
     }
@@ -921,8 +948,28 @@ function App() {
     showAllConnections,
     artifactMap,
     moduleDependents,
-    companyFilter
+    companyFilter,
+    initiativeData,
+    selectedDomains
   ]);
+
+  const graphInitiatives = useMemo(() => {
+    const visibleModuleIds = new Set(graphModules.map((module) => module.id));
+    const selectedInitiativeId = selectedNode?.type === 'initiative' ? selectedNode.id : null;
+
+    return initiativeData.filter((initiative) => {
+      const matchesDomain = initiative.domains.some((domainId) => selectedDomains.has(domainId));
+      const matchesModules = initiative.plannedModuleIds.some((moduleId) =>
+        visibleModuleIds.has(moduleId)
+      );
+
+      if (matchesDomain || matchesModules) {
+        return true;
+      }
+
+      return selectedInitiativeId === initiative.id;
+    });
+  }, [graphModules, initiativeData, selectedDomains, selectedNode]);
 
   const relevantDomainIds = useMemo(() => {
     const ids = new Set<string>();
@@ -941,12 +988,16 @@ function App() {
       module.domains.forEach((domainId) => addWithAncestors(domainId));
     });
 
+    graphInitiatives.forEach((initiative) => {
+      initiative.domains.forEach((domainId) => addWithAncestors(domainId));
+    });
+
     if (highlightedDomainId) {
       addWithAncestors(highlightedDomainId);
     }
 
     return ids;
-  }, [graphModules, highlightedDomainId, domainAncestors, selectedDomains]);
+  }, [graphModules, graphInitiatives, highlightedDomainId, domainAncestors, selectedDomains]);
 
   const graphDomains = useMemo(
     () => filterDomainTreeByIds(domainData, relevantDomainIds),
@@ -987,14 +1038,18 @@ function App() {
   }, [artifactData, graphModules, selectedNode]);
 
   const graphLinksAll = useMemo(
-    () => buildModuleLinks(moduleData, artifactData, displayableDomainIdSet),
-    [moduleData, artifactData, displayableDomainIdSet]
+    () => [
+      ...buildModuleLinks(moduleData, artifactData, displayableDomainIdSet),
+      ...buildInitiativeLinks(initiativeData, displayableDomainIdSet)
+    ],
+    [moduleData, artifactData, initiativeData, displayableDomainIdSet]
   );
 
   const filteredLinks = useMemo(() => {
     const moduleIds = new Set(graphModules.map((module) => module.id));
     const artifactIds = new Set(graphArtifacts.map((artifact) => artifact.id));
     const domainIds = relevantDomainIds.size > 0 ? relevantDomainIds : null;
+    const initiativeIds = new Set(graphInitiatives.map((initiative) => initiative.id));
 
     return graphLinksAll.filter((link) => {
       const sourceId = getLinkEndpointId(link.source);
@@ -1034,12 +1089,29 @@ function App() {
         return Boolean(producerProduct && consumerProduct && producerProduct === consumerProduct);
       }
 
+      if (link.type === 'initiative-domain') {
+        if (!initiativeIds.has(sourceId)) {
+          return false;
+        }
+
+        if (domainIds && !domainIds.has(targetId)) {
+          return false;
+        }
+
+        return true;
+      }
+
+      if (link.type === 'initiative-plan') {
+        return initiativeIds.has(sourceId) && moduleIds.has(targetId);
+      }
+
       return false;
     });
   }, [
     artifactMap,
     graphArtifacts,
     graphLinksAll,
+    graphInitiatives,
     graphModules,
     moduleById,
     relevantDomainIds,
@@ -2000,6 +2072,7 @@ function App() {
       includeDomains: boolean;
       includeModules: boolean;
       includeArtifacts: boolean;
+      includeInitiatives: boolean;
     }) => {
       try {
         const snapshot = await importGraphFromSource(request);
@@ -2010,7 +2083,8 @@ function App() {
         return {
           domains: snapshot.domains.length,
           modules: snapshot.modules.length,
-          artifacts: snapshot.artifacts.length
+          artifacts: snapshot.artifacts.length,
+          initiatives: snapshot.initiatives?.length ?? 0
         };
       } catch (error) {
         const message =
@@ -2054,8 +2128,15 @@ function App() {
     const includeDomains = graphCopyOptions.has('domains');
     const includeModules = graphCopyOptions.has('modules');
     const includeArtifacts = graphCopyOptions.has('artifacts');
+    const includeInitiatives = graphCopyOptions.has('initiatives');
 
-    if (graphSourceIdDraft && !includeDomains && !includeModules && !includeArtifacts) {
+    if (
+      graphSourceIdDraft &&
+      !includeDomains &&
+      !includeModules &&
+      !includeArtifacts &&
+      !includeInitiatives
+    ) {
       setGraphActionStatus({
         type: 'error',
         message: 'Выберите хотя бы один тип данных для копирования из выбранного графа.'
@@ -2070,7 +2151,8 @@ function App() {
         sourceGraphId: graphSourceIdDraft ?? undefined,
         includeDomains,
         includeModules,
-        includeArtifacts
+        includeArtifacts,
+        includeInitiatives
       });
       setGraphActionStatus({
         type: 'success',
@@ -2078,7 +2160,7 @@ function App() {
       });
       setGraphNameDraft('');
       setGraphSourceIdDraft(null);
-      setGraphCopyOptions(new Set(['domains', 'modules', 'artifacts']));
+      setGraphCopyOptions(new Set(['domains', 'modules', 'artifacts', 'initiatives']));
       setIsCreatePanelOpen(false);
       await refreshGraphs(created.id, { preserveSelection: false });
       showAdminNotice('success', `Граф «${created.name}» создан.`);
@@ -2501,10 +2583,12 @@ function App() {
                 modules={graphModules}
                 domains={graphDomains}
                 artifacts={graphArtifacts}
+                initiatives={graphInitiatives}
                 links={filteredLinks}
                 onSelect={handleSelectNode}
                 highlightedNode={selectedNode?.id ?? null}
                 visibleDomainIds={relevantDomainIds}
+                visibleModuleStatuses={statusFilters}
                 layoutPositions={layoutPositions}
                 onLayoutChange={handleLayoutChange}
               />
@@ -2564,6 +2648,7 @@ function App() {
           modules={moduleData}
           domains={domainData}
           artifacts={artifactData}
+          initiatives={initiativeData}
           onImport={handleImportGraph}
           onImportFromGraph={handleImportFromExistingGraph}
           graphs={graphs}
@@ -3119,6 +3204,29 @@ function buildModuleLinks(
       }));
 
     return [...domainLinks, ...dependencyLinks, ...produceLinks, ...consumeLinks];
+  });
+}
+
+function buildInitiativeLinks(
+  initiatives: InitiativeNode[],
+  allowedDomainIds: Set<string>
+): GraphLink[] {
+  return initiatives.flatMap((initiative) => {
+    const domainLinks: GraphLink[] = initiative.domains
+      .filter((domainId) => allowedDomainIds.has(domainId))
+      .map((domainId) => ({
+        source: initiative.id,
+        target: domainId,
+        type: 'initiative-domain'
+      }));
+
+    const moduleLinks: GraphLink[] = initiative.plannedModuleIds.map((moduleId) => ({
+      source: initiative.id,
+      target: moduleId,
+      type: 'initiative-plan'
+    }));
+
+    return [...domainLinks, ...moduleLinks];
   });
 }
 

--- a/src/components/GraphPersistenceControls.tsx
+++ b/src/components/GraphPersistenceControls.tsx
@@ -4,7 +4,7 @@ import { CheckboxGroup } from '@consta/uikit/CheckboxGroup';
 import { Select } from '@consta/uikit/Select';
 import { Text } from '@consta/uikit/Text';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { ArtifactNode, DomainNode, ModuleNode } from '../data';
+import type { ArtifactNode, DomainNode, InitiativeNode, ModuleNode } from '../data';
 import { normalizeLayoutSnapshot } from '../services/graphStorage';
 import {
   GRAPH_SNAPSHOT_VERSION,
@@ -23,13 +23,15 @@ type GraphPersistenceControlsProps = {
   modules: ModuleNode[];
   domains: DomainNode[];
   artifacts: ArtifactNode[];
+  initiatives: InitiativeNode[];
   onImport: (snapshot: GraphSnapshotPayload) => void;
   onImportFromGraph?: (request: {
     graphId: string;
     includeDomains: boolean;
     includeModules: boolean;
     includeArtifacts: boolean;
-  }) => Promise<{ domains: number; modules: number; artifacts: number }>;
+    includeInitiatives: boolean;
+  }) => Promise<{ domains: number; modules: number; artifacts: number; initiatives: number }>;
   graphs?: GraphSummary[];
   activeGraphId?: string | null;
   isGraphListLoading?: boolean;
@@ -41,6 +43,7 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
   modules,
   domains,
   artifacts,
+  initiatives,
   onImport,
   onImportFromGraph,
   graphs,
@@ -52,9 +55,9 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [status, setStatus] = useState<StatusMessage | null>(null);
   const [sourceGraphId, setSourceGraphId] = useState<string | null>(null);
-  const [copyOptions, setCopyOptions] = useState<Set<'domains' | 'modules' | 'artifacts'>>(
-    () => new Set(['domains', 'modules', 'artifacts'])
-  );
+  const [copyOptions, setCopyOptions] = useState<
+    Set<'domains' | 'modules' | 'artifacts' | 'initiatives'>
+  >(() => new Set(['domains', 'modules', 'artifacts', 'initiatives']));
   const [isGraphImporting, setIsGraphImporting] = useState(false);
 
   const buildSnapshot = useCallback((): GraphSnapshotPayload => {
@@ -65,9 +68,10 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
       modules,
       domains,
       artifacts,
+      initiatives,
       layout: sanitizedLayout
     };
-  }, [artifacts, domains, layout, modules]);
+  }, [artifacts, domains, initiatives, layout, modules]);
 
   const handleExport = () => {
     try {
@@ -119,9 +123,10 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
         const moduleCount = normalized.modules.length;
         const domainCount = normalized.domains.length;
         const artifactCount = normalized.artifacts.length;
+        const initiativeCount = normalized.initiatives?.length ?? 0;
         setStatus({
           type: 'success',
-          message: `Импорт завершён. Модулей: ${moduleCount}, доменов: ${domainCount}, артефактов: ${artifactCount}.`
+          message: `Импорт завершён. Модулей: ${moduleCount}, доменов: ${domainCount}, артефактов: ${artifactCount}, инициатив: ${initiativeCount}.`
         });
       } catch (error) {
         setStatus({
@@ -169,7 +174,8 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
       [
         { id: 'domains' as const, label: 'Домены' },
         { id: 'modules' as const, label: 'Модули' },
-        { id: 'artifacts' as const, label: 'Артефакты' }
+        { id: 'artifacts' as const, label: 'Артефакты' },
+        { id: 'initiatives' as const, label: 'Инициативы' }
       ],
     []
   );
@@ -204,12 +210,13 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
         graphId: sourceGraphId,
         includeDomains: copyOptions.has('domains'),
         includeModules: copyOptions.has('modules'),
-        includeArtifacts: copyOptions.has('artifacts')
+        includeArtifacts: copyOptions.has('artifacts'),
+        includeInitiatives: copyOptions.has('initiatives')
       });
       const graphName = graphs?.find((graph) => graph.id === sourceGraphId)?.name ?? 'выбранного графа';
       setStatus({
         type: 'success',
-        message: `Импорт завершён из графа «${graphName}». Модулей: ${result.modules}, доменов: ${result.domains}, артефактов: ${result.artifacts}.`
+        message: `Импорт завершён из графа «${graphName}». Модулей: ${result.modules}, доменов: ${result.domains}, артефактов: ${result.artifacts}, инициатив: ${result.initiatives}.`
       });
     } catch (error) {
       setStatus({
@@ -361,6 +368,7 @@ type GraphSnapshotLike = {
   modules: ModuleNode[];
   domains: DomainNode[];
   artifacts: ArtifactNode[];
+  initiatives?: InitiativeNode[];
   layout?: GraphSnapshotPayload['layout'];
 };
 
@@ -371,6 +379,10 @@ function isGraphSnapshotLike(value: unknown): value is GraphSnapshotLike {
 
   const candidate = value as Partial<GraphSnapshotPayload>;
   if (!Array.isArray(candidate.modules) || !Array.isArray(candidate.domains) || !Array.isArray(candidate.artifacts)) {
+    return false;
+  }
+
+  if (candidate.initiatives !== undefined && !Array.isArray(candidate.initiatives)) {
     return false;
   }
 
@@ -391,6 +403,7 @@ function normalizeImportedSnapshot(snapshot: GraphSnapshotLike): GraphSnapshotPa
     modules: snapshot.modules,
     domains: snapshot.domains,
     artifacts: snapshot.artifacts,
+    initiatives: snapshot.initiatives ?? [],
     layout: normalizeLayoutSnapshot(snapshot.layout) ?? undefined
   };
 }

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -7,13 +7,21 @@ import ForceGraph2D, {
   LinkObject,
   NodeObject
 } from 'react-force-graph-2d';
-import type { ArtifactNode, DomainNode, GraphLink, ModuleNode } from '../data';
+import type {
+  ArtifactNode,
+  DomainNode,
+  GraphLink,
+  InitiativeNode,
+  ModuleNode,
+  ModuleStatus
+} from '../data';
 import type { GraphLayoutNodePosition } from '../types/graph';
 import styles from './GraphView.module.css';
 
 type GraphNode =
   | ({ type: 'module' } & ModuleNode)
   | ({ type: 'domain' } & DomainNode)
+  | ({ type: 'initiative' } & InitiativeNode)
   | ({ type: 'artifact'; reuseScore?: number } & ArtifactNode);
 
 type LayoutChangeReason = 'drag' | 'engine';
@@ -22,10 +30,12 @@ type GraphViewProps = {
   modules: ModuleNode[];
   domains: DomainNode[];
   artifacts: ArtifactNode[];
+  initiatives: InitiativeNode[];
   links: GraphLink[];
   onSelect: (node: GraphNode | null) => void;
   highlightedNode: string | null;
   visibleDomainIds: Set<string>;
+  visibleModuleStatuses: Set<ModuleStatus>;
   layoutPositions: Record<string, GraphLayoutNodePosition>;
   onLayoutChange?: (
     positions: Record<string, GraphLayoutNodePosition>,
@@ -45,10 +55,12 @@ const GraphView: React.FC<GraphViewProps> = ({
   modules,
   domains,
   artifacts,
+  initiatives,
   links,
   onSelect,
   highlightedNode,
   visibleDomainIds,
+  visibleModuleStatuses,
   layoutPositions,
   onLayoutChange
 }) => {
@@ -158,6 +170,16 @@ const GraphView: React.FC<GraphViewProps> = ({
     [modules]
   );
 
+  const moduleStatusMap = useMemo(() => {
+    const map = new Map<string, ModuleStatus>();
+    moduleNodes.forEach((node) => {
+      if (node.type === 'module') {
+        map.set(node.id, node.status);
+      }
+    });
+    return map;
+  }, [moduleNodes]);
+
   const artifactNodes = useMemo<GraphNode[]>(
     () =>
       artifacts.map((artifact) => ({
@@ -166,6 +188,15 @@ const GraphView: React.FC<GraphViewProps> = ({
         reuseScore: 0
       })),
     [artifacts]
+  );
+
+  const initiativeNodes = useMemo<GraphNode[]>(
+    () =>
+      initiatives.map((initiative) => ({
+        ...initiative,
+        type: 'initiative'
+      })),
+    [initiatives]
   );
 
   const nodes = useMemo(() => {
@@ -189,9 +220,10 @@ const GraphView: React.FC<GraphViewProps> = ({
     domainNodes.forEach(upsertNode);
     artifactNodes.forEach(upsertNode);
     moduleNodes.forEach(upsertNode);
+    initiativeNodes.forEach(upsertNode);
 
     return nextNodes;
-  }, [domainNodes, artifactNodes, moduleNodes, layoutPositions]);
+  }, [domainNodes, artifactNodes, moduleNodes, initiativeNodes, layoutPositions]);
 
   const graphData = useMemo(
     () => ({
@@ -566,9 +598,12 @@ const GraphView: React.FC<GraphViewProps> = ({
   return (
     <div ref={containerRef} className={styles.container}>
       <div className={styles.legend}>
-        <Badge label="Модуль" size="s" view="filled" status="warning" />
-        <Badge label="Домен" size="s" view="filled" status="system" />
-        <Badge label="Артефакт" size="s" view="filled" status="success" />
+        <Badge label="🚀 Модуль • prod" size="s" view="filled" status="warning" />
+        <Badge label="🔧 Модуль • in-dev" size="s" view="filled" status="normal" />
+        <Badge label="🛑 Модуль • deprecated" size="s" view="filled" status="alert" />
+        <Badge label="📂 Домен" size="s" view="filled" status="system" />
+        <Badge label="🧩 Артефакт" size="s" view="filled" status="success" />
+        <Badge label="🎯 Инициатива" size="s" view="filled" status="warning" />
       </div>
       {highlightedNode ? (
         <div className={styles.viewControls}>
@@ -597,9 +632,19 @@ const GraphView: React.FC<GraphViewProps> = ({
           height={dimensions.height || 400}
           graphData={graphData}
           nodeLabel={(node: ForceNode) => node.name ?? node.id}
-          linkColor={(link: ForceLink) => resolveLinkColor(link, palette, visibleDomainIds)}
+          linkColor={(link: ForceLink) =>
+            resolveLinkColor(link, palette, visibleDomainIds, visibleModuleStatuses, moduleStatusMap)
+          }
           nodeCanvasObject={(node: ForceNode, ctx, globalScale) => {
-            drawNode(node, ctx, globalScale, highlightedNode, palette, visibleDomainIds);
+            drawNode(
+              node,
+              ctx,
+              globalScale,
+              highlightedNode,
+              palette,
+              visibleDomainIds,
+              visibleModuleStatuses
+            );
           }}
           nodeCanvasObjectMode={() => 'replace'}
           onNodeClick={(node) => {
@@ -695,14 +740,18 @@ function flattenDomains(domains: DomainNode[], visibleDomainIds?: Set<string>): 
 }
 
 type GraphPalette = {
-  module: string;
+  moduleProduction: string;
+  moduleInDev: string;
+  moduleDeprecated: string;
   domain: string;
   artifact: string;
+  initiative: string;
   text: string;
   linkDependency: string;
   linkProduces: string;
   linkRelates: string;
   linkConsumes: string;
+  linkInitiative: string;
 };
 
 function drawNode(
@@ -711,39 +760,122 @@ function drawNode(
   globalScale: number,
   highlighted: string | null,
   palette: GraphPalette,
-  visibleDomainIds: Set<string>
+  visibleDomainIds: Set<string>,
+  visibleModuleStatuses: Set<ModuleStatus>
 ) {
   const label = node.name ?? node.id;
-  const fontSize = 12 / Math.sqrt(globalScale);
-  const radius = node.type === 'module' ? 10 : node.type === 'domain' ? 8 : 6;
+  const x = typeof node.x === 'number' ? node.x : 0;
+  const y = typeof node.y === 'number' ? node.y : 0;
+  const isHighlighted = highlighted === node.id;
   const isDomainDimmed =
     node.type === 'domain' && visibleDomainIds.size > 0 && !visibleDomainIds.has(node.id);
-  const isHighlighted = highlighted && node.id === highlighted;
-  const baseAlpha = isHighlighted ? 1 : isDomainDimmed ? 0.2 : 1;
+  const isModuleDimmed =
+    node.type === 'module' &&
+    visibleModuleStatuses.size > 0 &&
+    !visibleModuleStatuses.has(node.status);
+  const baseAlpha = isHighlighted ? 1 : 1;
+  const dimFactor =
+    (highlighted && node.id !== highlighted ? 0.4 : 1) *
+    (isModuleDimmed && !isHighlighted ? 0.35 : 1) *
+    (isDomainDimmed && !isHighlighted ? 0.35 : 1);
+  const effectiveAlpha = clamp(baseAlpha * dimFactor, 0.1, 1);
+  const labelFontSize = Math.max(12 / Math.sqrt(globalScale), 10);
+  const iconFontSize = Math.max(14 / Math.sqrt(globalScale), 12);
+
   ctx.save();
-  ctx.beginPath();
-  ctx.arc(node.x ?? 0, node.y ?? 0, radius, 0, 2 * Math.PI, false);
-  ctx.fillStyle =
-    node.type === 'module'
-      ? palette.module
-      : node.type === 'domain'
-        ? palette.domain
-        : palette.artifact;
-  ctx.globalAlpha = highlighted && node.id !== highlighted ? 0.5 * baseAlpha : baseAlpha;
-  ctx.fill();
-  ctx.globalAlpha = 1;
-  ctx.font = `${fontSize}px sans-serif`;
+  ctx.globalAlpha = effectiveAlpha;
+
+  let labelOffset = 14;
+  let iconColor = palette.text;
+  const icon = resolveNodeIcon(node);
+
+  switch (node.type) {
+    case 'module': {
+      const moduleRadius = 11;
+      const fill = resolveModuleColor(node.status, palette);
+      renderCircle(ctx, x, y, moduleRadius, fill, withAlpha(fill, 0.35));
+      labelOffset = moduleRadius + 8;
+      iconColor = '#FFFFFF';
+      break;
+    }
+    case 'domain': {
+      const domainRadius = 9;
+      renderDiamond(ctx, x, y, domainRadius, palette.domain, withAlpha(palette.domain, 0.35));
+      labelOffset = domainRadius + 10;
+      break;
+    }
+    case 'artifact': {
+      const artifactRadius = 8;
+      renderTriangle(ctx, x, y, artifactRadius, palette.artifact, withAlpha(palette.artifact, 0.35));
+      labelOffset = artifactRadius + 10;
+      break;
+    }
+    case 'initiative': {
+      const width = 26;
+      const height = 16;
+      renderRoundedRect(
+        ctx,
+        x - width / 2,
+        y - height / 2,
+        width,
+        height,
+        6,
+        palette.initiative,
+        withAlpha(palette.initiative, 0.35)
+      );
+      labelOffset = height / 2 + 10;
+      iconColor = '#FFFFFF';
+      break;
+    }
+  }
+
+  if (icon) {
+    ctx.font = `${iconFontSize}px sans-serif`;
+    ctx.fillStyle = iconColor;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(icon, x, y);
+  }
+
+  const textAlpha = isHighlighted ? 1 : Math.max(effectiveAlpha, 0.45);
+  ctx.globalAlpha = textAlpha;
+  ctx.font = `${labelFontSize}px sans-serif`;
+  ctx.fillStyle = palette.text;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'top';
-  ctx.fillStyle = palette.text;
-  if (isDomainDimmed && !isHighlighted) {
-    ctx.globalAlpha = 0.6;
-  }
-  ctx.fillText(label, node.x ?? 0, (node.y ?? 0) + radius + 4);
+  ctx.fillText(label, x, y + labelOffset);
+
   ctx.restore();
 }
 
-function resolveLinkColor(link: ForceLink, palette: GraphPalette, visibleDomainIds: Set<string>) {
+function resolveLinkColor(
+  link: ForceLink,
+  palette: GraphPalette,
+  visibleDomainIds: Set<string>,
+  visibleModuleStatuses: Set<ModuleStatus>,
+  moduleStatusMap: Map<string, ModuleStatus>
+) {
+  if (link.type === 'initiative-plan') {
+    const moduleId =
+      typeof link.target === 'object' ? (link.target as ForceNode).id : String(link.target);
+    const base = palette.linkInitiative;
+
+    if (visibleModuleStatuses.size > 0) {
+      let status: ModuleStatus | undefined;
+      if (typeof link.target === 'object' && (link.target as ForceNode).type === 'module') {
+        status = (link.target as ForceNode & ModuleNode).status;
+      } else {
+        status = moduleStatusMap.get(moduleId);
+      }
+
+      if (status && !visibleModuleStatuses.has(status)) {
+        return withAlpha(base, 0.2);
+      }
+    }
+
+    return base;
+  }
+
   const baseColor =
     link.type === 'dependency'
       ? palette.linkDependency
@@ -751,18 +883,19 @@ function resolveLinkColor(link: ForceLink, palette: GraphPalette, visibleDomainI
         ? palette.linkProduces
         : link.type === 'consumes'
           ? palette.linkConsumes
-          : palette.linkRelates;
+          : link.type === 'initiative-domain'
+            ? palette.linkInitiative
+            : palette.linkRelates;
 
-  if (link.type !== 'domain' || visibleDomainIds.size === 0) {
-    return baseColor;
+  if ((link.type === 'domain' || link.type === 'initiative-domain') && visibleDomainIds.size > 0) {
+    const targetId =
+      typeof link.target === 'object' ? (link.target as ForceNode).id : String(link.target);
+    if (!visibleDomainIds.has(targetId)) {
+      return withAlpha(baseColor, 0.2);
+    }
   }
 
-  const targetId = typeof link.target === 'object' ? (link.target as ForceNode).id : String(link.target);
-  if (visibleDomainIds.has(targetId)) {
-    return baseColor;
-  }
-
-  return withAlpha(baseColor, 0.2);
+  return baseColor;
 }
 
 function withAlpha(color: string, alpha: number) {
@@ -782,6 +915,131 @@ function withAlpha(color: string, alpha: number) {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
+function renderCircle(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  radius: number,
+  fill: string,
+  outline: string
+) {
+  ctx.beginPath();
+  ctx.arc(x, y, radius, 0, 2 * Math.PI);
+  ctx.fillStyle = fill;
+  ctx.fill();
+  ctx.strokeStyle = outline;
+  ctx.lineWidth = 1.5;
+  ctx.stroke();
+}
+
+function renderDiamond(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  radius: number,
+  fill: string,
+  outline: string
+) {
+  ctx.beginPath();
+  ctx.moveTo(x, y - radius);
+  ctx.lineTo(x + radius, y);
+  ctx.lineTo(x, y + radius);
+  ctx.lineTo(x - radius, y);
+  ctx.closePath();
+  ctx.fillStyle = fill;
+  ctx.fill();
+  ctx.strokeStyle = outline;
+  ctx.lineWidth = 1.5;
+  ctx.stroke();
+}
+
+function renderTriangle(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  radius: number,
+  fill: string,
+  outline: string
+) {
+  ctx.beginPath();
+  ctx.moveTo(x, y - radius);
+  ctx.lineTo(x + radius, y + radius);
+  ctx.lineTo(x - radius, y + radius);
+  ctx.closePath();
+  ctx.fillStyle = fill;
+  ctx.fill();
+  ctx.strokeStyle = outline;
+  ctx.lineWidth = 1.5;
+  ctx.stroke();
+}
+
+function renderRoundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+  fill: string,
+  outline: string
+) {
+  const r = Math.min(radius, width / 2, height / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + width - r, y);
+  ctx.quadraticCurveTo(x + width, y, x + width, y + r);
+  ctx.lineTo(x + width, y + height - r);
+  ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+  ctx.lineTo(x + r, y + height);
+  ctx.quadraticCurveTo(x, y + height, x, y + height - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+  ctx.fillStyle = fill;
+  ctx.fill();
+  ctx.strokeStyle = outline;
+  ctx.lineWidth = 1.5;
+  ctx.stroke();
+}
+
+function resolveModuleColor(status: ModuleStatus, palette: GraphPalette): string {
+  switch (status) {
+    case 'production':
+      return palette.moduleProduction;
+    case 'in-dev':
+      return palette.moduleInDev;
+    case 'deprecated':
+    default:
+      return palette.moduleDeprecated;
+  }
+}
+
+const MODULE_ICON_MAP: Record<ModuleStatus, string> = {
+  production: '🚀',
+  'in-dev': '🔧',
+  deprecated: '🛑'
+};
+
+function resolveNodeIcon(node: GraphNode): string {
+  if (node.type === 'module') {
+    return MODULE_ICON_MAP[node.status];
+  }
+
+  if (node.type === 'domain') {
+    return '📂';
+  }
+
+  if (node.type === 'artifact') {
+    return '🧩';
+  }
+
+  if (node.type === 'initiative') {
+    return '🎯';
+  }
+
+  return '';
+}
+
 function resolvePalette(themeClassName?: string): GraphPalette {
   if (typeof window === 'undefined') {
     return DEFAULT_PALETTE;
@@ -792,14 +1050,18 @@ function resolvePalette(themeClassName?: string): GraphPalette {
   const getVar = (token: string, fallback: string) => styles.getPropertyValue(token).trim() || fallback;
 
   return {
-    module: getVar('--color-bg-warning', DEFAULT_PALETTE.module),
+    moduleProduction: getVar('--color-bg-warning', DEFAULT_PALETTE.moduleProduction),
+    moduleInDev: getVar('--color-bg-normal', DEFAULT_PALETTE.moduleInDev),
+    moduleDeprecated: getVar('--color-bg-alert', DEFAULT_PALETTE.moduleDeprecated),
     domain: getVar('--color-bg-info', DEFAULT_PALETTE.domain),
     artifact: getVar('--color-bg-success', DEFAULT_PALETTE.artifact),
+    initiative: getVar('--color-bg-brand', DEFAULT_PALETTE.initiative),
     text: getVar('--color-typo-primary', DEFAULT_PALETTE.text),
     linkDependency: getVar('--color-bg-border', DEFAULT_PALETTE.linkDependency),
     linkProduces: getVar('--color-bg-success', DEFAULT_PALETTE.linkProduces),
     linkRelates: getVar('--color-bg-info', DEFAULT_PALETTE.linkRelates),
-    linkConsumes: getVar('--color-bg-normal', DEFAULT_PALETTE.linkConsumes)
+    linkConsumes: getVar('--color-bg-normal', DEFAULT_PALETTE.linkConsumes),
+    linkInitiative: getVar('--color-bg-accent', DEFAULT_PALETTE.linkInitiative)
   };
 }
 
@@ -820,14 +1082,18 @@ function computeFocusZoom(
 }
 
 const DEFAULT_PALETTE: GraphPalette = {
-  module: '#FF8C69',
+  moduleProduction: '#FF8C69',
+  moduleInDev: '#4C9AFF',
+  moduleDeprecated: '#D06C6C',
   domain: '#5B8FF9',
   artifact: '#45C7B0',
+  initiative: '#A25DDC',
   text: '#1F1F1F',
   linkDependency: '#B8B8B8',
   linkProduces: '#45C7B0',
   linkRelates: '#5B8FF9',
-  linkConsumes: '#8E8E93'
+  linkConsumes: '#8E8E93',
+  linkInitiative: '#A25DDC'
 };
 
 export type { GraphNode };

--- a/src/components/NodeDetails.module.css
+++ b/src/components/NodeDetails.module.css
@@ -131,6 +131,13 @@
   gap: 2px;
 }
 
+.listItemHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .companyList {
   list-style: none;
   margin: 0;

--- a/src/components/NodeDetails.tsx
+++ b/src/components/NodeDetails.tsx
@@ -5,7 +5,13 @@ import { Select } from '@consta/uikit/Select';
 import { Tag } from '@consta/uikit/Tag';
 import { Text } from '@consta/uikit/Text';
 import React, { useEffect, useState } from 'react';
-import { type ModuleInput, type ModuleOutput, type TeamMember } from '../data';
+import {
+  type InitiativeApprovalStatus,
+  type InitiativeWorkItemStatus,
+  type ModuleInput,
+  type ModuleOutput,
+  type TeamMember
+} from '../data';
 import type { GraphNode } from './GraphView';
 import styles from './NodeDetails.module.css';
 
@@ -46,6 +52,25 @@ const clientTypeLabels: Record<'desktop' | 'web', string> = {
 const deploymentToolLabels: Record<'docker' | 'kubernetes', string> = {
   docker: 'Docker',
   kubernetes: 'Kubernetes'
+};
+
+const workItemStatusMeta: Record<
+  InitiativeWorkItemStatus,
+  { label: string; badge: 'normal' | 'warning' | 'system' | 'success' }
+> = {
+  discovery: { label: 'Исследование', badge: 'normal' },
+  design: { label: 'Проектирование', badge: 'warning' },
+  pilot: { label: 'Пилот', badge: 'system' },
+  delivery: { label: 'Внедрение', badge: 'success' }
+};
+
+const approvalStatusMeta: Record<
+  InitiativeApprovalStatus,
+  { label: string; badge: 'normal' | 'warning' | 'success' }
+> = {
+  pending: { label: 'Ожидание', badge: 'normal' },
+  'in-progress': { label: 'В работе', badge: 'warning' },
+  approved: { label: 'Одобрено', badge: 'success' }
 };
 
 const NodeDetails: React.FC<NodeDetailsProps> = ({
@@ -248,6 +273,174 @@ const NodeDetails: React.FC<NodeDetailsProps> = ({
           <a href={node.sampleUrl} className={styles.link} target="_blank" rel="noreferrer">
             {node.sampleUrl}
           </a>
+        </div>
+      </div>
+    );
+  }
+
+  if (node.type === 'initiative') {
+    const domainLabels = node.domains.map((domainId) => domainNameMap[domainId] ?? domainId);
+    const plannedModules = node.plannedModuleIds.map((moduleId) => ({
+      id: moduleId,
+      label: moduleNameMap[moduleId] ?? moduleId
+    }));
+
+    return (
+      <div className={styles.container}>
+        <header className={styles.header}>
+          <Text size="l" weight="bold">
+            {node.name}
+          </Text>
+          <Button size="xs" label="Закрыть" view="ghost" onClick={onClose} />
+        </header>
+
+        <div className={styles.section}>
+          <Text size="s" weight="semibold">
+            Описание
+          </Text>
+          <Text size="s" view="secondary">
+            {node.description}
+          </Text>
+        </div>
+
+        <div className={styles.section}>
+          <Text size="s" weight="semibold">
+            Домены
+          </Text>
+          {domainLabels.length > 0 ? (
+            <div className={styles.tagList}>
+              {domainLabels.map((label, index) => (
+                <Tag key={node.domains[index]} label={label} size="xs" />
+              ))}
+            </div>
+          ) : (
+            <Text size="xs" view="secondary">
+              Домены не указаны
+            </Text>
+          )}
+        </div>
+
+        <div className={styles.section}>
+          <Text size="s" weight="semibold">
+            Планируемые модули
+          </Text>
+          {plannedModules.length > 0 ? (
+            <ul className={styles.list}>
+              {plannedModules.map((module) => (
+                <li key={module.id} className={styles.listItem}>
+                  <a
+                    href="#"
+                    className={styles.link}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      onNavigate(module.id);
+                    }}
+                  >
+                    {module.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <Text size="xs" view="secondary">
+              Модули не назначены
+            </Text>
+          )}
+        </div>
+
+        <div className={styles.section}>
+          <Text size="s" weight="semibold">
+            Работы
+          </Text>
+          {node.workItems.length > 0 ? (
+            <ul className={styles.list}>
+              {node.workItems.map((item) => {
+                const status = workItemStatusMeta[item.status];
+                return (
+                  <li key={item.id} className={styles.listItem}>
+                    <div className={styles.listItemHeader}>
+                      <Text size="s" weight="semibold">
+                        {item.title}
+                      </Text>
+                      <Badge
+                        size="xs"
+                        status={status.badge}
+                        view="filled"
+                        label={status.label}
+                      />
+                    </div>
+                    <Text size="xs" view="secondary">
+                      {item.description}
+                    </Text>
+                    <Text size="xs" view="secondary">
+                      {`Ответственный: ${item.owner} • ${item.timeframe}`}
+                    </Text>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : (
+            <Text size="xs" view="secondary">
+              Работы не определены
+            </Text>
+          )}
+        </div>
+
+        <div className={styles.section}>
+          <Text size="s" weight="semibold">
+            Требуемые навыки
+          </Text>
+          {node.requiredSkills.length > 0 ? (
+            <div className={styles.tagList}>
+              {node.requiredSkills.map((skill) => (
+                <Tag key={skill} label={skill} size="xs" />
+              ))}
+            </div>
+          ) : (
+            <Text size="xs" view="secondary">
+              Навыки не указаны
+            </Text>
+          )}
+        </div>
+
+        <div className={styles.section}>
+          <Text size="s" weight="semibold">
+            Этапы согласования
+          </Text>
+          {node.approvalStages.length > 0 ? (
+            <ul className={styles.list}>
+              {node.approvalStages.map((stage) => {
+                const status = approvalStatusMeta[stage.status];
+                return (
+                  <li key={stage.id} className={styles.listItem}>
+                    <div className={styles.listItemHeader}>
+                      <Text size="s" weight="semibold">
+                        {stage.title}
+                      </Text>
+                      <Badge
+                        size="xs"
+                        status={status.badge}
+                        view="filled"
+                        label={status.label}
+                      />
+                    </div>
+                    <Text size="xs" view="secondary">
+                      {`Согласующий: ${stage.approver}`}
+                    </Text>
+                    {stage.comment ? (
+                      <Text size="xs" view="secondary">
+                        {stage.comment}
+                      </Text>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          ) : (
+            <Text size="xs" view="secondary">
+              Этапы согласования не заданы
+            </Text>
+          )}
         </div>
       </div>
     );

--- a/src/data.ts
+++ b/src/data.ts
@@ -128,6 +128,38 @@ export type ModuleNode = {
   nonFunctional: NonFunctionalRequirements;
 };
 
+export type InitiativeWorkItemStatus = 'discovery' | 'design' | 'pilot' | 'delivery';
+
+export type InitiativeWorkItem = {
+  id: string;
+  title: string;
+  description: string;
+  owner: string;
+  status: InitiativeWorkItemStatus;
+  timeframe: string;
+};
+
+export type InitiativeApprovalStatus = 'pending' | 'in-progress' | 'approved';
+
+export type InitiativeApprovalStage = {
+  id: string;
+  title: string;
+  approver: string;
+  status: InitiativeApprovalStatus;
+  comment?: string;
+};
+
+export type InitiativeNode = {
+  id: string;
+  name: string;
+  description: string;
+  domains: string[];
+  plannedModuleIds: string[];
+  requiredSkills: string[];
+  workItems: InitiativeWorkItem[];
+  approvalStages: InitiativeApprovalStage[];
+};
+
 export const domainTree: DomainNode[] = [
   {
     id: 'upstream',
@@ -1146,7 +1178,132 @@ export const modules: ModuleNode[] = [
 ];
 
 
-export const experts: ExpertProfile[] = [
+export const initiatives: InitiativeNode[] = [
+  {
+    id: 'initiative-digital-pad',
+    name: 'Цифровая кустовая площадка',
+    description:
+      'Создание цифрового контура подготовки площадок и проектирования наземной инфраструктуры для новых кустов скважин.',
+    domains: ['layout-optimization', 'surface-readiness'],
+    plannedModuleIds: ['module-infraplan-layout', 'module-infraplan-datahub', 'module-infraplan-economics'],
+    requiredSkills: [
+      'Оптимизация промысловой инфраструктуры',
+      'Инженерное моделирование',
+      'Геопространственный анализ',
+      'Управление проектными данными'
+    ],
+    workItems: [
+      {
+        id: 'digital-pad-discovery',
+        title: 'Сбор исходных требований площадок',
+        description: 'Анализ технологических ограничений и данных геодезии для типовых кустов.',
+        owner: 'Дарья Гончарова',
+        status: 'discovery',
+        timeframe: 'Q1 2025'
+      },
+      {
+        id: 'digital-pad-design',
+        title: 'Проектирование сценариев размещения',
+        description: 'Настройка алгоритмов оптимизации и сценарного анализа по выбранным полигонам.',
+        owner: 'Антон Чернышёв',
+        status: 'design',
+        timeframe: 'Q2 2025'
+      },
+      {
+        id: 'digital-pad-pilot',
+        title: 'Пилотирование в Восток Инжиниринг',
+        description: 'Совместная проверка расчётов и интеграция с INFRAPLAN Economics.',
+        owner: 'Александр Трофимов',
+        status: 'pilot',
+        timeframe: 'Q3 2025'
+      }
+    ],
+    approvalStages: [
+      {
+        id: 'digital-pad-architecture',
+        title: 'Архитектурный комитет',
+        approver: 'Дмитрий Валов',
+        status: 'approved',
+        comment: 'Целевая архитектура согласована, необходимо оформить план пилота.'
+      },
+      {
+        id: 'digital-pad-finance',
+        title: 'Финансовый комитет',
+        approver: 'Марина Крылова',
+        status: 'in-progress',
+        comment: 'Требуется уточнить эффект по CAPEX для пилотных кустов.'
+      },
+      {
+        id: 'digital-pad-operations',
+        title: 'Операционный совет',
+        approver: 'Игорь Ковалёв',
+        status: 'pending'
+      }
+    ]
+  },
+  {
+    id: 'initiative-remote-operations',
+    name: 'Единый контур дистанционного управления',
+    description:
+      'Интеграция цифровых двойников и сервисов диспетчеризации для безопасного дистанционного управления фонда скважин.',
+    domains: ['real-time-monitoring', 'workover-automation'],
+    plannedModuleIds: [
+      'module-dtwin-optimizer',
+      'module-dtwin-remote-ops',
+      'module-wwo-planner'
+    ],
+    requiredSkills: [
+      'Стриминговая обработка телеметрии',
+      'Интеграция SCADA-систем',
+      'Проектирование процессов дистанционного управления',
+      'Управление изменениями'
+    ],
+    workItems: [
+      {
+        id: 'remote-ops-discovery',
+        title: 'Картирование процессов и ролей',
+        description: 'Интервью с операторами и формализация цепочки принятия решений.',
+        owner: 'Ирина Сафонова',
+        status: 'discovery',
+        timeframe: 'Q4 2024'
+      },
+      {
+        id: 'remote-ops-design',
+        title: 'Проектирование интеграции SCADA',
+        description: 'Выбор каналов обмена и сценарии переключения режимов.',
+        owner: 'Геннадий Борисов',
+        status: 'design',
+        timeframe: 'Q1 2025'
+      },
+      {
+        id: 'remote-ops-delivery',
+        title: 'Запуск дистанционных процедур',
+        description: 'Обучение диспетчеров и выход в опытную эксплуатацию.',
+        owner: 'Галина Кручина',
+        status: 'delivery',
+        timeframe: 'Q3 2025'
+      }
+    ],
+    approvalStages: [
+      {
+        id: 'remote-ops-safety',
+        title: 'Комитет промышленной безопасности',
+        approver: 'Сергей Ежов',
+        status: 'in-progress',
+        comment: 'Подготовлены регламенты по аварийному отключению.'
+      },
+      {
+        id: 'remote-ops-it',
+        title: 'ИТ-архитектурный совет',
+        approver: 'Леонид Архипов',
+        status: 'pending'
+      }
+    ]
+  }
+];
+
+
+ export const experts: ExpertProfile[] = [
   {
     id: 'expert-viktoria-berezhnaya',
     fullName: 'Виктория Бережная',
@@ -1611,8 +1768,30 @@ export const artifactNameById: Record<string, string> = artifacts.reduce((acc, a
 export type GraphLink = {
   source: string;
   target: string;
-  type: 'domain' | 'dependency' | 'produces' | 'consumes';
+  type:
+    | 'domain'
+    | 'dependency'
+    | 'produces'
+    | 'consumes'
+    | 'initiative-domain'
+    | 'initiative-plan';
 };
+
+export const initiativeLinks: GraphLink[] = initiatives.flatMap((initiative) => {
+  const domainLinks: GraphLink[] = initiative.domains.map((domainId) => ({
+    source: initiative.id,
+    target: domainId,
+    type: 'initiative-domain'
+  }));
+
+  const moduleLinks: GraphLink[] = initiative.plannedModuleIds.map((moduleId) => ({
+    source: initiative.id,
+    target: moduleId,
+    type: 'initiative-plan'
+  }));
+
+  return [...domainLinks, ...moduleLinks];
+});
 
 const moduleById: Record<string, ModuleNode> = modules.reduce((acc, module) => {
   acc[module.id] = module;

--- a/src/services/graphStorage.ts
+++ b/src/services/graphStorage.ts
@@ -32,6 +32,7 @@ export async function createGraph(
     includeDomains: boolean;
     includeModules: boolean;
     includeArtifacts: boolean;
+    includeInitiatives: boolean;
   },
   signal?: AbortSignal
 ): Promise<GraphSummary> {
@@ -84,6 +85,7 @@ export async function fetchGraphSnapshot(
     modules: snapshot.modules,
     domains: snapshot.domains,
     artifacts: snapshot.artifacts,
+    initiatives: snapshot.initiatives ?? [],
     layout: normalizeLayoutSnapshot(snapshot.layout)
   };
 }
@@ -160,6 +162,7 @@ export async function importGraphFromSource(
     domains: request.includeDomains ? snapshot.domains : [],
     modules: request.includeModules ? snapshot.modules : [],
     artifacts: request.includeArtifacts ? snapshot.artifacts : [],
+    initiatives: request.includeInitiatives ? snapshot.initiatives ?? [] : [],
     layout:
       request.includeModules && snapshot.layout
         ? normalizeLayoutSnapshot(snapshot.layout) ?? undefined

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -1,6 +1,6 @@
-import type { ArtifactNode, DomainNode, ModuleNode } from '../data';
+import type { ArtifactNode, DomainNode, InitiativeNode, ModuleNode } from '../data';
 
-export const GRAPH_SNAPSHOT_VERSION = 1;
+export const GRAPH_SNAPSHOT_VERSION = 2;
 
 export type GraphLayoutNodePosition = {
   x: number;
@@ -19,6 +19,7 @@ export type GraphSnapshotPayload = {
   modules: ModuleNode[];
   domains: DomainNode[];
   artifacts: ArtifactNode[];
+  initiatives?: InitiativeNode[];
   layout?: GraphLayoutSnapshot;
 };
 
@@ -40,4 +41,5 @@ export type GraphCopyRequest = {
   includeDomains: boolean;
   includeModules: boolean;
   includeArtifacts: boolean;
+  includeInitiatives: boolean;
 };


### PR DESCRIPTION
## Summary
- add initiative entities with sample data and connect them to domains and planned modules
- include initiatives in graph rendering, persistence flows, and filtering
- display initiative-specific work items, required skills, and approval stages in the details panel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f51cbb581c8332ac83eaa5a21c4f32