### PR TITLE
Rework initiative scoring to focus on skill coverage

### DIFF
--- a/src/services/matching.test.ts
+++ b/src/services/matching.test.ts
@@ -49,7 +49,7 @@ function assertApproximately(actual: number, expected: number, epsilon = 1e-6) {
   );
 }
 
-test('scoreExpertForRole учитывает веса навыков, уровни, свежесть и доступность', () => {
+test('scoreExpertForRole даёт 100% при полном совпадении навыков', () => {
   const requirement: RoleRequirement = {
     roleId: 'role-ts',
     roleName: 'Frontend Lead',
@@ -73,50 +73,38 @@ test('scoreExpertForRole учитывает веса навыков, уровн�
 
   const { explanation } = scoreExpertForRole(requirement, expert);
 
-  const expectedTypeScriptFreshness = Math.exp((-Math.log(2) * 30) / 180);
-  const expectedReactFreshness = Math.exp((-Math.log(2) * 200) / 90);
-  const expectedSkillScore =
-    (0.6 * 1 * expectedTypeScriptFreshness + 0.4 * 1 * expectedReactFreshness) / 1;
-
-  assertApproximately(explanation.normalizedSkillScore, expectedSkillScore, 1e-6);
+  assertApproximately(explanation.normalizedSkillScore, 1, 1e-6);
   assertApproximately(explanation.availabilityMultiplier, 1);
   assertApproximately(explanation.fteSaturation, 1);
-  assertApproximately(explanation.totalScore, expectedSkillScore, 1e-6);
+  assertApproximately(explanation.totalScore, 1, 1e-6);
 
   const reactRisk = explanation.risks.find((risk) => risk.includes('React'));
   assert.ok(reactRisk, 'Ожидался риск по устареванию навыка React');
 });
 
-test('scoreExpertForRole снижает итоговый балл при неполной доступности по FTE', () => {
+test('scoreExpertForRole рассчитывает покрытие навыков по количеству совпадений', () => {
   const requirement: RoleRequirement = {
     roleId: 'role-data',
     roleName: 'Data Engineer',
     requiredFte: 1,
-    skills: [{ name: 'Python', weight: 1, requiredLevel: 'advanced', freshnessHalfLifeDays: 120 }]
+    skills: [
+      { name: 'Python', weight: 0.5, requiredLevel: 'advanced', freshnessHalfLifeDays: 120 },
+      { name: 'Airflow', weight: 0.5, requiredLevel: 'advanced', freshnessHalfLifeDays: 120 }
+    ]
   };
 
   const expert = createExpert({
     id: 'expert-partial',
-    availability: 'partial',
     skillEvidence: [{ id: 'python', name: 'Python', level: 'advanced', lastUsedDaysAgo: 10 }],
     competencies: ['Python']
   });
 
   const { explanation } = scoreExpertForRole(requirement, expert);
 
-  const expectedFreshness = Math.exp((-Math.log(2) * 10) / 120);
-  const expectedSkillScore = expectedFreshness; // levelFactor=1, weight=1
-  const expectedTotal = expectedSkillScore * 0.65 * 0.5;
-
-  assertApproximately(explanation.normalizedSkillScore, expectedSkillScore, 1e-6);
-  assertApproximately(explanation.availabilityMultiplier, 0.65, 1e-6);
-  assertApproximately(explanation.fteSaturation, 0.5, 1e-6);
-  assertApproximately(explanation.totalScore, expectedTotal, 1e-6);
-
-  assert.ok(
-    explanation.risks.includes('Недостаточная доступность по FTE для роли'),
-    'Должен сигнализироваться риск по FTE'
-  );
+  assertApproximately(explanation.normalizedSkillScore, 0.5, 1e-6);
+  assertApproximately(explanation.availabilityMultiplier, 1, 1e-6);
+  assertApproximately(explanation.fteSaturation, 1, 1e-6);
+  assertApproximately(explanation.totalScore, 0.5, 1e-6);
 });
 
 test('buildInitiativeMatchReport агрегирует оценки по ролям инициативы', () => {
@@ -165,16 +153,11 @@ test('buildInitiativeMatchReport агрегирует оценки по роля
 
   const dataOpsReport = report.roleReports[1];
   assert.equal(dataOpsReport.topMatch?.expert.id, 'expert-beta');
-  assert.ok(dataOpsReport.topMatch!.explanation.totalScore < 0.3);
+  assertApproximately(dataOpsReport.topMatch!.explanation.totalScore, 1, 1e-6);
 
   const expectedOverall =
     (frontendReport.topMatch!.explanation.totalScore +
       dataOpsReport.topMatch!.explanation.totalScore) /
     2;
   assertApproximately(report.overallScore, expectedOverall, 1e-6);
-
-  assert.ok(
-    report.overallRisks.some((risk) => risk.includes('Эксперт частично доступен для инициативы')),
-    'В совокупных рисках должна отображаться частичная доступность'
-  );
 });

--- a/src/services/matching.ts
+++ b/src/services/matching.ts
@@ -1,4 +1,4 @@
-import { type ExpertAvailability, type ExpertProfile } from '../data';
+import { type ExpertProfile } from '../data';
 
 const LEVEL_WEIGHTS = {
   novice: 0.4,
@@ -6,18 +6,6 @@ const LEVEL_WEIGHTS = {
   advanced: 0.9,
   expert: 1
 } as const;
-
-const AVAILABILITY_MULTIPLIERS: Record<ExpertAvailability, number> = {
-  available: 1,
-  partial: 0.65,
-  busy: 0.25
-};
-
-const AVAILABILITY_FTE: Record<ExpertAvailability, number> = {
-  available: 1,
-  partial: 0.5,
-  busy: 0.1
-};
 
 const DEFAULT_FRESHNESS_HALF_LIFE_DAYS = 180;
 
@@ -199,7 +187,7 @@ function calculateSkillCoverage(
     gaps.push(`Навык «${requirement.name}» есть в профиле, но без подтверждения уровня/свежести`);
   }
 
-  const coverageScore = requirement.weight * hasSkill * levelFactor * freshnessFactor;
+  const coverageScore = requirement.weight * (hasSkill ? 1 : 0);
 
   return {
     skill: requirement,
@@ -211,18 +199,8 @@ function calculateSkillCoverage(
   };
 }
 
-function calculateRisks(
-  coverage: SkillCoverageReport[],
-  availabilityMultiplier: number,
-  fteSaturation: number
-): string[] {
+function calculateRisks(coverage: SkillCoverageReport[]): string[] {
   const risks = coverage.flatMap((item) => item.gaps);
-  if (availabilityMultiplier < 1) {
-    risks.push('Эксперт частично доступен для инициативы');
-  }
-  if (fteSaturation < 1) {
-    risks.push('Недостаточная доступность по FTE для роли');
-  }
   return Array.from(new Set(risks));
 }
 
@@ -241,12 +219,11 @@ export function scoreExpertForRole(
       : coverageReports.reduce((sum, report) => sum + report.coverageScore, 0) /
         totalWeight;
 
-  const availabilityMultiplier = AVAILABILITY_MULTIPLIERS[expert.availability];
-  const expertFte = expert.fteCapacity ?? AVAILABILITY_FTE[expert.availability];
-  const fteSaturation = Math.min(expertFte / Math.max(requirement.requiredFte, 0.01), 1);
+  const availabilityMultiplier = 1;
+  const fteSaturation = 1;
 
-  const totalScore = normalizedSkillScore * availabilityMultiplier * fteSaturation;
-  const risks = calculateRisks(coverageReports, availabilityMultiplier, fteSaturation);
+  const totalScore = normalizedSkillScore;
+  const risks = calculateRisks(coverageReports);
 
   return {
     expert,

--- a/src/utils/initiativeMatching.ts
+++ b/src/utils/initiativeMatching.ts
@@ -269,12 +269,10 @@ export function buildCandidatesFromReport(report: RoleMatchReport): InitiativeCa
   }
 
   const skillCount = report.matches[0]?.explanation.skillCoverage.length ?? 0;
-  const skillWeight = skillCount > 0 ? 0.6 / skillCount : 0;
+  const skillWeight = skillCount > 0 ? 1 / skillCount : 0;
 
   return report.matches.map((match) => {
     const skillScore = match.explanation.normalizedSkillScore;
-    const availability = match.explanation.availabilityMultiplier;
-    const fte = match.explanation.fteSaturation;
     const totalScore = Math.min(100, Math.max(0, Math.round(match.explanation.totalScore * 100)));
 
     const commentParts: string[] = [];
@@ -286,17 +284,6 @@ export function buildCandidatesFromReport(report: RoleMatchReport): InitiativeCa
       commentParts.push('Есть заметные пробелы по навыкам роли');
     }
 
-    if (availability >= 1 && fte >= 1) {
-      commentParts.push('Доступен для подключения в полном объёме');
-    } else {
-      if (availability < 1) {
-        commentParts.push('Доступность ограничена текущей загрузкой');
-      }
-      if (fte < 1) {
-        commentParts.push('Требуется подстраховка по FTE');
-      }
-    }
-
     if (match.explanation.risks.length > 0) {
       commentParts.push(match.explanation.risks[0]);
     }
@@ -304,26 +291,9 @@ export function buildCandidatesFromReport(report: RoleMatchReport): InitiativeCa
     const scoreDetails = match.explanation.skillCoverage.map((coverage) => ({
       criterion: coverage.skill.name,
       weight: Number(skillWeight.toFixed(2)),
-      value: Number(
-        (coverage.hasSkill ? coverage.levelFactor * coverage.freshnessFactor : 0).toFixed(2)
-      ),
+      value: Number((coverage.hasSkill ? 1 : 0).toFixed(2)),
       comment: coverage.gaps[0]
     }));
-
-    scoreDetails.push(
-      {
-        criterion: 'Доступность',
-        weight: 0.2,
-        value: Number(availability.toFixed(2)),
-        comment: availability < 1 ? 'Эксперт частично занят в других инициативах' : undefined
-      },
-      {
-        criterion: 'Покрытие FTE',
-        weight: 0.2,
-        value: Number(fte.toFixed(2)),
-        comment: fte < 1 ? 'Недостаточно часов для полного закрытия роли' : undefined
-      }
-    );
 
     const fitComment = commentParts.join('. ').replace(/\.+$/, '') + '.';
 


### PR DESCRIPTION
## Summary
- remove availability and FTE multipliers from role scoring logic
- calculate skill coverage as a count-based percentage and update initiative candidate details
- refresh matching unit tests for the simplified scoring model

## Testing
- npm exec tsx --test src/services/matching.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f6c0a5bd208332bcab81a4af7cf7b3