### PR TITLE
Fix overflow in initiative recommendation cards

### DIFF
--- a/src/components/InitiativeCreationModal.module.css
+++ b/src/components/InitiativeCreationModal.module.css
@@ -177,6 +177,9 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  max-height: min(60vh, 480px);
+  overflow-y: auto;
+  padding-right: 4px;
 }
 
 .recommendationCandidate {
@@ -209,10 +212,23 @@
   word-break: break-word;
 }
 
+.recommendationCandidateComment {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .recommendationRisks {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  align-items: flex-start;
+}
+
+.recommendationRiskTag {
+  white-space: normal;
+  word-break: break-word;
+  max-width: 100%;
+  text-align: left;
 }
 
 .footer {

--- a/src/components/InitiativeCreationModal.tsx
+++ b/src/components/InitiativeCreationModal.tsx
@@ -1337,7 +1337,12 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
                                       label={`${candidate.score} баллов`}
                                     />
                                   </div>
-                                  <Text size="xs">{candidate.fitComment}</Text>
+                                  <Text
+                                    size="xs"
+                                    className={styles.recommendationCandidateComment}
+                                  >
+                                    {candidate.fitComment}
+                                  </Text>
                                   {candidate.riskTags.length > 0 && (
                                     <div className={styles.recommendationRisks}>
                                       {candidate.riskTags.slice(0, 3).map((risk) => (
@@ -1345,6 +1350,7 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
                                           key={`${candidate.expertId}-${risk}`}
                                           size="2xs"
                                           view="ghost"
+                                          className={styles.recommendationRiskTag}
                                           label={risk}
                                         />
                                       ))}


### PR DESCRIPTION
## Summary
- allow recommendation candidate comments and risk tags to wrap and expand within the card
- limit recommendation candidate lists to a scrollable area per role to avoid overflowing cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f7d2353ac88332988fbcd319a78a29