### PR TITLE
Prevent repeated layout sync from engine ticks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -146,6 +146,7 @@ function App() {
   const loadedGraphsRef = useRef(new Set<string>());
   const adminNoticeIdRef = useRef(0);
   const moduleDraftPrefillIdRef = useRef(0);
+  const shouldCaptureEngineLayoutRef = useRef(true);
   const [moduleDraftPrefill, setModuleDraftPrefill] = useState<ModuleDraftPrefillRequest | null>(null);
   const handleModuleDraftPrefillApplied = useCallback(() => {
     setModuleDraftPrefill(null);
@@ -290,6 +291,7 @@ function App() {
 
         return layoutsEqual(prev, merged) ? prev : merged;
       });
+      shouldCaptureEngineLayoutRef.current = true;
       hasLoadedSnapshotRef.current = true;
       hasPendingPersistRef.current = false;
     },
@@ -1530,6 +1532,15 @@ function App() {
 
   const handleLayoutChange = useCallback(
     (positions: Record<string, GraphLayoutNodePosition>, reason: 'drag' | 'engine') => {
+      if (reason === 'engine') {
+        if (!shouldCaptureEngineLayoutRef.current) {
+          return;
+        }
+        shouldCaptureEngineLayoutRef.current = false;
+      } else {
+        shouldCaptureEngineLayoutRef.current = true;
+      }
+
       let didChange = false;
       setLayoutPositions((prev) => {
         const merged = mergeLayoutPositions(prev, positions);
@@ -1617,6 +1628,7 @@ function App() {
           [moduleId]: initialPosition
         };
       });
+      shouldCaptureEngineLayoutRef.current = true;
       setSelectedDomains((prev) => {
         const next = new Set(prev);
         createdModule?.domains.forEach((domainId) => {
@@ -1773,6 +1785,7 @@ function App() {
         });
         return next;
       });
+      shouldCaptureEngineLayoutRef.current = true;
 
       setSelectedNode((prev) => {
         if (!prev) {
@@ -2009,6 +2022,7 @@ function App() {
         });
         return next;
       });
+      shouldCaptureEngineLayoutRef.current = true;
       setSelectedNode((prev) => (prev && removedIds.has(prev.id) ? null : prev));
       showAdminNotice(
         'success',
@@ -2265,6 +2279,7 @@ function App() {
         delete next[artifactId];
         return next;
       });
+      shouldCaptureEngineLayoutRef.current = true;
 
       setSelectedNode((prev) => (prev && prev.id === artifactId ? null : prev));
       showAdminNotice('success', `Артефакт «${existing.name}» удалён.`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -263,6 +263,7 @@ function App() {
       setProductFilter(buildProductList(snapshot.modules));
       setCompanyFilter(null);
       setSelectedDomains(new Set(domainIds));
+      let resolvedLayoutPositions: Record<string, GraphLayoutNodePosition> | null = null;
       setLayoutPositions((prev) => {
         const serverPositions = snapshot.layout?.nodes ?? {};
         const prunedServerPositions = pruneLayoutPositions(serverPositions, activeNodeIds);
@@ -270,8 +271,10 @@ function App() {
 
         if (!hasExistingLayout) {
           if (layoutsEqual(prev, prunedServerPositions)) {
+            resolvedLayoutPositions = prev;
             return prev;
           }
+          resolvedLayoutPositions = prunedServerPositions;
           return prunedServerPositions;
         }
 
@@ -289,9 +292,15 @@ function App() {
           }
         });
 
-        return layoutsEqual(prev, merged) ? prev : merged;
+        const nextLayout = layoutsEqual(prev, merged) ? prev : merged;
+        resolvedLayoutPositions = nextLayout;
+        return nextLayout;
       });
-      shouldCaptureEngineLayoutRef.current = true;
+      const nextLayoutPositions = resolvedLayoutPositions ?? {};
+      shouldCaptureEngineLayoutRef.current = needsEngineLayoutCapture(
+        nextLayoutPositions,
+        activeNodeIds
+      );
       hasLoadedSnapshotRef.current = true;
       hasPendingPersistRef.current = false;
     },
@@ -3495,6 +3504,28 @@ function buildProductList(modules: ModuleNode[]): string[] {
     }
   });
   return Array.from(products).sort((a, b) => a.localeCompare(b, 'ru'));
+}
+
+function needsEngineLayoutCapture(
+  layout: Record<string, GraphLayoutNodePosition>,
+  activeIds: Set<string>
+): boolean {
+  for (const id of activeIds) {
+    const position = layout[id];
+    if (!position) {
+      return true;
+    }
+
+    if (typeof position.x !== 'number' || Number.isNaN(position.x)) {
+      return true;
+    }
+
+    if (typeof position.y !== 'number' || Number.isNaN(position.y)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function mergeLayoutPositions(


### PR DESCRIPTION
## Summary
- throttle layout updates from the force graph engine so we ignore repeated engine ticks once the layout has been captured
- reset engine layout capture when a new snapshot is applied or when graph structure changes, keeping drag updates intact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f6c6ae9d788332bcfd015aa55bb072