### PR TITLE
feat: reposition initiative gantt layout

### DIFF
--- a/src/components/InitiativeCreationModal.module.css
+++ b/src/components/InitiativeCreationModal.module.css
@@ -38,6 +38,41 @@
   background: var(--color-bg-default);
 }
 
+.workPlanningSection {
+  gap: 24px;
+}
+
+.workPlanningGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.workColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 0;
+}
+
+.ganttColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 0;
+}
+
+.ganttPreview {
+  flex: 1 1 auto;
+  min-height: 320px;
+  border-radius: 12px;
+  border: 1px solid var(--color-bg-border);
+  background: var(--color-bg-secondary);
+  padding: 16px;
+  overflow: auto;
+}
+
 .gridTwoCols {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -235,4 +270,14 @@
   display: flex;
   justify-content: flex-end;
   gap: 12px;
+}
+
+@media (max-width: 1100px) {
+  .workPlanningGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .ganttPreview {
+    min-height: 240px;
+  }
 }

--- a/src/components/InitiativeCreationModal.tsx
+++ b/src/components/InitiativeCreationModal.tsx
@@ -1043,218 +1043,227 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
             </>
           )}
           {activeStep === 'work' && (
-            <>
-              <section className={styles.section}>
-                <div className={styles.sectionHeader}>
-                  <Text size="s" weight="semibold">
-                    План работ и задачи сотрудников
-                  </Text>
-                  <Button size="s" view="ghost" label="Добавить работу" onClick={handleAddWork} />
-                </div>
-                <div className={styles.workList}>
-                  {works.map((work) => {
-                    const scheduleBounds = work.assignments.map((assignment) => {
-                      const normalizedStart = Math.max(0, Math.round(assignment.startDay));
-                      const normalizedDuration = Math.max(1, Math.round(assignment.durationDays));
-                      return {
-                        start: normalizedStart,
-                        end: normalizedStart + normalizedDuration
-                      };
-                    });
-                    const hasAssignments = scheduleBounds.length > 0;
-                    const workStart = hasAssignments
-                      ? scheduleBounds.reduce((min, current) => Math.min(min, current.start), Infinity)
-                      : 0;
-                    const workEnd = hasAssignments
-                      ? scheduleBounds.reduce((max, current) => Math.max(max, current.end), 0)
-                      : 0;
-                    const displayStart = Number.isFinite(workStart) ? workStart : 0;
-                    const displayEnd = hasAssignments
-                      ? Math.max(displayStart + 1, workEnd)
-                      : displayStart + 1;
-                    const workDuration = hasAssignments ? Math.max(1, displayEnd - displayStart) : 0;
+            <section className={`${styles.section} ${styles.workPlanningSection}`}>
+              <div className={styles.workPlanningGrid}>
+                <div className={styles.workColumn}>
+                  <div className={styles.sectionHeader}>
+                    <Text size="s" weight="semibold">
+                      План работ и задачи сотрудников
+                    </Text>
+                    <Button
+                      size="s"
+                      view="ghost"
+                      label="Добавить работу"
+                      onClick={handleAddWork}
+                    />
+                  </div>
+                  <div className={styles.workList}>
+                    {works.map((work) => {
+                      const scheduleBounds = work.assignments.map((assignment) => {
+                        const normalizedStart = Math.max(0, Math.round(assignment.startDay));
+                        const normalizedDuration = Math.max(1, Math.round(assignment.durationDays));
+                        return {
+                          start: normalizedStart,
+                          end: normalizedStart + normalizedDuration
+                        };
+                      });
+                      const hasAssignments = scheduleBounds.length > 0;
+                      const workStart = hasAssignments
+                        ? scheduleBounds.reduce((min, current) => Math.min(min, current.start), Infinity)
+                        : 0;
+                      const workEnd = hasAssignments
+                        ? scheduleBounds.reduce((max, current) => Math.max(max, current.end), 0)
+                        : 0;
+                      const displayStart = Number.isFinite(workStart) ? workStart : 0;
+                      const displayEnd = hasAssignments
+                        ? Math.max(displayStart + 1, workEnd)
+                        : displayStart + 1;
+                      const workDuration = hasAssignments ? Math.max(1, displayEnd - displayStart) : 0;
 
-                    return (
-                      <Card
-                        key={work.id}
-                        className={styles.workCard}
-                        verticalSpace="l"
-                        horizontalSpace="l"
-                      >
-                        <div className={styles.workHeader}>
-                          <TextField
-                            size="s"
-                            label="Название работы"
-                            placeholder="Например, Подготовка данных"
-                            value={work.title}
-                            onChange={(value) => handleWorkChange(work.id, { title: value ?? '' })}
-                          />
-                          <Button
-                            size="s"
-                            view="ghost"
-                            label="Удалить"
-                            onClick={() => handleRemoveWork(work.id)}
-                            disabled={works.length <= 1}
-                          />
-                        </div>
-                        <TextField
-                          size="s"
-                          label="Описание"
-                          value={work.description}
-                          onChange={(value) => handleWorkChange(work.id, { description: value ?? '' })}
-                          type="textarea"
-                          minRows={2}
-                        />
-                        <TextField
-                          size="s"
-                          label="Допущения / ограничения"
-                          value={work.assumptions}
-                          onChange={(value) => handleWorkChange(work.id, { assumptions: value ?? '' })}
-                          type="textarea"
-                          minRows={2}
-                        />
-                        <Text size="xs" view="secondary" className={styles.workTiming}>
-                          {hasAssignments
-                            ? `Период: Д${displayStart + 1} – Д${displayEnd} · Длительность: ${workDuration} дн.`
-                            : 'Назначьте сотрудников, чтобы определить период работы.'}
-                        </Text>
-                        <div className={styles.assignmentList}>
-                          <div className={styles.assignmentHeader}>
-                            <Text size="xs" view="secondary">
-                              Назначьте роли и выберите задачи для сотрудников.
-                            </Text>
+                      return (
+                        <Card
+                          key={work.id}
+                          className={styles.workCard}
+                          verticalSpace="l"
+                          horizontalSpace="l"
+                        >
+                          <div className={styles.workHeader}>
+                            <TextField
+                              size="s"
+                              label="Название работы"
+                              placeholder="Например, Подготовка данных"
+                              value={work.title}
+                              onChange={(value) => handleWorkChange(work.id, { title: value ?? '' })}
+                            />
                             <Button
-                              size="xs"
+                              size="s"
                               view="ghost"
-                              label="Добавить сотрудника"
-                              onClick={() => handleAddAssignment(work.id)}
+                              label="Удалить"
+                              onClick={() => handleRemoveWork(work.id)}
+                              disabled={works.length <= 1}
                             />
                           </div>
-                        <div className={styles.assignmentGrid}>
-                          {work.assignments.map((assignment, index) => {
-                            const roleOption =
-                              roleOptions.find((option) => option.value === assignment.role) ?? roleOptions[0];
-                            const skillOptionsForRole = roleSkillOptions[assignment.role] ?? [];
-                            const selectedTask =
-                              skillOptionsForRole.find((option) => option.value === assignment.task) ?? null;
-                            return (
-                              <div key={assignment.id} className={styles.assignmentCard}>
-                                <div className={styles.assignmentRow}>
-                                  <Select<SelectOption<TeamRole>>
-                                    size="s"
-                                    label={`Роль сотрудника ${index + 1}`}
-                                    items={roleOptions}
-                                    value={roleOption}
-                                    getItemLabel={(item) => item.label}
-                                    getItemKey={(item) => item.value}
-                                    onChange={(option) =>
-                                      option && handleAssignmentRoleChange(work.id, assignment.id, option.value)
-                                    }
-                                  />
-                                  <Button
-                                    size="xs"
-                                    view="ghost"
-                                    label="Удалить"
-                                    onClick={() => handleRemoveAssignment(work.id, assignment.id)}
-                                    disabled={work.assignments.length <= 1}
-                                  />
-                                </div>
-                                <Combobox<OptionItem>
-                                  size="s"
-                                  items={skillOptionsForRole}
-                                  value={selectedTask}
-                                  getItemLabel={(item) => item.label}
-                                  getItemKey={(item) => item.value}
-                                  placeholder="Выберите задачу из списка навыков"
-                                  label={`Задача для сотрудника ${index + 1}`}
-                                  onChange={(option) =>
-                                    handleAssignmentTaskChange(
-                                      work.id,
-                                      assignment.id,
-                                      option?.value ?? ''
-                                    )
-                                  }
-                                  onCreate={(label) =>
-                                    handleAssignmentTaskCreate(
-                                      assignment.role,
-                                      work.id,
-                                      assignment.id,
-                                      label
-                                    )
-                                  }
-                                  labelForCreate="Добавить новую задачу"
-                                />
-                                <TextField
-                                  size="s"
-                                  label="Описание задачи"
-                                  value={assignment.description}
-                                  onChange={(value) =>
-                                    handleAssignmentChange(work.id, assignment.id, {
-                                      description: value ?? ''
-                                    })
-                                  }
-                                  type="textarea"
-                                  minRows={2}
-                                />
-                                <div className={styles.assignmentTimingGrid}>
-                                  <TextField
-                                    size="s"
-                                    label="Старт (день)"
-                                    type="number"
-                                    value={String(assignment.startDay)}
-                                    onChange={(value) =>
-                                      handleAssignmentChange(work.id, assignment.id, {
-                                        startDay: Number(value ?? assignment.startDay) || 0
-                                      })
-                                    }
-                                  />
-                                  <TextField
-                                    size="s"
-                                    label="Длительность (дней)"
-                                    type="number"
-                                    value={String(assignment.durationDays)}
-                                    onChange={(value) =>
-                                      handleAssignmentChange(work.id, assignment.id, {
-                                        durationDays: Number(value ?? assignment.durationDays) || 1
-                                      })
-                                    }
-                                  />
-                                  <TextField
-                                    size="s"
-                                    label="Трудозатраты (дней)"
-                                    type="number"
-                                    value={String(assignment.effortDays)}
-                                    onChange={(value) =>
-                                      handleAssignmentChange(work.id, assignment.id, {
-                                        effortDays: Number(value ?? assignment.effortDays) || 1
-                                      })
-                                    }
-                                  />
-                                </div>
-                              </div>
-                            );
-                          })}
-                        </div>
-                      </div>
-                      </Card>
-                    );
-                  })}
-                </div>
-              </section>
-              <section className={styles.section}>
-                <div className={styles.sectionHeader}>
-                  <div>
-                    <Text size="s" weight="semibold">
-                      Диаграмма Ганта
-                    </Text>
-                    <Text size="xs" view="secondary">
-                      Всего {totalEffortDays} человеко-дней по текущему плану.
-                    </Text>
+                          <TextField
+                            size="s"
+                            label="Описание"
+                            value={work.description}
+                            onChange={(value) => handleWorkChange(work.id, { description: value ?? '' })}
+                            type="textarea"
+                            minRows={2}
+                          />
+                          <TextField
+                            size="s"
+                            label="Допущения / ограничения"
+                            value={work.assumptions}
+                            onChange={(value) => handleWorkChange(work.id, { assumptions: value ?? '' })}
+                            type="textarea"
+                            minRows={2}
+                          />
+                          <Text size="xs" view="secondary" className={styles.workTiming}>
+                            {hasAssignments
+                              ? `Период: Д${displayStart + 1} – Д${displayEnd} · Длительность: ${workDuration} дн.`
+                              : 'Назначьте сотрудников, чтобы определить период работы.'}
+                          </Text>
+                          <div className={styles.assignmentList}>
+                            <div className={styles.assignmentHeader}>
+                              <Text size="xs" view="secondary">
+                                Назначьте роли и выберите задачи для сотрудников.
+                              </Text>
+                              <Button
+                                size="xs"
+                                view="ghost"
+                                label="Добавить сотрудника"
+                                onClick={() => handleAddAssignment(work.id)}
+                              />
+                            </div>
+                            <div className={styles.assignmentGrid}>
+                              {work.assignments.map((assignment, index) => {
+                                const roleOption =
+                                  roleOptions.find((option) => option.value === assignment.role) ?? roleOptions[0];
+                                const skillOptionsForRole = roleSkillOptions[assignment.role] ?? [];
+                                const selectedTask =
+                                  skillOptionsForRole.find((option) => option.value === assignment.task) ?? null;
+                                return (
+                                  <div key={assignment.id} className={styles.assignmentCard}>
+                                    <div className={styles.assignmentRow}>
+                                      <Select<SelectOption<TeamRole>>
+                                        size="s"
+                                        label={`Роль сотрудника ${index + 1}`}
+                                        items={roleOptions}
+                                        value={roleOption}
+                                        getItemLabel={(item) => item.label}
+                                        getItemKey={(item) => item.value}
+                                        onChange={(option) =>
+                                          option && handleAssignmentRoleChange(work.id, assignment.id, option.value)
+                                        }
+                                      />
+                                      <Button
+                                        size="xs"
+                                        view="ghost"
+                                        label="Удалить"
+                                        onClick={() => handleRemoveAssignment(work.id, assignment.id)}
+                                        disabled={work.assignments.length <= 1}
+                                      />
+                                    </div>
+                                    <Combobox<OptionItem>
+                                      size="s"
+                                      items={skillOptionsForRole}
+                                      value={selectedTask}
+                                      getItemLabel={(item) => item.label}
+                                      getItemKey={(item) => item.value}
+                                      placeholder="Выберите задачу из списка навыков"
+                                      label={`Задача для сотрудника ${index + 1}`}
+                                      onChange={(option) =>
+                                        handleAssignmentTaskChange(
+                                          work.id,
+                                          assignment.id,
+                                          option?.value ?? ''
+                                        )
+                                      }
+                                      onCreate={(label) =>
+                                        handleAssignmentTaskCreate(
+                                          assignment.role,
+                                          work.id,
+                                          assignment.id,
+                                          label
+                                        )
+                                      }
+                                      labelForCreate="Добавить новую задачу"
+                                    />
+                                    <TextField
+                                      size="s"
+                                      label="Описание задачи"
+                                      value={assignment.description}
+                                      onChange={(value) =>
+                                        handleAssignmentChange(work.id, assignment.id, {
+                                          description: value ?? ''
+                                        })
+                                      }
+                                      type="textarea"
+                                      minRows={2}
+                                    />
+                                    <div className={styles.assignmentTimingGrid}>
+                                      <TextField
+                                        size="s"
+                                        label="Старт (день)"
+                                        type="number"
+                                        value={String(assignment.startDay)}
+                                        onChange={(value) =>
+                                          handleAssignmentChange(work.id, assignment.id, {
+                                            startDay: Number(value ?? assignment.startDay) || 0
+                                          })
+                                        }
+                                      />
+                                      <TextField
+                                        size="s"
+                                        label="Длительность (дней)"
+                                        type="number"
+                                        value={String(assignment.durationDays)}
+                                        onChange={(value) =>
+                                          handleAssignmentChange(work.id, assignment.id, {
+                                            durationDays: Number(value ?? assignment.durationDays) || 1
+                                          })
+                                        }
+                                      />
+                                      <TextField
+                                        size="s"
+                                        label="Трудозатраты (дней)"
+                                        type="number"
+                                        value={String(assignment.effortDays)}
+                                        onChange={(value) =>
+                                          handleAssignmentChange(work.id, assignment.id, {
+                                            effortDays: Number(value ?? assignment.effortDays) || 1
+                                          })
+                                        }
+                                      />
+                                    </div>
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          </div>
+                        </Card>
+                      );
+                    })}
                   </div>
                 </div>
-                <InitiativeGanttChart tasks={ganttTasks} />
-              </section>
-            </>
+                <div className={styles.ganttColumn}>
+                  <div className={styles.sectionHeader}>
+                    <div>
+                      <Text size="s" weight="semibold">
+                        Диаграмма Ганта
+                      </Text>
+                      <Text size="xs" view="secondary">
+                        Всего {totalEffortDays} человеко-дней по текущему плану.
+                      </Text>
+                    </div>
+                  </div>
+                  <div className={styles.ganttPreview}>
+                    <InitiativeGanttChart tasks={ganttTasks} />
+                  </div>
+                </div>
+              </div>
+            </section>
           )}
           {activeStep === 'team' && (
             <section className={styles.section}>

--- a/src/components/InitiativeGanttChart.module.css
+++ b/src/components/InitiativeGanttChart.module.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  height: 100%;
 }
 
 .axis {
@@ -22,6 +23,10 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 4px 0;
 }
 
 .row {
@@ -38,7 +43,7 @@
 
 .timeline {
   position: relative;
-  min-height: 56px;
+  min-height: 64px;
   border-radius: 12px;
   background: var(--color-bg-secondary);
   overflow: hidden;

--- a/src/components/InitiativePlanner.module.css
+++ b/src/components/InitiativePlanner.module.css
@@ -67,10 +67,19 @@
   gap: 16px;
 }
 
+.sideColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 0;
+}
+
 .timelineCard {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  flex: 1 1 auto;
+  min-height: 360px;
 }
 
 .timelineHeader {
@@ -79,6 +88,12 @@
   align-items: center;
   gap: 12px;
   flex-wrap: wrap;
+}
+
+.timelineBody {
+  flex: 1 1 auto;
+  min-height: 320px;
+  overflow: auto;
 }
 
 .customerCard {
@@ -198,6 +213,7 @@
 .riskSection {
   position: sticky;
   top: 0;
+  align-self: flex-start;
 }
 
 .riskCard {
@@ -252,7 +268,19 @@
     grid-template-columns: 1fr;
   }
 
+  .sideColumn {
+    order: -1;
+  }
+
   .riskSection {
     position: static;
+  }
+
+  .timelineCard {
+    min-height: 320px;
+  }
+
+  .timelineBody {
+    min-height: 260px;
   }
 }

--- a/src/components/InitiativePlanner.tsx
+++ b/src/components/InitiativePlanner.tsx
@@ -366,19 +366,6 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
       </div>
       <div className={styles.contentGrid}>
         <section className={styles.rolesSection} aria-label="Роли и кандидаты">
-          <Card className={styles.timelineCard} verticalSpace="xl" horizontalSpace="xl">
-            <div className={styles.timelineHeader}>
-              <Text size="s" weight="semibold">
-                План работ
-              </Text>
-              <Text size="xs" view="secondary">
-                {timelineTasks.length > 0
-                  ? `Задач в расписании: ${timelineTasks.length}`
-                  : 'Диаграмма появится после добавления работ по ролям.'}
-              </Text>
-            </div>
-            <InitiativeGanttChart tasks={timelineTasks} />
-          </Card>
           {selectedInitiative.customer && (
             <Card className={styles.customerCard} verticalSpace="xl" horizontalSpace="xl">
               <Text size="s" weight="semibold">
@@ -419,65 +406,82 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
           )}
           {selectedInitiative.roles.map((role) => renderRoleCard(role))}
         </section>
-        <aside className={styles.riskSection} aria-label="Риски инициативы">
-          <Card verticalSpace="xl" horizontalSpace="xl" className={styles.riskCard}>
-            <Text size="s" weight="semibold">
-              Риски
-            </Text>
-            {selectedInitiative.risks.length === 0 ? (
-              <Text size="xs" view="secondary">
-                Риски не зафиксированы.
+        <div className={styles.sideColumn}>
+          <Card className={styles.timelineCard} verticalSpace="xl" horizontalSpace="xl">
+            <div className={styles.timelineHeader}>
+              <Text size="s" weight="semibold">
+                План работ
               </Text>
-            ) : (
-              <ul className={styles.riskList}>
-                {selectedInitiative.risks.map((risk) => {
-                  const meta = severityBadgeMeta[risk.severity];
-                  return (
-                    <li key={risk.id} className={styles.riskItem}>
-                      <div className={styles.riskHeader}>
-                        <Badge size="xs" status={meta.status} label={meta.label} />
-                        <Text size="xs" view="secondary">
-                          {new Date(risk.createdAt).toLocaleString('ru-RU')}
-                        </Text>
-                      </div>
-                      <Text size="xs">{risk.description}</Text>
-                      <Button
-                        size="xs"
-                        view="ghost"
-                        label="Удалить"
-                        onClick={() => onRemoveRisk(selectedInitiative.id, risk.id)}
-                      />
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-            <div className={styles.riskForm}>
-              <Select<SeverityOption>
-                size="s"
-                items={severityOptions}
-                value={severitySelectValue}
-                getItemKey={(item) => item.value}
-                getItemLabel={(item) => item.label}
-                onChange={(option) => option && setRiskSeverity(option.value)}
-              />
-              <textarea
-                className={styles.riskTextarea}
-                rows={3}
-                placeholder="Опишите риск или блокирующий фактор"
-                value={riskDescription}
-                onChange={(event) => setRiskDescription(event.target.value)}
-              />
-              <Button
-                size="s"
-                view="secondary"
-                label="Зафиксировать риск"
-                disabled={riskDescription.trim().length === 0}
-                onClick={handleAddRisk}
-              />
+              <Text size="xs" view="secondary">
+                {timelineTasks.length > 0
+                  ? `Задач в расписании: ${timelineTasks.length}`
+                  : 'Диаграмма появится после добавления работ по ролям.'}
+              </Text>
+            </div>
+            <div className={styles.timelineBody}>
+              <InitiativeGanttChart tasks={timelineTasks} />
             </div>
           </Card>
-        </aside>
+          <aside className={styles.riskSection} aria-label="Риски инициативы">
+            <Card verticalSpace="xl" horizontalSpace="xl" className={styles.riskCard}>
+              <Text size="s" weight="semibold">
+                Риски
+              </Text>
+              {selectedInitiative.risks.length === 0 ? (
+                <Text size="xs" view="secondary">
+                  Риски не зафиксированы.
+                </Text>
+              ) : (
+                <ul className={styles.riskList}>
+                  {selectedInitiative.risks.map((risk) => {
+                    const meta = severityBadgeMeta[risk.severity];
+                    return (
+                      <li key={risk.id} className={styles.riskItem}>
+                        <div className={styles.riskHeader}>
+                          <Badge size="xs" status={meta.status} label={meta.label} />
+                          <Text size="xs" view="secondary">
+                            {new Date(risk.createdAt).toLocaleString('ru-RU')}
+                          </Text>
+                        </div>
+                        <Text size="xs">{risk.description}</Text>
+                        <Button
+                          size="xs"
+                          view="ghost"
+                          label="Удалить"
+                          onClick={() => onRemoveRisk(selectedInitiative.id, risk.id)}
+                        />
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+              <div className={styles.riskForm}>
+                <Select<SeverityOption>
+                  size="s"
+                  items={severityOptions}
+                  value={severitySelectValue}
+                  getItemKey={(item) => item.value}
+                  getItemLabel={(item) => item.label}
+                  onChange={(option) => option && setRiskSeverity(option.value)}
+                />
+                <textarea
+                  className={styles.riskTextarea}
+                  rows={3}
+                  placeholder="Опишите риск или блокирующий фактор"
+                  value={riskDescription}
+                  onChange={(event) => setRiskDescription(event.target.value)}
+                />
+                <Button
+                  size="s"
+                  view="secondary"
+                  label="Зафиксировать риск"
+                  disabled={riskDescription.trim().length === 0}
+                  onClick={handleAddRisk}
+                />
+              </div>
+            </Card>
+          </aside>
+        </div>
       </div>
       <InitiativeCreationModal
         isOpen={isCreateModalOpen}


### PR DESCRIPTION
## Summary
- move the initiative creation gantt preview next to work inputs to give it full-height space
- place the initiative gantt on the planner sidebar with a scrollable canvas for manipulation
- refresh gantt styling to expand within its container and support scrolling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f7ea4871288332b79c84214aa70ae9