### PR TITLE
Include work item skills in initiative matching

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,7 @@ import {
   selectPinnedExperts,
   type RolePlanningDraft
 } from './utils/initiativeMatching';
+import { preparePlannerModuleSelections } from './utils/initiativePlanner';
 
 const allStatuses: ModuleStatus[] = ['production', 'in-dev', 'deprecated'];
 const initialProducts = buildProductList(initialModules);
@@ -2321,7 +2322,9 @@ function App() {
       const normalizedImpact = request.expectedImpact.trim() || 'Эффект не оценён';
       const normalizedTarget = request.targetModuleName.trim() || normalizedName;
       const domains = request.domains.map((domain) => domain.trim()).filter(Boolean);
-      const potentialModules = request.potentialModules.map((module) => module.trim()).filter(Boolean);
+      const { potentialModules, plannedModuleIds } = preparePlannerModuleSelections(
+        request.potentialModules
+      );
       const roleEntries = request.roles.map((role, index) => {
         const roleId = role.id?.trim() || `${initiativeId}-role-${index + 1}`;
         const sanitizedWorkItems = role.workItems.map((item, workIndex) => ({
@@ -2392,7 +2395,7 @@ function App() {
         name: normalizedName,
         description: normalizedDescription,
         domains,
-        plannedModuleIds: [],
+        plannedModuleIds,
         requiredSkills: [],
         workItems: [],
         approvalStages: [],

--- a/src/components/InitiativeCreationModal.tsx
+++ b/src/components/InitiativeCreationModal.tsx
@@ -7,8 +7,8 @@ import { Select } from '@consta/uikit/Select';
 import { Text } from '@consta/uikit/Text';
 import { TextField } from '@consta/uikit/TextField';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { domainNameById, modules } from '../data';
-import type { ExpertProfile, InitiativeStatus, TeamRole } from '../data';
+import { domainNameById, domainTree, modules } from '../data';
+import type { DomainNode, ExpertProfile, InitiativeStatus, TeamRole } from '../data';
 import { getSkillsByRole } from '../data/skills';
 import InitiativeGanttChart from './InitiativeGanttChart';
 import type { InitiativeGanttTask } from './InitiativeGanttChart';
@@ -53,6 +53,27 @@ const COMPANY_CREATE_OPTION: OptionItem = {
   label: 'Создать нового',
   value: NEW_COMPANY_OPTION_ID
 };
+
+const collectGraphDomainIds = (domains: DomainNode[]): string[] => {
+  const result: string[] = [];
+
+  const visit = (nodes: DomainNode[]) => {
+    nodes.forEach((node) => {
+      const children = node.children ?? [];
+      if (!node.isCatalogRoot && children.length === 0) {
+        result.push(node.id);
+      }
+      if (children.length > 0) {
+        visit(children);
+      }
+    });
+  };
+
+  visit(domains);
+  return result;
+};
+
+const graphDomainIds = collectGraphDomainIds(domainTree);
 
 type RoleWorkTaskDraft = {
   id: string;
@@ -142,8 +163,8 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
 }) => {
   const domainBaseItems = useMemo<OptionItem[]>(
     () =>
-      Object.entries(domainNameById)
-        .map(([id, label]) => ({ id, label, value: id }))
+      graphDomainIds
+        .map((id) => ({ id, label: domainNameById[id], value: id }))
         .sort((a, b) => a.label.localeCompare(b.label, 'ru')),
     []
   );

--- a/src/components/InitiativeCreationModal.tsx
+++ b/src/components/InitiativeCreationModal.tsx
@@ -199,7 +199,7 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
           .map((skill) => ({
             id: skill.id,
             label: skill.name,
-            value: skill.name
+            value: skill.id
           }))
           .sort((a, b) => a.label.localeCompare(b.label, 'ru'));
         acc[option.value] = skillOptions;

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -220,6 +220,303 @@ export const skills: Record<string, SkillDefinition> = {
     recommendedLevel: 'W',
     evidenceStatus: 'observed',
     roles: ['Эксперт R&D', 'Владелец продукта']
+  },
+  'data-normalization': {
+    id: 'data-normalization',
+    name: 'Подготовка и нормализация данных',
+    description:
+      'Стандартизация источников, очистка и приведение к целевым моделям данных для аналитических решений.',
+    category: 'hard',
+    sources: ['SFIA'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'documented',
+    roles: ['Аналитик', 'Эксперт R&D']
+  },
+  'streaming-pipelines': {
+    id: 'streaming-pipelines',
+    name: 'Построение стриминговых пайплайнов',
+    description:
+      'Проектирование и эксплуатация потоковой обработки данных, обеспечение отказоустойчивости и SLA доставки.',
+    category: 'hard',
+    sources: ['SFIA'],
+    recommendedLevel: 'Ad',
+    evidenceStatus: 'verified',
+    roles: ['Архитектор', 'Backend']
+  },
+  'data-governance': {
+    id: 'data-governance',
+    name: 'Управление качеством и владением данными',
+    description:
+      'Определение ролей владения, регламентов качества и процессов каталогизации корпоративных данных.',
+    category: 'hard',
+    sources: ['SFIA'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'documented',
+    roles: ['Аналитик', 'Руководитель проекта']
+  },
+  'layout-optimization': {
+    id: 'layout-optimization',
+    name: 'Оптимизация размещения инфраструктуры',
+    description:
+      'Применение математических моделей и ограничений для выбора оптимального расположения объектов.',
+    category: 'hard',
+    sources: ['INCOSE'],
+    recommendedLevel: 'Ad',
+    evidenceStatus: 'observed',
+    roles: ['Архитектор', 'Эксперт R&D']
+  },
+  'geo-apis': {
+    id: 'geo-apis',
+    name: 'Геопространственные API и интеграции',
+    description:
+      'Разработка и интеграция геосервисов, работа с пространственными данными и ограничениями.',
+    category: 'hard',
+    sources: ['SFIA'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'documented',
+    roles: ['Backend', 'Архитектор']
+  },
+  'infrastructure-economics': {
+    id: 'infrastructure-economics',
+    name: 'Экономика инфраструктурных проектов',
+    description:
+      'Расчёт экономической эффективности, CAPEX/OPEX и оценка инвестиционных сценариев инфраструктуры.',
+    category: 'domain',
+    sources: ['INCOSE'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'observed',
+    roles: ['Аналитик', 'Владелец продукта']
+  },
+  'financial-modeling': {
+    id: 'financial-modeling',
+    name: 'Финансовое моделирование',
+    description:
+      'Построение финансовых моделей, стресс-сценариев и анализ чувствительности.',
+    category: 'hard',
+    sources: ['IIBA'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'documented',
+    roles: ['Аналитик', 'Владелец продукта']
+  },
+  'scenario-planning': {
+    id: 'scenario-planning',
+    name: 'Сценарное планирование',
+    description:
+      'Подготовка и оценка альтернативных сценариев развития с учётом рисков и ограничений.',
+    category: 'soft',
+    sources: ['INCOSE'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'observed',
+    roles: ['Аналитик', 'Руководитель проекта']
+  },
+  'ma-support': {
+    id: 'ma-support',
+    name: 'Поддержка сделок M&A',
+    description:
+      'Сопровождение сделок по слияниям и поглощениям, анализ синергий и подготовка материалов.',
+    category: 'domain',
+    sources: ['IIBA'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'documented',
+    roles: ['Аналитик', 'Владелец продукта']
+  },
+  'telemetry-streaming': {
+    id: 'telemetry-streaming',
+    name: 'Телеметрия и потоковая обработка',
+    description:
+      'Интеграция датчиков, построение конвейеров обработки и доставка телеметрии в режиме реального времени.',
+    category: 'hard',
+    sources: ['SFIA'],
+    recommendedLevel: 'Ad',
+    evidenceStatus: 'verified',
+    roles: ['Архитектор', 'Backend']
+  },
+  'iot-integration': {
+    id: 'iot-integration',
+    name: 'Интеграция промышленного IoT',
+    description:
+      'Подключение IoT-устройств, управление протоколами связи и безопасность производственных систем.',
+    category: 'hard',
+    sources: ['INCOSE'],
+    recommendedLevel: 'Ad',
+    evidenceStatus: 'observed',
+    roles: ['Архитектор', 'Эксперт R&D']
+  },
+  'sre-monitoring': {
+    id: 'sre-monitoring',
+    name: 'SRE и эксплуатационный мониторинг',
+    description:
+      'Настройка SLO/SLI, автоматизация мониторинга и инцидент-менеджмент высоконагруженных систем.',
+    category: 'hard',
+    sources: ['SFIA'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'documented',
+    roles: ['Архитектор', 'Backend']
+  },
+  'production-ml': {
+    id: 'production-ml',
+    name: 'ML для оптимизации добычи',
+    description:
+      'Разработка и внедрение моделей машинного обучения для управления добывающими активами.',
+    category: 'hard',
+    sources: ['SFIA'],
+    recommendedLevel: 'Ad',
+    evidenceStatus: 'verified',
+    roles: ['Эксперт R&D', 'Аналитик']
+  },
+  'mlops-production': {
+    id: 'mlops-production',
+    name: 'MLOps в производстве',
+    description:
+      'Организация жизненного цикла ML-моделей, автоматизация деплоя и мониторинга в промышленных условиях.',
+    category: 'hard',
+    sources: ['SFIA'],
+    recommendedLevel: 'Ad',
+    evidenceStatus: 'documented',
+    roles: ['Эксперт R&D', 'Backend']
+  },
+  'value-discovery': {
+    id: 'value-discovery',
+    name: 'Value Discovery',
+    description:
+      'Выявление бизнес-ценности инициатив, формирование гипотез и дорожных карт изменений.',
+    category: 'soft',
+    sources: ['IIBA'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'observed',
+    roles: ['Владелец продукта', 'Аналитик']
+  },
+  'remote-ops-integration': {
+    id: 'remote-ops-integration',
+    name: 'Интеграция дистанционных операций',
+    description:
+      'Связка систем удалённого управления, потоков телеметрии и оперативного реагирования.',
+    category: 'hard',
+    sources: ['INCOSE'],
+    recommendedLevel: 'Ad',
+    evidenceStatus: 'observed',
+    roles: ['Архитектор', 'Эксперт R&D']
+  },
+  'remote-ops-security': {
+    id: 'remote-ops-security',
+    name: 'Безопасность дистанционных операций',
+    description:
+      'Обеспечение кибербезопасности и устойчивости систем дистанционного управления производством.',
+    category: 'hard',
+    sources: ['INCOSE'],
+    recommendedLevel: 'Ad',
+    evidenceStatus: 'observed',
+    roles: ['Архитектор']
+  },
+  'change-management': {
+    id: 'change-management',
+    name: 'Управление изменениями',
+    description:
+      'Подготовка и проведение программ изменений, управление вовлечением и обучением команд.',
+    category: 'soft',
+    sources: ['INCOSE'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'observed',
+    roles: ['Руководитель проекта', 'Владелец продукта']
+  },
+  'wwo-planning': {
+    id: 'wwo-planning',
+    name: 'Планирование ГТМ и ремонтов скважин',
+    description:
+      'Формирование программ ГТМ/ТКРС, координация ресурсов и контроль исполнения.',
+    category: 'domain',
+    sources: ['INCOSE'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'observed',
+    roles: ['Руководитель проекта', 'Аналитик']
+  },
+  'contractor-management': {
+    id: 'contractor-management',
+    name: 'Управление подрядчиками',
+    description:
+      'Организация работы с подрядными организациями, контроль SLA и качества услуг.',
+    category: 'soft',
+    sources: ['INCOSE'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'observed',
+    roles: ['Руководитель проекта']
+  },
+  'process-digitization': {
+    id: 'process-digitization',
+    name: 'Цифровизация производственных процессов',
+    description:
+      'Перевод регламентов и операций в цифровые форматы, автоматизация и контроль исполнения.',
+    category: 'hard',
+    sources: ['INCOSE'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'documented',
+    roles: ['Руководитель проекта', 'Эксперт R&D']
+  },
+  'data-storytelling': {
+    id: 'data-storytelling',
+    name: 'Data Storytelling',
+    description:
+      'Подготовка аналитических историй, визуализаций и презентаций для вовлечения стейкхолдеров.',
+    category: 'soft',
+    sources: ['IIBA'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'observed',
+    roles: ['Аналитик', 'Владелец продукта']
+  },
+  'field-dispatching': {
+    id: 'field-dispatching',
+    name: 'Диспетчеризация полевых работ',
+    description:
+      'Организация оперативного управления бригадами, координация ресурсов и логистики на месторождениях.',
+    category: 'domain',
+    sources: ['INCOSE'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'observed',
+    roles: ['Руководитель проекта', 'Аналитик']
+  },
+  forecasting: {
+    id: 'forecasting',
+    name: 'Прогнозирование производственных показателей',
+    description:
+      'Построение прогнозов на основе исторических данных, сценариев и сезонных факторов.',
+    category: 'hard',
+    sources: ['SFIA'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'documented',
+    roles: ['Аналитик', 'Эксперт R&D']
+  },
+  'mobile-solutions': {
+    id: 'mobile-solutions',
+    name: 'Мобильные решения для производства',
+    description:
+      'Проектирование и внедрение мобильных приложений для оперативного персонала и полевых команд.',
+    category: 'hard',
+    sources: ['SFIA'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'documented',
+    roles: ['Frontend', 'Владелец продукта']
+  },
+  'wwo-analytics': {
+    id: 'wwo-analytics',
+    name: 'Аналитика WWO-процессов',
+    description:
+      'Сбор и анализ показателей ремонтов скважин, подготовка рекомендаций по повышению эффективности.',
+    category: 'hard',
+    sources: ['INCOSE'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'documented',
+    roles: ['Аналитик', 'Эксперт R&D']
+  },
+  'hse-compliance': {
+    id: 'hse-compliance',
+    name: 'Соответствие требованиям HSE',
+    description:
+      'Контроль соблюдения стандартов промышленной безопасности, охраны труда и экологии.',
+    category: 'domain',
+    sources: ['INCOSE'],
+    recommendedLevel: 'P',
+    evidenceStatus: 'observed',
+    roles: ['Руководитель проекта', 'Эксперт R&D']
   }
 };
 

--- a/src/services/matching.test.ts
+++ b/src/services/matching.test.ts
@@ -66,8 +66,8 @@ test('scoreExpertForRole учитывает веса навыков, уровн�
     competencies: ['TypeScript', 'React'],
     availability: 'available',
     skillEvidence: [
-      { name: 'TypeScript', level: 'expert', lastUsedDaysAgo: 30 },
-      { name: 'React', level: 'advanced', lastUsedDaysAgo: 200 }
+      { id: 'typescript', name: 'TypeScript', level: 'expert', lastUsedDaysAgo: 30 },
+      { id: 'react', name: 'React', level: 'advanced', lastUsedDaysAgo: 200 }
     ]
   });
 
@@ -98,7 +98,7 @@ test('scoreExpertForRole снижает итоговый балл при неп�
   const expert = createExpert({
     id: 'expert-partial',
     availability: 'partial',
-    skillEvidence: [{ name: 'Python', level: 'advanced', lastUsedDaysAgo: 10 }],
+    skillEvidence: [{ id: 'python', name: 'Python', level: 'advanced', lastUsedDaysAgo: 10 }],
     competencies: ['Python']
   });
 
@@ -124,14 +124,14 @@ test('buildInitiativeMatchReport агрегирует оценки по роля
     createExpert({
       id: 'expert-alpha',
       fullName: 'Frontend Специалист',
-      skillEvidence: [{ name: 'TypeScript', level: 'expert', lastUsedDaysAgo: 5 }],
+      skillEvidence: [{ id: 'typescript', name: 'TypeScript', level: 'expert', lastUsedDaysAgo: 5 }],
       competencies: ['TypeScript'],
       availability: 'available'
     }),
     createExpert({
       id: 'expert-beta',
       fullName: 'Data Аналитик',
-      skillEvidence: [{ name: 'DataOps', level: 'advanced', lastUsedDaysAgo: 400 }],
+      skillEvidence: [{ id: 'dataops', name: 'DataOps', level: 'advanced', lastUsedDaysAgo: 400 }],
       focusAreas: ['DataOps'],
       availability: 'partial'
     })

--- a/src/services/matching.ts
+++ b/src/services/matching.ts
@@ -24,6 +24,7 @@ const DEFAULT_FRESHNESS_HALF_LIFE_DAYS = 180;
 export type SkillLevel = keyof typeof LEVEL_WEIGHTS;
 
 export type SkillRequirement = {
+  id?: string;
   name: string;
   weight: number;
   requiredLevel?: SkillLevel;
@@ -38,6 +39,7 @@ export type RoleRequirement = {
 };
 
 export type ExpertSkillEvidence = {
+  id: string;
   name: string;
   level: SkillLevel;
   lastUsedDaysAgo: number;
@@ -97,25 +99,48 @@ export type InitiativeMatchReport = {
 
 const LOG_2 = Math.log(2);
 
+function collectRequirementTargets(requirement: SkillRequirement): string[] {
+  const targets = new Set<string>();
+  if (requirement.id) {
+    targets.add(requirement.id.toLowerCase());
+  }
+  if (requirement.name) {
+    targets.add(requirement.name.toLowerCase());
+  }
+  return Array.from(targets);
+}
+
 function findEvidence(
   expert: MatchableExpertProfile,
-  skillName: string
+  requirement: SkillRequirement
 ): ExpertSkillEvidence | undefined {
-  return expert.skillEvidence?.find(
-    (item) => item.name.toLowerCase() === skillName.toLowerCase()
-  );
+  const targets = collectRequirementTargets(requirement);
+  if (targets.length === 0) {
+    return undefined;
+  }
+  return expert.skillEvidence?.find((item) => {
+    const evidenceValues = [item.id, item.name]
+      .filter(Boolean)
+      .map((value) => value.toLowerCase());
+    return evidenceValues.some((value) => targets.includes(value));
+  });
 }
 
 function hasSkillInProfile(
   expert: MatchableExpertProfile,
-  skillName: string
+  requirement: SkillRequirement
 ): boolean {
-  const lower = skillName.toLowerCase();
-  return (
-    expert.competencies.some((skill) => skill.toLowerCase() === lower) ||
-    expert.consultingSkills.some((skill) => skill.toLowerCase() === lower) ||
-    expert.focusAreas.some((skill) => skill.toLowerCase() === lower)
-  );
+  const targets = collectRequirementTargets(requirement);
+  if (targets.length === 0) {
+    return false;
+  }
+  const normalizedCompetencies = [
+    ...expert.competencies,
+    ...expert.consultingSkills,
+    ...expert.focusAreas
+  ].map((skill) => skill.toLowerCase());
+
+  return normalizedCompetencies.some((skill) => targets.includes(skill));
 }
 
 function calculateFreshnessFactor(
@@ -135,8 +160,8 @@ function calculateSkillCoverage(
   requirement: SkillRequirement,
   expert: MatchableExpertProfile
 ): SkillCoverageReport {
-  const evidence = findEvidence(expert, requirement.name);
-  const hasProfileSkill = hasSkillInProfile(expert, requirement.name);
+  const evidence = findEvidence(expert, requirement);
+  const hasProfileSkill = hasSkillInProfile(expert, requirement);
   const hasSkill = Boolean(evidence) || hasProfileSkill;
 
   const requiredLevelWeight = requirement.requiredLevel

--- a/src/utils/initiativeMatching.test.ts
+++ b/src/utils/initiativeMatching.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildRoleMatchReports,
+  type RolePlanningDraft
+} from './initiativeMatching';
+import type { ExpertProfile } from '../data';
+
+const baseExpert: ExpertProfile = {
+  id: 'expert-1',
+  fullName: 'Тестовый Эксперт',
+  title: 'Специалист',
+  summary: 'Описание эксперта',
+  domains: [],
+  modules: [],
+  competencies: [],
+  consultingSkills: [],
+  focusAreas: [],
+  experienceYears: 5,
+  location: 'Москва',
+  contact: 'expert@example.com',
+  languages: ['ru'],
+  notableProjects: [],
+  availability: 'available',
+  availabilityComment: '',
+  skills: []
+};
+
+describe('buildRoleMatchReports', () => {
+  it('includes work item skills in role requirements and scoring', () => {
+    const role: RolePlanningDraft = {
+      id: 'role-1',
+      role: 'Аналитик',
+      required: 1,
+      skills: [],
+      workItems: [
+        {
+          id: 'work-1',
+          title: 'Исследование',
+          description: 'Аналитическая задача',
+          startDay: 0,
+          durationDays: 5,
+          effortDays: 5,
+          tasks: ['Оптимизация размещения инфраструктуры']
+        }
+      ]
+    };
+
+    const expert: ExpertProfile = {
+      ...baseExpert,
+      competencies: ['Оптимизация размещения инфраструктуры']
+    };
+
+    const [report] = buildRoleMatchReports([role], [expert]);
+
+    assert.ok(report, 'Report should be generated');
+    assert.deepEqual(report.requirement.skills.map((skill) => skill.name), [
+      'Оптимизация размещения инфраструктуры'
+    ]);
+
+    const [match] = report.matches;
+    assert.ok(match, 'Match should be calculated for the expert');
+    assert.ok(
+      match.explanation.normalizedSkillScore > 0,
+      'Skill score should reflect provided task skill'
+    );
+  });
+});
+

--- a/src/utils/initiativeMatching.test.ts
+++ b/src/utils/initiativeMatching.test.ts
@@ -58,12 +58,64 @@ describe('buildRoleMatchReports', () => {
     assert.deepEqual(report.requirement.skills.map((skill) => skill.name), [
       'Оптимизация размещения инфраструктуры'
     ]);
+    assert.deepEqual(report.requirement.skills.map((skill) => skill.id), ['layout-optimization']);
 
     const [match] = report.matches;
     assert.ok(match, 'Match should be calculated for the expert');
     assert.ok(
       match.explanation.normalizedSkillScore > 0,
       'Skill score should reflect provided task skill'
+    );
+  });
+
+  it('maps task identifiers to catalog skills for ranking', () => {
+    const role: RolePlanningDraft = {
+      id: 'role-2',
+      role: 'Аналитик',
+      required: 1,
+      skills: [],
+      workItems: [
+        {
+          id: 'work-2',
+          title: 'Нормализация',
+          description: 'Приведение источников к модели данных',
+          startDay: 0,
+          durationDays: 10,
+          effortDays: 10,
+          tasks: ['data-normalization']
+        }
+      ]
+    };
+
+    const expert: ExpertProfile = {
+      ...baseExpert,
+      id: 'expert-data',
+      skills: [
+        {
+          id: 'data-normalization',
+          level: 'A',
+          proofStatus: 'verified',
+          artifacts: [],
+          interest: 'high',
+          availableFte: 0.5,
+          usage: { from: '2024-01-01' }
+        }
+      ]
+    };
+
+    const [report] = buildRoleMatchReports([role], [expert]);
+    assert.ok(report.requirement.skills[0]?.id === 'data-normalization');
+    assert.equal(report.requirement.skills[0]?.name, 'Подготовка и нормализация данных');
+
+    const [match] = report.matches;
+    assert.ok(match, 'Match should exist for expert with matching skill evidence');
+    assert.ok(
+      match.explanation.normalizedSkillScore > 0.05,
+      'Expected skill score to be greater than zero for matching evidence'
+    );
+    assert.ok(
+      match.explanation.totalScore > 0.01,
+      'Total score should reflect matching skill and availability'
     );
   });
 });

--- a/src/utils/initiativeMatching.ts
+++ b/src/utils/initiativeMatching.ts
@@ -96,16 +96,39 @@ function toMatchableExpert(expert: ExpertProfile): MatchableExpertProfile {
   };
 }
 
+function deduplicateSkills(skills: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  skills.forEach((skill) => {
+    const trimmed = skill.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const key = trimmed.toLowerCase();
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(trimmed);
+    }
+  });
+
+  return result;
+}
+
 function buildSkillRequirements(role: RolePlanningDraft): SkillRequirement[] {
-  const explicitSkills = role.skills.map((skill) => skill.trim()).filter(Boolean);
+  const explicitSkills = deduplicateSkills(role.skills);
+  const taskSkills = deduplicateSkills(role.workItems.flatMap((work) => work.tasks));
+  const providedSkills = deduplicateSkills([...explicitSkills, ...taskSkills]);
+
   const defaultSkills =
-    explicitSkills.length > 0
+    providedSkills.length > 0
       ? []
       : getSkillsByRole(role.role).map((skill) => skill.name).filter(Boolean);
 
-  const skillNames = Array.from(new Set([...explicitSkills, ...defaultSkills]));
-  const normalizedNames = skillNames.length > 0 ? skillNames : [`Экспертиза: ${role.role}`];
-  const weight = 1 / normalizedNames.length;
+  const allSkills = deduplicateSkills([...providedSkills, ...defaultSkills]);
+  const normalizedNames = allSkills.length > 0 ? allSkills : [`Экспертиза: ${role.role}`];
+  const weight = normalizedNames.length > 0 ? 1 / normalizedNames.length : 1;
   const level = defaultRoleLevel[role.role] ?? 'advanced';
 
   return normalizedNames.map((name) => ({

--- a/src/utils/initiativeMatching.ts
+++ b/src/utils/initiativeMatching.ts
@@ -78,6 +78,7 @@ function toSkillEvidence(skill: ExpertSkill): ExpertSkillEvidence {
     : Math.max(0, Math.round((Date.now() - timestamp) / MS_IN_DAY));
 
   return {
+    id: skill.id,
     name,
     level: skillLevelMap[skill.level] ?? 'novice',
     lastUsedDaysAgo: daysAgo ?? 365
@@ -96,43 +97,117 @@ function toMatchableExpert(expert: ExpertProfile): MatchableExpertProfile {
   };
 }
 
-function deduplicateSkills(skills: string[]): string[] {
-  const seen = new Set<string>();
-  const result: string[] = [];
+type NormalizedSkill = {
+  id?: string;
+  name: string;
+};
 
-  skills.forEach((skill) => {
-    const trimmed = skill.trim();
-    if (!trimmed) {
+const skillDefinitions = Object.values(skillCatalog);
+
+function slugToTitle(slug: string): string {
+  return slug
+    .split('-')
+    .filter(Boolean)
+    .map((chunk) => chunk.charAt(0).toUpperCase() + chunk.slice(1))
+    .join(' ');
+}
+
+function lookupSkillDefinition(input: string) {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const direct = skillCatalog[trimmed];
+  if (direct) {
+    return direct;
+  }
+  const lower = trimmed.toLowerCase();
+  const lowerIdMatch = skillCatalog[lower];
+  if (lowerIdMatch) {
+    return lowerIdMatch;
+  }
+  return skillDefinitions.find((definition) => definition.name.toLowerCase() === lower);
+}
+
+function normalizeSkillInput(skill: string | NormalizedSkill): NormalizedSkill | null {
+  if (typeof skill !== 'string') {
+    const id = skill.id?.trim();
+    const name = skill.name.trim();
+    if (!id && !name) {
+      return null;
+    }
+    if (id) {
+      const definition = lookupSkillDefinition(id);
+      if (definition) {
+        return { id: definition.id, name: definition.name };
+      }
+      return { id, name: name || slugToTitle(id) };
+    }
+    const definition = lookupSkillDefinition(name);
+    if (definition) {
+      return { id: definition.id, name: definition.name };
+    }
+    return { name };
+  }
+
+  const trimmed = skill.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const definition = lookupSkillDefinition(trimmed);
+  if (definition) {
+    return { id: definition.id, name: definition.name };
+  }
+
+  if (/^[a-z0-9-]+$/i.test(trimmed)) {
+    return { id: trimmed.toLowerCase(), name: slugToTitle(trimmed) };
+  }
+
+  return { name: trimmed };
+}
+
+function normalizeSkillList(inputs: (string | NormalizedSkill)[]): NormalizedSkill[] {
+  const seen = new Set<string>();
+  const result: NormalizedSkill[] = [];
+
+  inputs.forEach((input) => {
+    const normalized = normalizeSkillInput(input);
+    if (!normalized) {
       return;
     }
 
-    const key = trimmed.toLowerCase();
-    if (!seen.has(key)) {
-      seen.add(key);
-      result.push(trimmed);
+    const key = normalized.id?.toLowerCase() ?? normalized.name.toLowerCase();
+    if (seen.has(key)) {
+      return;
     }
+
+    seen.add(key);
+    result.push(normalized);
   });
 
   return result;
 }
 
 function buildSkillRequirements(role: RolePlanningDraft): SkillRequirement[] {
-  const explicitSkills = deduplicateSkills(role.skills);
-  const taskSkills = deduplicateSkills(role.workItems.flatMap((work) => work.tasks));
-  const providedSkills = deduplicateSkills([...explicitSkills, ...taskSkills]);
+  const explicitSkills = normalizeSkillList(role.skills);
+  const taskSkills = normalizeSkillList(role.workItems.flatMap((work) => work.tasks));
+  const providedSkills = normalizeSkillList([...explicitSkills, ...taskSkills]);
 
   const defaultSkills =
     providedSkills.length > 0
       ? []
-      : getSkillsByRole(role.role).map((skill) => skill.name).filter(Boolean);
+      : getSkillsByRole(role.role).map((skill) => ({ id: skill.id, name: skill.name }));
 
-  const allSkills = deduplicateSkills([...providedSkills, ...defaultSkills]);
-  const normalizedNames = allSkills.length > 0 ? allSkills : [`Экспертиза: ${role.role}`];
-  const weight = normalizedNames.length > 0 ? 1 / normalizedNames.length : 1;
+  const allSkills = normalizeSkillList([...providedSkills, ...defaultSkills]);
+  const normalizedSkills =
+    allSkills.length > 0 ? allSkills : [{ name: `Экспертиза: ${role.role}` }];
+  const weight = normalizedSkills.length > 0 ? 1 / normalizedSkills.length : 1;
   const level = defaultRoleLevel[role.role] ?? 'advanced';
 
-  return normalizedNames.map((name) => ({
-    name,
+  return normalizedSkills.map((skill) => ({
+    id: skill.id,
+    name: skill.name,
     weight,
     requiredLevel: level
   }));

--- a/src/utils/initiativePlanner.test.ts
+++ b/src/utils/initiativePlanner.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { preparePlannerModuleSelections } from './initiativePlanner';
+
+describe('preparePlannerModuleSelections', () => {
+  it('trims blank entries and returns deduplicated modules', () => {
+    const { potentialModules, plannedModuleIds } = preparePlannerModuleSelections([
+      ' module-a ',
+      'module-b',
+      'module-a',
+      '',
+      '   '
+    ]);
+
+    assert.deepEqual(potentialModules, ['module-a', 'module-b']);
+    assert.deepEqual(plannedModuleIds, ['module-a', 'module-b']);
+  });
+
+  it('handles empty inputs', () => {
+    const { potentialModules, plannedModuleIds } = preparePlannerModuleSelections([]);
+
+    assert.deepEqual(potentialModules, []);
+    assert.deepEqual(plannedModuleIds, []);
+  });
+});

--- a/src/utils/initiativePlanner.ts
+++ b/src/utils/initiativePlanner.ts
@@ -1,0 +1,15 @@
+export function preparePlannerModuleSelections(moduleIds: string[]): {
+  potentialModules: string[];
+  plannedModuleIds: string[];
+} {
+  const normalized = moduleIds
+    .map((moduleId) => moduleId.trim())
+    .filter((moduleId) => moduleId.length > 0);
+
+  const unique = Array.from(new Set(normalized));
+
+  return {
+    potentialModules: unique,
+    plannedModuleIds: [...unique]
+  };
+}


### PR DESCRIPTION
## Summary
- merge explicit role skills with work item task skills when building initiative requirements
- fall back to default role skills only when no explicit or task skills are provided and normalize deduplication
- cover the behavior with a unit test for `buildRoleMatchReports`

## Testing
- npm exec tsx --test src/utils/initiativeMatching.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f62a1a421c8332b472d1e12e15bd56