### PR TITLE
Fix overflow in initiative planner candidate cards

### DIFF
--- a/src/components/InitiativePlanner.module.css
+++ b/src/components/InitiativePlanner.module.css
@@ -136,12 +136,15 @@
   justify-content: space-between;
   align-items: flex-start;
   gap: 12px;
+  flex-wrap: wrap;
 }
 
 .candidateTitle {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  min-width: 0;
+  word-break: break-word;
 }
 
 .candidateActions {
@@ -149,6 +152,7 @@
   flex-wrap: wrap;
   gap: 8px;
   justify-content: flex-end;
+  min-width: 0;
 }
 
 .candidateDetails {
@@ -161,6 +165,8 @@
 
 .candidateComment {
   max-width: 640px;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .scoreDetails {
@@ -173,12 +179,20 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+  word-break: break-word;
 }
 
 .riskTagList {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+}
+
+.riskTag {
+  white-space: normal;
+  word-break: break-word;
+  text-align: left;
+  max-width: 100%;
 }
 
 .riskSection {

--- a/src/components/InitiativePlanner.tsx
+++ b/src/components/InitiativePlanner.tsx
@@ -286,7 +286,13 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
                     {candidate.riskTags.length > 0 && (
                       <div className={styles.riskTagList}>
                         {candidate.riskTags.map((tag) => (
-                          <Badge key={`${candidateKey}-${tag}`} size="xs" view="stroked" label={tag} />
+                          <Badge
+                            key={`${candidateKey}-${tag}`}
+                            size="xs"
+                            view="stroked"
+                            label={tag}
+                            className={styles.riskTag}
+                          />
                         ))}
                       </div>
                     )}


### PR DESCRIPTION
## Summary
- allow candidate headers and comments to wrap within their cards
- enable risk tag badges to break long labels so text stays inside the card

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f6cd75702883329fa0f05d9d9437e1