### PR TITLE
Implement expert-role matching service

### DIFF
--- a/src/services/matching.test.ts
+++ b/src/services/matching.test.ts
@@ -1,0 +1,180 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildInitiativeMatchReport,
+  type InitiativeRequirement,
+  type MatchableExpertProfile,
+  type RoleRequirement,
+  scoreExpertForRole
+} from './matching';
+
+function createExpert(overrides: Partial<MatchableExpertProfile>): MatchableExpertProfile {
+  const base: MatchableExpertProfile = {
+    id: 'expert-base',
+    fullName: 'Эксперт Базовый',
+    title: 'Lead Engineer',
+    summary: 'Опытный специалист.',
+    domains: ['core'],
+    modules: [],
+    competencies: [],
+    consultingSkills: [],
+    focusAreas: [],
+    experienceYears: 10,
+    location: 'Москва',
+    contact: 'expert@example.com',
+    languages: ['ru'],
+    notableProjects: [],
+    availability: 'available',
+    availabilityComment: 'Готов к новым проектам',
+    skillEvidence: []
+  } as MatchableExpertProfile;
+
+  // Spread overrides afterwards to allow array overrides.
+  return {
+    ...base,
+    ...overrides,
+    // Deep merge arrays when not provided in overrides
+    competencies: overrides.competencies ?? base.competencies,
+    consultingSkills: overrides.consultingSkills ?? base.consultingSkills,
+    focusAreas: overrides.focusAreas ?? base.focusAreas,
+    languages: overrides.languages ?? base.languages,
+    skillEvidence: overrides.skillEvidence ?? base.skillEvidence
+  };
+}
+
+function assertApproximately(actual: number, expected: number, epsilon = 1e-6) {
+  assert.ok(
+    Math.abs(actual - expected) <= epsilon,
+    `Expected ${actual} to be approximately ${expected}`
+  );
+}
+
+test('scoreExpertForRole учитывает веса навыков, уровни, свежесть и доступность', () => {
+  const requirement: RoleRequirement = {
+    roleId: 'role-ts',
+    roleName: 'Frontend Lead',
+    requiredFte: 1,
+    skills: [
+      { name: 'TypeScript', weight: 0.6, requiredLevel: 'advanced', freshnessHalfLifeDays: 180 },
+      { name: 'React', weight: 0.4, requiredLevel: 'advanced', freshnessHalfLifeDays: 90 }
+    ]
+  };
+
+  const expert = createExpert({
+    id: 'expert-ts',
+    fullName: 'Алексей TypeScript',
+    competencies: ['TypeScript', 'React'],
+    availability: 'available',
+    skillEvidence: [
+      { name: 'TypeScript', level: 'expert', lastUsedDaysAgo: 30 },
+      { name: 'React', level: 'advanced', lastUsedDaysAgo: 200 }
+    ]
+  });
+
+  const { explanation } = scoreExpertForRole(requirement, expert);
+
+  const expectedTypeScriptFreshness = Math.exp((-Math.log(2) * 30) / 180);
+  const expectedReactFreshness = Math.exp((-Math.log(2) * 200) / 90);
+  const expectedSkillScore =
+    (0.6 * 1 * expectedTypeScriptFreshness + 0.4 * 1 * expectedReactFreshness) / 1;
+
+  assertApproximately(explanation.normalizedSkillScore, expectedSkillScore, 1e-6);
+  assertApproximately(explanation.availabilityMultiplier, 1);
+  assertApproximately(explanation.fteSaturation, 1);
+  assertApproximately(explanation.totalScore, expectedSkillScore, 1e-6);
+
+  const reactRisk = explanation.risks.find((risk) => risk.includes('React'));
+  assert.ok(reactRisk, 'Ожидался риск по устареванию навыка React');
+});
+
+test('scoreExpertForRole снижает итоговый балл при неполной доступности по FTE', () => {
+  const requirement: RoleRequirement = {
+    roleId: 'role-data',
+    roleName: 'Data Engineer',
+    requiredFte: 1,
+    skills: [{ name: 'Python', weight: 1, requiredLevel: 'advanced', freshnessHalfLifeDays: 120 }]
+  };
+
+  const expert = createExpert({
+    id: 'expert-partial',
+    availability: 'partial',
+    skillEvidence: [{ name: 'Python', level: 'advanced', lastUsedDaysAgo: 10 }],
+    competencies: ['Python']
+  });
+
+  const { explanation } = scoreExpertForRole(requirement, expert);
+
+  const expectedFreshness = Math.exp((-Math.log(2) * 10) / 120);
+  const expectedSkillScore = expectedFreshness; // levelFactor=1, weight=1
+  const expectedTotal = expectedSkillScore * 0.65 * 0.5;
+
+  assertApproximately(explanation.normalizedSkillScore, expectedSkillScore, 1e-6);
+  assertApproximately(explanation.availabilityMultiplier, 0.65, 1e-6);
+  assertApproximately(explanation.fteSaturation, 0.5, 1e-6);
+  assertApproximately(explanation.totalScore, expectedTotal, 1e-6);
+
+  assert.ok(
+    explanation.risks.includes('Недостаточная доступность по FTE для роли'),
+    'Должен сигнализироваться риск по FTE'
+  );
+});
+
+test('buildInitiativeMatchReport агрегирует оценки по ролям инициативы', () => {
+  const experts: MatchableExpertProfile[] = [
+    createExpert({
+      id: 'expert-alpha',
+      fullName: 'Frontend Специалист',
+      skillEvidence: [{ name: 'TypeScript', level: 'expert', lastUsedDaysAgo: 5 }],
+      competencies: ['TypeScript'],
+      availability: 'available'
+    }),
+    createExpert({
+      id: 'expert-beta',
+      fullName: 'Data Аналитик',
+      skillEvidence: [{ name: 'DataOps', level: 'advanced', lastUsedDaysAgo: 400 }],
+      focusAreas: ['DataOps'],
+      availability: 'partial'
+    })
+  ];
+
+  const initiative: InitiativeRequirement = {
+    initiativeId: 'initiative-1',
+    initiativeName: 'Цифровой апстрим',
+    roles: [
+      {
+        roleId: 'role-frontend',
+        roleName: 'Frontend Lead',
+        requiredFte: 1,
+        skills: [{ name: 'TypeScript', weight: 1, requiredLevel: 'advanced', freshnessHalfLifeDays: 120 }]
+      },
+      {
+        roleId: 'role-dataops',
+        roleName: 'DataOps инженер',
+        requiredFte: 0.5,
+        skills: [{ name: 'DataOps', weight: 1, requiredLevel: 'advanced', freshnessHalfLifeDays: 180 }]
+      }
+    ]
+  };
+
+  const report = buildInitiativeMatchReport(initiative, experts);
+  assert.equal(report.roleReports.length, 2);
+
+  const frontendReport = report.roleReports[0];
+  assert.equal(frontendReport.topMatch?.expert.id, 'expert-alpha');
+  assert.ok(frontendReport.topMatch!.explanation.totalScore > 0.8);
+
+  const dataOpsReport = report.roleReports[1];
+  assert.equal(dataOpsReport.topMatch?.expert.id, 'expert-beta');
+  assert.ok(dataOpsReport.topMatch!.explanation.totalScore < 0.3);
+
+  const expectedOverall =
+    (frontendReport.topMatch!.explanation.totalScore +
+      dataOpsReport.topMatch!.explanation.totalScore) /
+    2;
+  assertApproximately(report.overallScore, expectedOverall, 1e-6);
+
+  assert.ok(
+    report.overallRisks.some((risk) => risk.includes('Эксперт частично доступен для инициативы')),
+    'В совокупных рисках должна отображаться частичная доступность'
+  );
+});

