### PR TITLE
Refine gantt visualization to support hierarchical planning

### DIFF
--- a/src/components/InitiativeCreationModal.module.css
+++ b/src/components/InitiativeCreationModal.module.css
@@ -67,9 +67,21 @@
 
 .workPlanningGrid {
   display: grid;
-  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+  grid-template-columns: minmax(380px, 520px) minmax(0, 1fr);
   gap: 24px;
   align-items: start;
+}
+
+@media (max-width: 1280px) {
+  .workPlanningGrid {
+    grid-template-columns: minmax(340px, 480px) minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 1120px) {
+  .workPlanningGrid {
+    grid-template-columns: minmax(320px, 440px) minmax(0, 1fr);
+  }
 }
 
 .workColumn {

--- a/src/components/InitiativeCreationModal.module.css
+++ b/src/components/InitiativeCreationModal.module.css
@@ -205,7 +205,9 @@
 }
 
 .recommendationScoreBadge {
-  flex-shrink: 0;
+  flex-shrink: 1;
+  max-width: 100%;
+  white-space: normal;
 }
 
 .recommendationCandidates {

--- a/src/components/InitiativeCreationModal.module.css
+++ b/src/components/InitiativeCreationModal.module.css
@@ -1,6 +1,7 @@
 .modal {
-  max-width: 1200px;
-  width: 100%;
+  width: calc(100vw - 32px);
+  max-width: none;
+  margin: 16px auto;
 }
 
 .container {
@@ -9,8 +10,30 @@
   gap: 24px;
   padding: 32px;
   box-sizing: border-box;
-  max-height: 90vh;
+  max-height: calc(100vh - 96px);
   overflow: auto;
+  width: 100%;
+}
+
+@media (max-width: 1280px) {
+  .container {
+    padding: 28px;
+    max-height: calc(100vh - 80px);
+  }
+}
+
+@media (max-width: 960px) {
+  .container {
+    padding: 24px;
+    max-height: calc(100vh - 64px);
+  }
+}
+
+@media (max-width: 600px) {
+  .container {
+    padding: 20px;
+    gap: 20px;
+  }
 }
 
 .header {

--- a/src/components/InitiativeCreationModal.tsx
+++ b/src/components/InitiativeCreationModal.tsx
@@ -10,8 +10,12 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { domainNameById, domainTree, modules } from '../data';
 import type { DomainNode, ExpertProfile, InitiativeStatus, TeamRole } from '../data';
 import { getSkillsByRole } from '../data/skills';
-import InitiativeGanttChart from './InitiativeGanttChart';
-import type { InitiativeGanttTask } from './InitiativeGanttChart';
+import InitiativeGanttChart, {
+  type InitiativeGanttBlocker,
+  type InitiativeGanttDependency,
+  type InitiativeGanttResource,
+  type InitiativeGanttTask
+} from './InitiativeGanttChart';
 import type { InitiativeCreationRequest } from '../types/initiativeCreation';
 import {
   buildCandidatesFromReport,
@@ -84,6 +88,19 @@ type WorkAssignmentDraft = {
   startDay: number;
   durationDays: number;
   isCustom?: boolean;
+  tasks?: string[];
+  minUnits?: number;
+  maxUnits?: number;
+  roleUnits?: number;
+  canSplit?: boolean;
+  parallel?: boolean;
+  durationMode?: 'fixed-effort' | 'fixed-duration';
+  constraints?: { id: string; label: string }[];
+  priority?: number;
+  wipLimitTag?: string;
+  branchLabel?: string;
+  calendarId?: string;
+  assignedExpertId?: string;
 };
 
 type WorkDraft = {
@@ -390,18 +407,89 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
     () =>
       works.flatMap((work) => {
         const normalizedTitle = work.title.trim() || 'Задача';
-        return work.assignments.map((assignment) => {
+        return work.assignments.flatMap((assignment, index) => {
           const normalizedStart = Math.max(0, Math.round(assignment.startDay));
           const normalizedDuration = Math.max(1, Math.round(assignment.durationDays));
           const normalizedEffort = Math.max(1, Math.round(assignment.effortDays));
-          return {
+          const resources: InitiativeGanttResource[] = assignment.assignedExpertId
+            ? [
+                {
+                  id: assignment.assignedExpertId,
+                  name: assignment.assignedExpertId,
+                  role: assignment.role,
+                  units: 1
+                }
+              ]
+            : [];
+          const blockers: InitiativeGanttBlocker[] = assignment.assignedExpertId
+            ? []
+            : [
+                {
+                  id: `${work.id}-${assignment.id}-blocker`,
+                  scope: 'task',
+                  reason: 'Не выбран исполнитель',
+                  active: true
+                }
+              ];
+          const dependencies: InitiativeGanttDependency[] = [];
+          if (index > 0) {
+            const previous = work.assignments[index - 1];
+            dependencies.push({ id: `${work.id}-${previous.id}`, type: 'FS' });
+          }
+
+          const baseTask: InitiativeGanttTask = {
             id: `${work.id}-${assignment.id}`,
+            name: normalizedTitle,
             role: assignment.role,
-            title: normalizedTitle,
+            workId: work.id,
+            workName: normalizedTitle,
             startDay: normalizedStart,
             durationDays: normalizedDuration,
-            effortDays: normalizedEffort
+            effortDays: normalizedEffort,
+            effortHours: normalizedEffort * 8,
+            minUnits: Math.max(1, Math.round(assignment.minUnits ?? 1)),
+            maxUnits: Math.max(1, Math.round(assignment.maxUnits ?? assignment.roleUnits ?? 1)),
+            canSplit: Boolean(assignment.canSplit ?? true),
+            parallelAllowed: Boolean(assignment.parallel ?? true),
+            durationMode: assignment.durationMode ?? 'fixed-effort',
+            constraints:
+              normalizedStart > 0
+                ? [`SNET D${normalizedStart + 1}`]
+                : assignment.constraints?.map((constraint) => constraint.label),
+            priority: assignment.priority ?? index + 1,
+            wipLimitTag: assignment.wipLimitTag,
+            assignedExpert: assignment.assignedExpertId,
+            resources,
+            dependencies,
+            blockers,
+            scenarioBranch: assignment.branchLabel ?? 'Черновик',
+            calendarId: assignment.calendarId ?? 'project-calendar'
           };
+
+          const childTasks = (assignment.tasks ?? []).map((taskName, childIndex) => ({
+            id: `${baseTask.id}-sub-${childIndex + 1}`,
+            name: taskName,
+            role: assignment.role,
+            workId: baseTask.workId,
+            workName: baseTask.workName,
+            parentTaskId: baseTask.id,
+            startDay: normalizedStart + childIndex,
+            durationDays: Math.max(1, Math.round(normalizedDuration / (assignment.tasks?.length || 1))),
+            effortDays: Math.max(1, Math.round(normalizedEffort / (assignment.tasks?.length || 1))),
+            minUnits: baseTask.minUnits,
+            maxUnits: baseTask.maxUnits,
+            canSplit: baseTask.canSplit,
+            parallelAllowed: baseTask.parallelAllowed,
+            durationMode: baseTask.durationMode,
+            priority: baseTask.priority,
+            wipLimitTag: baseTask.wipLimitTag,
+            assignedExpert: baseTask.assignedExpert,
+            resources: baseTask.resources,
+            scenarioBranch: baseTask.scenarioBranch,
+            calendarId: baseTask.calendarId
+          } satisfies InitiativeGanttTask));
+
+          return [baseTask, ...childTasks];
         });
       }),
     [works]

--- a/src/components/InitiativeGanttChart.module.css
+++ b/src/components/InitiativeGanttChart.module.css
@@ -1,17 +1,34 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
   height: 100%;
+}
+
+.header {
+  display: grid;
+  grid-template-columns: minmax(360px, 1.1fr) 1fr;
+  gap: 12px;
+  align-items: stretch;
+}
+
+.tableHeader {
+  display: grid;
+  grid-template-columns: minmax(220px, 3fr) 120px 120px 100px 160px minmax(160px, 2fr);
+  gap: 12px;
+  padding: 8px 16px;
+  border-radius: 12px;
+  background: var(--color-bg-secondary);
+  align-items: center;
 }
 
 .axis {
   display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(48px, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(48px, 1fr));
+  gap: 4px;
+  padding: 8px 0;
+  border-radius: 12px;
   background: var(--color-bg-secondary);
-  border-radius: 8px;
-  padding: 4px 0;
 }
 
 .axisCell {
@@ -19,37 +36,110 @@
   justify-content: center;
 }
 
-.rows {
+.body {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
-  padding: 4px 0;
+  padding-right: 4px;
 }
 
 .row {
   display: grid;
-  grid-template-columns: 200px minmax(0, 1fr);
+  grid-template-columns: minmax(220px, 3fr) 120px 120px 100px 160px minmax(160px, 2fr) minmax(320px, 1fr);
   gap: 12px;
   align-items: stretch;
+  padding: 8px 12px;
+  border-radius: 12px;
+  background: var(--color-bg-default);
+  border: 1px solid var(--color-bg-border);
 }
 
-.roleCell {
+.nameCell {
   display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.nameCell[data-level='1'] {
+  padding-left: 16px;
+}
+
+.nameCell[data-level='2'] {
+  padding-left: 28px;
+}
+
+.nameCell[data-level='3'] {
+  padding-left: 40px;
+}
+
+.nameContent {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  min-width: 0;
+}
+
+.treeMarker {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--color-bg-border);
+  margin-top: 6px;
+  flex-shrink: 0;
+}
+
+.nameTextGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.metaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
   align-items: center;
 }
 
-.timeline {
+.metaBadge {
+  white-space: nowrap;
+}
+
+.parallelCell,
+.unitsCell,
+.priorityCell,
+.roleCell,
+.resourceCell {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.resourceList {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.timelineCell {
   position: relative;
-  min-height: 64px;
+  min-height: 72px;
+}
+
+.timelineLane {
+  position: absolute;
+  inset: 0;
   border-radius: 12px;
   background: var(--color-bg-secondary);
   overflow: hidden;
 }
 
-.task {
+.timelineBar {
   position: absolute;
   top: 8px;
   display: flex;
@@ -60,6 +150,26 @@
   background: rgba(37, 110, 255, 0.16);
   border: 1px solid rgba(37, 110, 255, 0.35);
   box-shadow: 0 4px 12px rgba(18, 51, 121, 0.15);
+  min-width: 56px;
+}
+
+.timelineBar[data-type='project'] {
+  background: rgba(23, 162, 184, 0.14);
+  border-color: rgba(23, 162, 184, 0.4);
+}
+
+.timelineBar[data-type='work'] {
+  background: rgba(86, 148, 255, 0.14);
+  border-color: rgba(86, 148, 255, 0.4);
+}
+
+.timelineBar[data-buffer='true'] {
+  border-style: dashed;
+}
+
+.timelineBar[data-blocked='true'] {
+  background: rgba(217, 69, 80, 0.18);
+  border-color: rgba(217, 69, 80, 0.5);
 }
 
 .emptyState {
@@ -67,4 +177,40 @@
   border-radius: 12px;
   border: 1px dashed var(--color-bg-border);
   background: var(--color-bg-default);
+}
+
+@media (max-width: 1280px) {
+  .header {
+    grid-template-columns: 1fr;
+  }
+
+  .row {
+    grid-template-columns: minmax(220px, 3fr) 100px 100px 90px 140px minmax(140px, 2fr) minmax(260px, 1fr);
+  }
+}
+
+@media (max-width: 960px) {
+  .tableHeader {
+    display: none;
+  }
+
+  .header {
+    grid-template-columns: 1fr;
+  }
+
+  .row {
+    grid-template-columns: minmax(220px, 3fr) minmax(0, 1fr);
+    grid-template-areas:
+      'name timeline'
+      'meta timeline';
+    row-gap: 8px;
+  }
+
+  .parallelCell,
+  .unitsCell,
+  .priorityCell,
+  .roleCell,
+  .resourceCell {
+    display: none;
+  }
 }

--- a/src/components/InitiativeGanttChart.tsx
+++ b/src/components/InitiativeGanttChart.tsx
@@ -1,45 +1,242 @@
+import { Badge } from '@consta/uikit/Badge';
+import { Checkbox } from '@consta/uikit/Checkbox';
 import { Text } from '@consta/uikit/Text';
 import React, { useMemo } from 'react';
 import type { TeamRole } from '../data';
 import styles from './InitiativeGanttChart.module.css';
 
+export type InitiativeGanttDependencyType = 'FS' | 'SS' | 'FF' | 'SF';
+
+export type InitiativeGanttDependency = {
+  id: string;
+  type: InitiativeGanttDependencyType;
+  lag?: number;
+  lagUnit?: 'hours' | 'days';
+};
+
+export type InitiativeGanttBlockerScope = 'task' | 'work' | 'project';
+
+export type InitiativeGanttBlocker = {
+  id: string;
+  scope: InitiativeGanttBlockerScope;
+  reason: string;
+  createdBy?: string;
+  active: boolean;
+};
+
+export type InitiativeGanttResource = {
+  id: string;
+  name: string;
+  role: TeamRole;
+  units?: number;
+  capacityHoursPerWeek?: number;
+  calendarId?: string;
+  skills?: string[];
+};
+
 export type InitiativeGanttTask = {
   id: string;
+  name: string;
   role: TeamRole;
-  title: string;
+  effortDays: number;
   startDay: number;
   durationDays: number;
-  effortDays: number;
+  projectId?: string;
+  projectName?: string;
+  workId?: string;
+  workName?: string;
+  parentTaskId?: string;
+  effortHours?: number;
+  minUnits?: number;
+  maxUnits?: number;
+  canSplit?: boolean;
+  parallelAllowed?: boolean;
+  durationMode?: 'fixed-effort' | 'fixed-duration';
+  constraints?: string[];
+  calendarId?: string;
+  priority?: number;
+  wipLimitTag?: string;
+  scenarioBranch?: string;
+  type?: 'task' | 'buffer';
   assignedExpert?: string;
+  resources?: InitiativeGanttResource[];
+  dependencies?: InitiativeGanttDependency[];
+  blockers?: InitiativeGanttBlocker[];
 };
 
 type InitiativeGanttChartProps = {
   tasks: InitiativeGanttTask[];
 };
 
+type TimelineRow = {
+  id: string;
+  type: 'project' | 'work' | 'task' | 'subtask';
+  name: string;
+  level: number;
+  effortDays?: number;
+  startDay: number;
+  durationDays: number;
+  role?: TeamRole;
+  minUnits?: number;
+  maxUnits?: number;
+  canSplit?: boolean;
+  parallelAllowed?: boolean;
+  durationMode?: 'fixed-effort' | 'fixed-duration';
+  constraints?: string[];
+  priority?: number;
+  wipLimitTag?: string;
+  scenarioBranch?: string;
+  typeTag?: 'task' | 'buffer';
+  assignedExpert?: string;
+  resources?: InitiativeGanttResource[];
+  dependencies?: InitiativeGanttDependency[];
+  blockers?: InitiativeGanttBlocker[];
+  childIds?: string[];
+};
+
 const MIN_COLUMN_COUNT = 8;
 
 const InitiativeGanttChart: React.FC<InitiativeGanttChartProps> = ({ tasks }) => {
-  const grouped = useMemo(() => {
-    const map = new Map<TeamRole, InitiativeGanttTask[]>();
-    tasks.forEach((task) => {
-      if (!map.has(task.role)) {
-        map.set(task.role, []);
+  const { rows, totalDays } = useMemo(() => {
+    if (tasks.length === 0) {
+      return { rows: [] as TimelineRow[], totalDays: MIN_COLUMN_COUNT };
+    }
+
+    const projects = new Map<string, { id: string; name: string; workIds: Set<string> }>();
+    const works = new Map<
+      string,
+      {
+        id: string;
+        name: string;
+        projectId: string;
+        role?: TeamRole;
+        tasks: InitiativeGanttTask[];
       }
-      map.get(task.role)?.push(task);
+    >();
+    const taskIndex = new Map<string, InitiativeGanttTask>();
+
+    tasks.forEach((task) => {
+      const projectId = task.projectId ?? 'default-project';
+      const projectName = task.projectName ?? 'Проект';
+      if (!projects.has(projectId)) {
+        projects.set(projectId, { id: projectId, name: projectName, workIds: new Set() });
+      }
+      const workId = task.workId ?? `${projectId}-work-${task.role}`;
+      const workName = task.workName ?? task.role;
+      projects.get(projectId)?.workIds.add(workId);
+      if (!works.has(workId)) {
+        works.set(workId, {
+          id: workId,
+          name: workName,
+          projectId,
+          role: task.role,
+          tasks: []
+        });
+      }
+      works.get(workId)?.tasks.push(task);
+      taskIndex.set(task.id, task);
     });
-    return map;
+
+    const rows: TimelineRow[] = [];
+
+    projects.forEach((project) => {
+      const projectTasks = Array.from(project.workIds).flatMap((workId) => works.get(workId)?.tasks ?? []);
+      const projectStart = projectTasks.reduce((min, item) => Math.min(min, item.startDay), Infinity);
+      const projectEnd = projectTasks.reduce(
+        (max, item) => Math.max(max, item.startDay + item.durationDays),
+        -Infinity
+      );
+      rows.push({
+        id: project.id,
+        type: 'project',
+        name: project.name,
+        level: 0,
+        startDay: projectStart === Infinity ? 0 : projectStart,
+        durationDays: projectEnd === -Infinity ? 1 : Math.max(1, projectEnd - projectStart),
+        constraints: projectTasks.flatMap((item) => item.constraints ?? []),
+        blockers: projectTasks.flatMap((item) => item.blockers ?? []),
+        childIds: Array.from(project.workIds)
+      });
+
+      project.workIds.forEach((workId) => {
+        const work = works.get(workId);
+        if (!work) {
+          return;
+        }
+        const workStart = work.tasks.reduce((min, item) => Math.min(min, item.startDay), Infinity);
+        const workEnd = work.tasks.reduce(
+          (max, item) => Math.max(max, item.startDay + item.durationDays),
+          -Infinity
+        );
+        rows.push({
+          id: work.id,
+          type: 'work',
+          name: work.name,
+          level: 1,
+          startDay: workStart === Infinity ? 0 : workStart,
+          durationDays: workEnd === -Infinity ? 1 : Math.max(1, workEnd - workStart),
+          role: work.role,
+          childIds: work.tasks.map((task) => task.id),
+          blockers: work.tasks.flatMap((task) => task.blockers ?? []),
+          constraints: work.tasks.flatMap((task) => task.constraints ?? [])
+        });
+
+        const parentChildMap = new Map<string, InitiativeGanttTask[]>();
+        work.tasks.forEach((task) => {
+          const parentId = task.parentTaskId ?? null;
+          const list = parentChildMap.get(parentId ?? '__root__') ?? [];
+          list.push(task);
+          parentChildMap.set(parentId ?? '__root__', list);
+        });
+
+        const rootTasks = parentChildMap.get('__root__') ?? [];
+        const addTaskRows = (taskList: InitiativeGanttTask[], level: number) => {
+          taskList
+            .slice()
+            .sort((a, b) => a.startDay - b.startDay || a.name.localeCompare(b.name))
+            .forEach((task) => {
+              const children = parentChildMap.get(task.id) ?? [];
+              rows.push({
+                id: task.id,
+                type: level === 2 ? 'task' : 'subtask',
+                name: task.name,
+                level,
+                effortDays: task.effortDays,
+                startDay: task.startDay,
+                durationDays: task.durationDays,
+                role: task.role,
+                minUnits: task.minUnits,
+                maxUnits: task.maxUnits,
+                canSplit: task.canSplit,
+                parallelAllowed: task.parallelAllowed,
+                durationMode: task.durationMode,
+                constraints: task.constraints,
+                priority: task.priority,
+                wipLimitTag: task.wipLimitTag,
+                scenarioBranch: task.scenarioBranch,
+                typeTag: task.type,
+                assignedExpert: task.assignedExpert,
+                resources: task.resources,
+                dependencies: task.dependencies,
+                blockers: task.blockers,
+                childIds: children.map((child) => child.id)
+              });
+              if (children.length > 0) {
+                addTaskRows(children, level + 1);
+              }
+            });
+        };
+
+        addTaskRows(rootTasks, 2);
+      });
+    });
+
+    const totalDays = rows.reduce((max, row) => Math.max(max, row.startDay + row.durationDays), MIN_COLUMN_COUNT);
+
+    return { rows, totalDays };
   }, [tasks]);
 
-  const totalDays = useMemo(() => {
-    const maxEnd = tasks.reduce((acc, task) => {
-      const end = task.startDay + task.durationDays;
-      return end > acc ? end : acc;
-    }, 0);
-    return Math.max(maxEnd, MIN_COLUMN_COUNT);
-  }, [tasks]);
-
-  if (tasks.length === 0) {
+  if (rows.length === 0) {
     return (
       <div className={styles.emptyState}>
         <Text size="s" view="secondary">
@@ -53,50 +250,208 @@ const InitiativeGanttChart: React.FC<InitiativeGanttChartProps> = ({ tasks }) =>
 
   return (
     <div className={styles.container}>
-      <div className={styles.axis}>
-        {Array.from({ length: totalDays }, (_, index) => (
-          <div key={index} className={styles.axisCell}>
-            <Text size="xs" view="secondary">
-              Д{index + 1}
-            </Text>
-          </div>
-        ))}
-      </div>
-      <div className={styles.rows}>
-        {Array.from(grouped.entries()).map(([role, roleTasks]) => (
-          <div key={role} className={styles.row}>
-            <div className={styles.roleCell}>
-              <Text size="s" weight="semibold">
-                {role}
+      <div className={styles.header}>
+        <div className={styles.tableHeader}>
+          <Text size="xs" view="secondary">
+            Проект / Работы / Задачи
+          </Text>
+          <Text size="xs" view="secondary">
+            Параллельность
+          </Text>
+          <Text size="xs" view="secondary">
+            Мин/Макс Units
+          </Text>
+          <Text size="xs" view="secondary">
+            Приоритет
+          </Text>
+          <Text size="xs" view="secondary">
+            Роль
+          </Text>
+          <Text size="xs" view="secondary">
+            Ресурсы
+          </Text>
+        </div>
+        <div className={styles.axis}>
+          {Array.from({ length: totalDays }, (_, index) => (
+            <div key={index} className={styles.axisCell}>
+              <Text size="xs" view="secondary">
+                Д{index + 1}
               </Text>
             </div>
-            <div className={styles.timeline}>
-              {roleTasks
-                .slice()
-                .sort((a, b) => a.startDay - b.startDay)
-                .map((task) => {
-                  const left = task.startDay * dayWidth;
-                  const width = Math.max(task.durationDays * dayWidth, dayWidth * 0.75);
-                  return (
-                    <div
-                      key={task.id}
-                      className={styles.task}
-                      style={{ left: `${left}%`, width: `${width}%` }}
-                    >
-                      <Text size="xs" weight="semibold" truncate>
-                        {task.title}
-                      </Text>
-                      <Text size="2xs" view="secondary" truncate>
-                        {task.assignedExpert
-                          ? `${task.assignedExpert} • ${task.effortDays} дн.`
-                          : `${task.effortDays} дн.`}
-                      </Text>
+          ))}
+        </div>
+      </div>
+      <div className={styles.body}>
+        {rows.map((row) => {
+          const left = row.startDay * dayWidth;
+          const width = Math.max(row.durationDays * dayWidth, dayWidth * 0.75);
+          const hasActiveBlocker = (row.blockers ?? []).some((blocker) => blocker.active);
+          return (
+            <div key={row.id} className={styles.row}>
+              <div className={styles.nameCell} data-level={row.level} data-type={row.type}>
+                <div className={styles.nameContent}>
+                  {row.type === 'project' && <span className={styles.treeMarker} />}
+                  {row.type === 'work' && <span className={styles.treeMarker} />}
+                  {row.type !== 'project' && row.type !== 'work' && <span className={styles.treeMarker} />}
+                  <div className={styles.nameTextGroup}>
+                    <Text size="s" weight={row.type === 'project' ? 'bold' : 'semibold'} truncate>
+                      {row.name}
+                    </Text>
+                    <div className={styles.metaRow}>
+                      {row.typeTag === 'buffer' && (
+                        <Badge
+                          size="2xs"
+                          view="ghost"
+                          status="warning"
+                          label="Буфер"
+                          className={styles.metaBadge}
+                        />
+                      )}
+                      {row.durationMode && (
+                        <Badge
+                          size="2xs"
+                          view="ghost"
+                          status="system"
+                          label={row.durationMode === 'fixed-effort' ? 'Fixed Effort' : 'Fixed Duration'}
+                          className={styles.metaBadge}
+                        />
+                      )}
+                      {row.wipLimitTag && (
+                        <Badge
+                          size="2xs"
+                          view="ghost"
+                          status="alert"
+                          label={row.wipLimitTag}
+                          className={styles.metaBadge}
+                        />
+                      )}
+                      {row.scenarioBranch && (
+                        <Badge
+                          size="2xs"
+                          view="ghost"
+                          status="normal"
+                          label={`Сценарий: ${row.scenarioBranch}`}
+                          className={styles.metaBadge}
+                        />
+                      )}
                     </div>
-                  );
-                })}
+                    {row.constraints && row.constraints.length > 0 && (
+                      <div className={styles.metaRow}>
+                        {row.constraints.slice(0, 3).map((constraint) => (
+                          <Badge
+                            key={`${row.id}-constraint-${constraint}`}
+                            size="2xs"
+                            view="ghost"
+                            status="secondary"
+                            label={constraint}
+                            className={styles.metaBadge}
+                          />
+                        ))}
+                      </div>
+                    )}
+                    {hasActiveBlocker && (
+                      <div className={styles.metaRow}>
+                        {(row.blockers ?? [])
+                          .filter((blocker) => blocker.active)
+                          .slice(0, 2)
+                          .map((blocker) => (
+                            <Badge
+                              key={blocker.id}
+                              size="2xs"
+                              view="filled"
+                              status="error"
+                              label={`Блокер: ${blocker.reason}`}
+                              className={styles.metaBadge}
+                            />
+                          ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+              <div className={styles.parallelCell}>
+                <Checkbox size="s" checked={Boolean(row.parallelAllowed ?? row.canSplit)} disabled />
+              </div>
+              <div className={styles.unitsCell}>
+                <Text size="xs" view="secondary">
+                  {row.minUnits || row.maxUnits ? `${row.minUnits ?? 0}/${row.maxUnits ?? '∞'}` : '—'}
+                </Text>
+              </div>
+              <div className={styles.priorityCell}>
+                <Text size="xs" view="secondary">
+                  {row.priority ?? '—'}
+                </Text>
+              </div>
+              <div className={styles.roleCell}>
+                <Text size="xs" view="secondary">
+                  {row.role ?? '—'}
+                </Text>
+              </div>
+              <div className={styles.resourceCell}>
+                {row.resources && row.resources.length > 0 ? (
+                  <div className={styles.resourceList}>
+                    {row.resources.slice(0, 3).map((resource) => (
+                      <Text key={resource.id} size="xs" truncate>
+                        {resource.name}
+                        {resource.units ? ` · ${resource.units}u` : ''}
+                      </Text>
+                    ))}
+                    {row.assignedExpert &&
+                      !row.resources.some((resource) => resource.name === row.assignedExpert) && (
+                        <Text size="xs" truncate>
+                          {row.assignedExpert}
+                        </Text>
+                      )}
+                  </div>
+                ) : row.assignedExpert ? (
+                  <Text size="xs" truncate>
+                    {row.assignedExpert}
+                  </Text>
+                ) : (
+                  <Text size="xs" view="secondary">
+                    —
+                  </Text>
+                )}
+              </div>
+              <div className={styles.timelineCell}>
+                <div className={styles.timelineLane}>
+                  <div
+                    className={styles.timelineBar}
+                    data-type={row.type}
+                    data-buffer={row.typeTag === 'buffer'}
+                    data-blocked={hasActiveBlocker}
+                    style={{ left: `${left}%`, width: `${width}%` }}
+                    title={`Длительность: ${row.durationDays} дн. · Старт D${row.startDay + 1}`}
+                  >
+                    <Text size="2xs" weight="semibold" truncate>
+                      {row.effortDays ? `${row.name} · ${row.effortDays} дн.` : row.name}
+                    </Text>
+                    {row.dependencies && row.dependencies.length > 0 && (
+                      <div className={styles.metaRow}>
+                        {row.dependencies.slice(0, 3).map((dependency) => (
+                          <Badge
+                            key={`${row.id}-${dependency.id}-${dependency.type}`}
+                            size="2xs"
+                            view="ghost"
+                            status="system"
+                            label={`${dependency.type}${
+                              dependency.lag
+                                ? ` ${dependency.lag > 0 ? '+' : ''}${dependency.lag}${
+                                    dependency.lagUnit === 'hours' ? 'ч' : 'д'
+                                  }`
+                                : ''
+                            }`}
+                            className={styles.metaBadge}
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/InitiativePlanner.tsx
+++ b/src/components/InitiativePlanner.tsx
@@ -13,7 +13,12 @@ import type {
   InitiativeStatus
 } from '../data';
 import InitiativeCreationModal from './InitiativeCreationModal';
-import InitiativeGanttChart, { type InitiativeGanttTask } from './InitiativeGanttChart';
+import InitiativeGanttChart, {
+  type InitiativeGanttBlocker,
+  type InitiativeGanttDependency,
+  type InitiativeGanttResource,
+  type InitiativeGanttTask
+} from './InitiativeGanttChart';
 import type { InitiativeCreationRequest } from '../types/initiativeCreation';
 import styles from './InitiativePlanner.module.css';
 
@@ -128,19 +133,106 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
       return [];
     }
 
-    return selectedInitiative.roles.flatMap((role) =>
-      (role.workItems ?? []).map((item) => ({
-        id: `${role.id}-${item.id}`,
-        role: role.role,
-        title: item.title,
-        startDay: item.startDay,
-        durationDays: item.durationDays,
-        effortDays: item.effortDays,
-        assignedExpert: item.assignedExpertId
+    return selectedInitiative.roles.flatMap((role) => {
+      const workTasks = (role.workItems ?? []).map((item, index) => {
+        const assignedExpertName = item.assignedExpertId
           ? expertMap.get(item.assignedExpertId)?.fullName ?? item.assignedExpertId
-          : undefined
-      }))
-    );
+          : undefined;
+        const resources: InitiativeGanttResource[] = assignedExpertName
+          ? [
+              {
+                id: item.assignedExpertId ?? `${role.id}-${item.id}-resource`,
+                name: assignedExpertName,
+                role: role.role,
+                units: 1
+              }
+            ]
+          : [];
+        const blockers: InitiativeGanttBlocker[] = assignedExpertName
+          ? []
+          : [
+              {
+                id: `${role.id}-${item.id}-blocker`,
+                scope: 'task',
+                reason: 'Нет назначенного эксперта',
+                active: true
+              }
+            ];
+
+        const dependencies: InitiativeGanttDependency[] = [];
+        if (index > 0) {
+          const previous = role.workItems?.[index - 1];
+          if (previous) {
+            dependencies.push({
+              id: `${role.id}-${previous.id}`,
+              type: 'FS'
+            });
+          }
+        }
+
+        return {
+          id: `${role.id}-${item.id}`,
+          name: item.title,
+          role: role.role,
+          projectId: selectedInitiative.id,
+          projectName: selectedInitiative.name,
+          workId: role.id,
+          workName: role.role,
+          startDay: item.startDay,
+          durationDays: item.durationDays,
+          effortDays: item.effortDays,
+          effortHours: item.effortDays * 8,
+          minUnits: 1,
+          maxUnits: Math.max(1, role.required),
+          canSplit: role.required > 1,
+          parallelAllowed: role.required > 1,
+          durationMode: 'fixed-effort',
+          constraints: item.startDay > 0 ? [`SNET D${item.startDay + 1}`] : undefined,
+          priority: index + 1,
+          wipLimitTag: role.role,
+          assignedExpert: assignedExpertName,
+          resources,
+          dependencies,
+          blockers,
+          scenarioBranch: 'Базовый план'
+        } satisfies InitiativeGanttTask;
+      });
+
+      const subTasks = workTasks.flatMap((task) => {
+        const workItem = role.workItems?.find((item) => `${role.id}-${item.id}` === task.id);
+        const tasks = workItem?.tasks ?? [];
+        if (tasks.length === 0) {
+          return [];
+        }
+        const sliceDuration = Math.max(1, Math.round(task.durationDays / tasks.length));
+        const sliceEffort = Math.max(1, Math.round(task.effortDays / tasks.length));
+        return tasks.map((taskName, idx) => ({
+          id: `${task.id}-sub-${idx + 1}`,
+          name: taskName,
+          role: task.role,
+          projectId: task.projectId,
+          projectName: task.projectName,
+          workId: task.workId,
+          workName: task.workName,
+          parentTaskId: task.id,
+          startDay: task.startDay + idx * sliceDuration,
+          durationDays: sliceDuration,
+          effortDays: sliceEffort,
+          minUnits: task.minUnits,
+          maxUnits: task.maxUnits,
+          canSplit: task.canSplit,
+          parallelAllowed: task.parallelAllowed,
+          durationMode: 'fixed-effort',
+          priority: task.priority,
+          wipLimitTag: task.wipLimitTag,
+          assignedExpert: task.assignedExpert,
+          resources: task.resources,
+          scenarioBranch: task.scenarioBranch
+        } satisfies InitiativeGanttTask));
+      });
+
+      return [...workTasks, ...subTasks];
+    });
   }, [expertMap, selectedInitiative]);
 
   const handleOpenCreate = () => {


### PR DESCRIPTION
## Summary
- overhaul the Gantt chart to present project/work/task hierarchy with constraints, blockers, dependencies, and resource details
- populate the chart with enriched planning data from the planner and creation modal, including derived subtasks and scenario metadata
- prevent the recommended expert badge text from overflowing the card layout during team formation

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f7eeba69308332abbdce5726fe9a01