--- a/src/services/matching.ts
+++ b/src/services/matching.ts
@@ -1,0 +1,287 @@
+import { type ExpertAvailability, type ExpertProfile } from '../data';
+
+const LEVEL_WEIGHTS = {
+  novice: 0.4,
+  intermediate: 0.7,
+  advanced: 0.9,
+  expert: 1
+} as const;
+
+const AVAILABILITY_MULTIPLIERS: Record<ExpertAvailability, number> = {
+  available: 1,
+  partial: 0.65,
+  busy: 0.25
+};
+
+const AVAILABILITY_FTE: Record<ExpertAvailability, number> = {
+  available: 1,
+  partial: 0.5,
+  busy: 0.1
+};
+
+const DEFAULT_FRESHNESS_HALF_LIFE_DAYS = 180;
+
+export type SkillLevel = keyof typeof LEVEL_WEIGHTS;
+
+export type SkillRequirement = {
+  name: string;
+  weight: number;
+  requiredLevel?: SkillLevel;
+  freshnessHalfLifeDays?: number;
+};
+
+export type RoleRequirement = {
+  roleId: string;
+  roleName: string;
+  skills: SkillRequirement[];
+  requiredFte: number;
+};
+
+export type ExpertSkillEvidence = {
+  name: string;
+  level: SkillLevel;
+  lastUsedDaysAgo: number;
+};
+
+export type MatchableExpertProfile = ExpertProfile & {
+  skillEvidence?: ExpertSkillEvidence[];
+  /**
+   * Фактическая загрузка эксперта. Если не указана, оценивается по статусу доступности.
+   */
+  fteCapacity?: number;
+};
+
+export type SkillCoverageReport = {
+  skill: SkillRequirement;
+  hasSkill: boolean;
+  coverageScore: number;
+  levelFactor: number;
+  freshnessFactor: number;
+  gaps: string[];
+};
+
+export type RoleMatchExplanation = {
+  totalScore: number;
+  normalizedSkillScore: number;
+  availabilityMultiplier: number;
+  fteSaturation: number;
+  skillCoverage: SkillCoverageReport[];
+  risks: string[];
+};
+
+export type RoleMatchResult = {
+  expert: MatchableExpertProfile;
+  explanation: RoleMatchExplanation;
+};
+
+export type RoleMatchReport = {
+  requirement: RoleRequirement;
+  matches: RoleMatchResult[];
+  topMatch: RoleMatchResult | null;
+  averageScore: number;
+};
+
+export type InitiativeRequirement = {
+  initiativeId: string;
+  initiativeName: string;
+  roles: RoleRequirement[];
+};
+
+export type InitiativeMatchReport = {
+  initiativeId: string;
+  initiativeName: string;
+  roleReports: RoleMatchReport[];
+  overallScore: number;
+  overallRisks: string[];
+};
+
+const LOG_2 = Math.log(2);
+
+function findEvidence(
+  expert: MatchableExpertProfile,
+  skillName: string
+): ExpertSkillEvidence | undefined {
+  return expert.skillEvidence?.find(
+    (item) => item.name.toLowerCase() === skillName.toLowerCase()
+  );
+}
+
+function hasSkillInProfile(
+  expert: MatchableExpertProfile,
+  skillName: string
+): boolean {
+  const lower = skillName.toLowerCase();
+  return (
+    expert.competencies.some((skill) => skill.toLowerCase() === lower) ||
+    expert.consultingSkills.some((skill) => skill.toLowerCase() === lower) ||
+    expert.focusAreas.some((skill) => skill.toLowerCase() === lower)
+  );
+}
+
+function calculateFreshnessFactor(
+  lastUsedDaysAgo: number | undefined,
+  halfLifeDays: number
+): number {
+  if (lastUsedDaysAgo === undefined) {
+    return 0.75;
+  }
+  if (lastUsedDaysAgo <= 0) {
+    return 1;
+  }
+  return Math.exp((-LOG_2 * lastUsedDaysAgo) / Math.max(halfLifeDays, 1));
+}
+
+function calculateSkillCoverage(
+  requirement: SkillRequirement,
+  expert: MatchableExpertProfile
+): SkillCoverageReport {
+  const evidence = findEvidence(expert, requirement.name);
+  const hasProfileSkill = hasSkillInProfile(expert, requirement.name);
+  const hasSkill = Boolean(evidence) || hasProfileSkill;
+
+  const requiredLevelWeight = requirement.requiredLevel
+    ? LEVEL_WEIGHTS[requirement.requiredLevel]
+    : LEVEL_WEIGHTS.expert;
+
+  let levelFactor = 0;
+  let freshnessFactor = 0;
+  const gaps: string[] = [];
+
+  if (!hasSkill) {
+    gaps.push(`Нет подтвержденного навыка «${requirement.name}»`);
+  }
+
+  if (evidence) {
+    const levelWeight = LEVEL_WEIGHTS[evidence.level];
+    levelFactor = Math.min(levelWeight / requiredLevelWeight, 1);
+    const halfLife = requirement.freshnessHalfLifeDays ?? DEFAULT_FRESHNESS_HALF_LIFE_DAYS;
+    freshnessFactor = calculateFreshnessFactor(evidence.lastUsedDaysAgo, halfLife);
+    if (levelFactor < 1) {
+      gaps.push(
+        `Уровень владения «${requirement.name}» ниже требуемого (${evidence.level} < ${
+          requirement.requiredLevel ?? 'expert'
+        })`
+      );
+    }
+    if (freshnessFactor < 0.6) {
+      gaps.push(
+        `Навык «${requirement.name}» может быть устаревшим (использовался ${evidence.lastUsedDaysAgo} дней назад)`
+      );
+    }
+  } else if (hasProfileSkill) {
+    levelFactor = 0.65;
+    freshnessFactor = 0.6;
+    gaps.push(`Навык «${requirement.name}» есть в профиле, но без подтверждения уровня/свежести`);
+  }
+
+  const coverageScore = requirement.weight * hasSkill * levelFactor * freshnessFactor;
+
+  return {
+    skill: requirement,
+    hasSkill,
+    coverageScore,
+    levelFactor,
+    freshnessFactor,
+    gaps
+  };
+}
+
+function calculateRisks(
+  coverage: SkillCoverageReport[],
+  availabilityMultiplier: number,
+  fteSaturation: number
+): string[] {
+  const risks = coverage.flatMap((item) => item.gaps);
+  if (availabilityMultiplier < 1) {
+    risks.push('Эксперт частично доступен для инициативы');
+  }
+  if (fteSaturation < 1) {
+    risks.push('Недостаточная доступность по FTE для роли');
+  }
+  return Array.from(new Set(risks));
+}
+
+export function scoreExpertForRole(
+  requirement: RoleRequirement,
+  expert: MatchableExpertProfile
+): RoleMatchResult {
+  const coverageReports = requirement.skills.map((skill) =>
+    calculateSkillCoverage(skill, expert)
+  );
+
+  const totalWeight = requirement.skills.reduce((sum, skill) => sum + skill.weight, 0);
+  const normalizedSkillScore =
+    totalWeight === 0
+      ? 1
+      : coverageReports.reduce((sum, report) => sum + report.coverageScore, 0) /
+        totalWeight;
+
+  const availabilityMultiplier = AVAILABILITY_MULTIPLIERS[expert.availability];
+  const expertFte = expert.fteCapacity ?? AVAILABILITY_FTE[expert.availability];
+  const fteSaturation = Math.min(expertFte / Math.max(requirement.requiredFte, 0.01), 1);
+
+  const totalScore = normalizedSkillScore * availabilityMultiplier * fteSaturation;
+  const risks = calculateRisks(coverageReports, availabilityMultiplier, fteSaturation);
+
+  return {
+    expert,
+    explanation: {
+      totalScore,
+      normalizedSkillScore,
+      availabilityMultiplier,
+      fteSaturation,
+      skillCoverage: coverageReports,
+      risks
+    }
+  };
+}
+
+export function buildRoleMatchReport(
+  requirement: RoleRequirement,
+  experts: MatchableExpertProfile[]
+): RoleMatchReport {
+  const matches = experts
+    .map((expert) => scoreExpertForRole(requirement, expert))
+    .sort((a, b) => b.explanation.totalScore - a.explanation.totalScore);
+
+  const averageScore =
+    matches.length === 0
+      ? 0
+      : matches.reduce((sum, match) => sum + match.explanation.totalScore, 0) /
+        matches.length;
+
+  return {
+    requirement,
+    matches,
+    topMatch: matches[0] ?? null,
+    averageScore
+  };
+}
+
+export function buildInitiativeMatchReport(
+  initiative: InitiativeRequirement,
+  experts: MatchableExpertProfile[]
+): InitiativeMatchReport {
+  const roleReports = initiative.roles.map((role) => buildRoleMatchReport(role, experts));
+  const topScores = roleReports
+    .map((report) => report.topMatch?.explanation.totalScore ?? 0)
+    .filter((score) => score > 0);
+  const overallScore =
+    topScores.length === 0
+      ? 0
+      : topScores.reduce((sum, score) => sum + score, 0) / topScores.length;
+
+  const overallRisks = Array.from(
+    new Set(
+      roleReports.flatMap((report) => report.topMatch?.explanation.risks ?? [])
+    )
+  );
+
+  return {
+    initiativeId: initiative.initiativeId,
+    initiativeName: initiative.initiativeName,
+    roleReports,
+    overallScore,
+    overallRisks
+  };
+}


### PR DESCRIPTION
## Summary
- add a matching service that scores experts for role requirements using skill weighting, availability multipliers, freshness decay, and FTE saturation
- generate explainable coverage reports with risk annotations and aggregate results for initiatives
- capture the scoring formulas with targeted unit tests on initiative and expert fixtures

## Testing
- npx tsx --test src/services/matching.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f51cbd08d083328f7c758fb3f8fe21