### PR TITLE
Enhance initiative creation with inherited planning data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,10 +59,13 @@ import {
   type DomainNode,
   type GraphLink,
   type Initiative,
+  type InitiativeApprovalStage,
   type InitiativeRequirement,
   type InitiativeRolePlan,
   type InitiativeRoleWork,
   type InitiativeWork,
+  type InitiativeWorkItem,
+  type InitiativeWorkItemStatus,
   type ModuleMetrics,
   type ModuleNode,
   type ModuleStatus,
@@ -72,6 +75,7 @@ import styles from './App.module.css';
 import ExpertExplorer from './components/ExpertExplorer';
 import InitiativePlanner from './components/InitiativePlanner';
 import type { InitiativeCreationRequest } from './types/initiativeCreation';
+import { getSkillNameById } from './data/skills';
 import {
   assignExpertsToWorkItems,
   buildCandidatesFromReport,
@@ -2340,6 +2344,7 @@ function App() {
     (request: InitiativeCreationRequest): Initiative => {
       const existingIds = new Set(initiativeData.map((initiative) => initiative.id));
       const initiativeId = createEntityId('initiative', request.name, existingIds);
+      const expertNameById = new Map(expertProfiles.map((expert) => [expert.id, expert.fullName]));
       const normalizedName = request.name.trim() || `Новая инициатива ${existingIds.size + 1}`;
       const normalizedDescription = request.description.trim() || 'Описание не заполнено';
       const normalizedOwner = request.owner.trim() || 'Ответственный не указан';
@@ -2397,6 +2402,141 @@ function App() {
         };
       });
 
+      const requiredSkillLabels = new Set<string>();
+      const workScheduleLookup = new Map<
+        string,
+        { startDay: number; durationDays: number; roleName: InitiativeRolePlan['role'] }
+      >();
+      roleEntries.forEach((entry) => {
+        entry.draft.skills.forEach((skillId) => {
+          if (!skillId) {
+            return;
+          }
+          requiredSkillLabels.add(getSkillNameById(skillId) ?? skillId);
+        });
+        entry.draft.workItems.forEach((item) => {
+          workScheduleLookup.set(item.id, {
+            startDay: item.startDay,
+            durationDays: item.durationDays,
+            roleName: entry.draft.role
+          });
+          item.tasks.forEach((taskId) => {
+            if (!taskId) {
+              return;
+            }
+            requiredSkillLabels.add(getSkillNameById(taskId) ?? taskId);
+          });
+        });
+      });
+
+      const requiredSkills = Array.from(requiredSkillLabels).sort((a, b) =>
+        a.localeCompare(b, 'ru')
+      );
+
+      const assignedExpertNameByWorkItem = new Map<string, string>();
+      roles.forEach((rolePlan) => {
+        (rolePlan.workItems ?? []).forEach((item) => {
+          if (!item.assignedExpertId) {
+            return;
+          }
+          const expertName = expertNameById.get(item.assignedExpertId) ?? item.assignedExpertId;
+          assignedExpertNameByWorkItem.set(item.id, expertName);
+        });
+      });
+
+      const normalizedWorkItemsFromRequest: InitiativeWorkItem[] = (request.workItems ?? []).map(
+        (item, index) => {
+          const rawId = item.id?.trim() ?? '';
+          const lookupKey = rawId || item.id || '';
+          const schedule = lookupKey ? workScheduleLookup.get(lookupKey) : undefined;
+          const id = rawId || `${initiativeId}-timeline-${index + 1}`;
+          const title = item.title.trim() || `Работа ${index + 1}`;
+          const description = item.description.trim() || 'Описание не заполнено';
+          const ownerCandidate = item.owner.trim();
+          const owner =
+            ownerCandidate ||
+            (lookupKey ? assignedExpertNameByWorkItem.get(lookupKey) : undefined) ||
+            (schedule ? schedule.roleName : undefined) ||
+            normalizedOwner;
+          const timeframeCandidate = item.timeframe.trim();
+          const timeframe =
+            timeframeCandidate ||
+            (schedule
+              ? `Д${schedule.startDay + 1} – Д${schedule.startDay + schedule.durationDays}`
+              : 'Срок не определён');
+          const status = item.status ?? 'discovery';
+
+          return {
+            id,
+            title,
+            description,
+            owner,
+            status,
+            timeframe
+          } satisfies InitiativeWorkItem;
+        }
+      );
+
+      const fallbackStatusOrder: InitiativeWorkItemStatus[] = [
+        'discovery',
+        'design',
+        'pilot',
+        'delivery'
+      ];
+      let fallbackStatusIndex = 0;
+      const fallbackWorkItemMap = new Map<string, InitiativeWorkItem>();
+      roleEntries.forEach((entry) => {
+        entry.draft.workItems.forEach((item) => {
+          if (fallbackWorkItemMap.has(item.id)) {
+            return;
+          }
+          const schedule = workScheduleLookup.get(item.id);
+          const timeframe = schedule
+            ? `Д${schedule.startDay + 1} – Д${schedule.startDay + schedule.durationDays}`
+            : 'Срок не определён';
+          const status =
+            fallbackStatusOrder[
+              Math.min(fallbackStatusOrder.length - 1, fallbackStatusIndex)
+            ];
+          fallbackStatusIndex += 1;
+          fallbackWorkItemMap.set(item.id, {
+            id: item.id,
+            title: item.title,
+            description: item.description,
+            owner: schedule?.roleName ?? entry.draft.role,
+            status,
+            timeframe
+          });
+        });
+      });
+
+      const workItemsSource =
+        normalizedWorkItemsFromRequest.length > 0
+          ? normalizedWorkItemsFromRequest
+          : Array.from(fallbackWorkItemMap.values());
+
+      const workItems: InitiativeWorkItem[] = workItemsSource.filter(
+        (item, index, array) =>
+          array.findIndex((candidate) => candidate.id === item.id) === index
+      );
+
+      const approvalStages: InitiativeApprovalStage[] = [];
+      (request.approvalStages ?? []).forEach((stage, index) => {
+        const trimmedTitle = stage.title.trim();
+        const trimmedApprover = stage.approver.trim();
+        const trimmedComment = stage.comment?.trim() ?? '';
+        if (!trimmedTitle && !trimmedApprover && !trimmedComment) {
+          return;
+        }
+        approvalStages.push({
+          id: stage.id?.trim() || `${initiativeId}-approval-${index + 1}`,
+          title: trimmedTitle || `Этап согласования ${index + 1}`,
+          approver: trimmedApprover || 'Не назначен',
+          status: stage.status ?? 'pending',
+          comment: trimmedComment || undefined
+        });
+      });
+
       const works: InitiativeWork[] = roles.flatMap((rolePlan) =>
         (rolePlan.workItems ?? []).map((item) => ({
           id: `${rolePlan.id}-${item.id}`,
@@ -2420,9 +2560,9 @@ function App() {
         description: normalizedDescription,
         domains,
         plannedModuleIds,
-        requiredSkills: [],
-        workItems: [],
-        approvalStages: [],
+        requiredSkills,
+        workItems,
+        approvalStages,
         status: request.status,
         owner: normalizedOwner,
         expectedImpact: normalizedImpact,

--- a/src/components/InitiativeCreationModal.tsx
+++ b/src/components/InitiativeCreationModal.tsx
@@ -8,7 +8,14 @@ import { Text } from '@consta/uikit/Text';
 import { TextField } from '@consta/uikit/TextField';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { domainNameById, domainTree, modules } from '../data';
-import type { DomainNode, ExpertProfile, InitiativeStatus, TeamRole } from '../data';
+import type {
+  DomainNode,
+  ExpertProfile,
+  InitiativeApprovalStatus,
+  InitiativeStatus,
+  InitiativeWorkItemStatus,
+  TeamRole
+} from '../data';
 import { getSkillNameById, getSkillsByRole } from '../data/skills';
 import InitiativeGanttChart, {
   type InitiativeGanttBlocker,
@@ -108,7 +115,18 @@ type WorkDraft = {
   title: string;
   description: string;
   assumptions: string;
+  owner: string;
+  timeframe: string;
+  status: InitiativeWorkItemStatus;
   assignments: WorkAssignmentDraft[];
+};
+
+type ApprovalStageDraft = {
+  id: string;
+  title: string;
+  approver: string;
+  status: InitiativeApprovalStatus;
+  comment: string;
 };
 
 type CreationStep = 'details' | 'work' | 'team';
@@ -138,6 +156,19 @@ const roleOptions: SelectOption<TeamRole>[] = [
   { label: 'Тестировщик', value: 'Тестировщик' },
   { label: 'Руководитель проекта', value: 'Руководитель проекта' },
   { label: 'UX', value: 'UX' }
+];
+
+const workItemStatusOptions: SelectOption<InitiativeWorkItemStatus>[] = [
+  { label: 'Исследование', value: 'discovery' },
+  { label: 'Проектирование', value: 'design' },
+  { label: 'Пилот', value: 'pilot' },
+  { label: 'Внедрение', value: 'delivery' }
+];
+
+const approvalStatusOptions: SelectOption<InitiativeApprovalStatus>[] = [
+  { label: 'Ожидание', value: 'pending' },
+  { label: 'В работе', value: 'in-progress' },
+  { label: 'Одобрено', value: 'approved' }
 ];
 
 const creationStepOrder: CreationStep[] = ['details', 'work', 'team'];
@@ -181,7 +212,18 @@ const createWorkDraft = (offset = 0): WorkDraft => ({
   title: '',
   description: '',
   assumptions: '',
+  owner: '',
+  timeframe: '',
+  status: 'discovery',
   assignments: [createWorkAssignmentDraft(roleOptions[0].value, offset)]
+});
+
+const createApprovalStageDraft = (): ApprovalStageDraft => ({
+  id: createId(),
+  title: '',
+  approver: '',
+  status: 'pending',
+  comment: ''
 });
 
 const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
@@ -244,6 +286,9 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
   const [customerContact, setCustomerContact] = useState('');
   const [customerComment, setCustomerComment] = useState('');
   const [works, setWorks] = useState<WorkDraft[]>([createWorkDraft()]);
+  const [approvalStages, setApprovalStages] = useState<ApprovalStageDraft[]>([
+    createApprovalStageDraft()
+  ]);
   const [activeStep, setActiveStep] = useState<CreationStep>('details');
   const baseRoleSkillOptions = useMemo<Record<TeamRole, OptionItem[]>>(
     () =>
@@ -297,6 +342,7 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
       setCustomerContact('');
       setCustomerComment('');
       setWorks([createWorkDraft()]);
+      setApprovalStages([createApprovalStageDraft()]);
       setRoleSkillOptions(createRoleSkillState());
       setActiveStep('details');
     }
@@ -599,6 +645,31 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
   const draftPayload = useMemo<InitiativeCreationRequest>(
     () => {
       const workLookup = new Map(works.map((work) => [work.id, work]));
+      const workItemsPayload = works.map((work) => ({
+        id: work.id,
+        title: work.title.trim(),
+        description: work.description.trim(),
+        owner: work.owner.trim(),
+        timeframe: work.timeframe.trim(),
+        status: work.status
+      }));
+      const approvalStagePayload = approvalStages
+        .map((stage) => {
+          const title = stage.title.trim();
+          const approver = stage.approver.trim();
+          const comment = stage.comment.trim();
+          if (!title && !approver && !comment) {
+            return null;
+          }
+          return {
+            id: stage.id,
+            title,
+            approver,
+            status: stage.status,
+            comment: comment || undefined
+          };
+        })
+        .filter((stage): stage is NonNullable<typeof stage> => stage !== null);
       return {
         name: name.trim(),
         description: description.trim(),
@@ -646,10 +717,13 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
             skills: role.skills,
             workItems
           };
-        })
+        }),
+        workItems: workItemsPayload,
+        approvalStages: approvalStagePayload
       };
     },
     [
+      approvalStages,
       customerComment,
       customerContact,
       customerRepresentative,
@@ -811,6 +885,25 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
 
   const handleAddWork = () => {
     setWorks((prev) => [...prev, createWorkDraft(prev.length * 5)]);
+  };
+
+  const handleApprovalStageChange = (
+    stageId: string,
+    patch: Partial<ApprovalStageDraft>
+  ) => {
+    setApprovalStages((prev) =>
+      prev.map((stage) => (stage.id === stageId ? { ...stage, ...patch } : stage))
+    );
+  };
+
+  const handleAddApprovalStage = () => {
+    setApprovalStages((prev) => [...prev, createApprovalStageDraft()]);
+  };
+
+  const handleRemoveApprovalStage = (stageId: string) => {
+    setApprovalStages((prev) =>
+      prev.length <= 1 ? prev : prev.filter((stage) => stage.id !== stageId)
+    );
   };
 
   const handleRemoveWork = (workId: string) => {
@@ -1114,6 +1207,87 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
                   minRows={2}
                 />
               </section>
+              <section className={styles.section}>
+                <div className={styles.sectionHeader}>
+                  <Text size="s" weight="semibold">
+                    Этапы согласования
+                  </Text>
+                  <Button
+                    size="s"
+                    view="ghost"
+                    label="Добавить этап"
+                    onClick={handleAddApprovalStage}
+                  />
+                </div>
+                <div className={styles.workList}>
+                  {approvalStages.map((stage) => {
+                    const statusOption =
+                      approvalStatusOptions.find((option) => option.value === stage.status) ??
+                      approvalStatusOptions[0];
+                    return (
+                      <Card
+                        key={stage.id}
+                        className={styles.workCard}
+                        verticalSpace="l"
+                        horizontalSpace="l"
+                      >
+                        <div className={styles.workHeader}>
+                          <TextField
+                            size="s"
+                            label="Название этапа"
+                            placeholder="Например, Архитектурный комитет"
+                            value={stage.title}
+                            onChange={(value) =>
+                              handleApprovalStageChange(stage.id, { title: value ?? '' })
+                            }
+                          />
+                          <Button
+                            size="s"
+                            view="ghost"
+                            label="Удалить"
+                            onClick={() => handleRemoveApprovalStage(stage.id)}
+                            disabled={approvalStages.length <= 1}
+                          />
+                        </div>
+                        <div className={styles.gridTwoCols}>
+                          <TextField
+                            size="s"
+                            label="Согласующий"
+                            placeholder="ФИО или роль"
+                            value={stage.approver}
+                            onChange={(value) =>
+                              handleApprovalStageChange(stage.id, { approver: value ?? '' })
+                            }
+                          />
+                          <Select<SelectOption<InitiativeApprovalStatus>>
+                            size="s"
+                            label="Статус"
+                            items={approvalStatusOptions}
+                            value={statusOption}
+                            getItemLabel={(item) => item.label}
+                            getItemKey={(item) => item.value}
+                            onChange={(option) =>
+                              option &&
+                              handleApprovalStageChange(stage.id, { status: option.value })
+                            }
+                          />
+                        </div>
+                        <TextField
+                          size="s"
+                          label="Комментарий"
+                          placeholder="Дополнительные детали или требования"
+                          value={stage.comment}
+                          onChange={(value) =>
+                            handleApprovalStageChange(stage.id, { comment: value ?? '' })
+                          }
+                          type="textarea"
+                          minRows={2}
+                        />
+                      </Card>
+                    );
+                  })}
+                </div>
+              </section>
             </>
           )}
           {activeStep === 'work' && (
@@ -1192,6 +1366,38 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
                             onChange={(value) => handleWorkChange(work.id, { assumptions: value ?? '' })}
                             type="textarea"
                             minRows={2}
+                          />
+                          <div className={styles.gridTwoCols}>
+                            <TextField
+                              size="s"
+                              label="Ответственный за этап"
+                              placeholder="ФИО или роль"
+                              value={work.owner}
+                              onChange={(value) => handleWorkChange(work.id, { owner: value ?? '' })}
+                            />
+                            <TextField
+                              size="s"
+                              label="Период / таймфрейм"
+                              placeholder="Например, Q1 2025"
+                              value={work.timeframe}
+                              onChange={(value) =>
+                                handleWorkChange(work.id, { timeframe: value ?? '' })
+                              }
+                            />
+                          </div>
+                          <Select<SelectOption<InitiativeWorkItemStatus>>
+                            size="s"
+                            label="Статус этапа"
+                            items={workItemStatusOptions}
+                            value={
+                              workItemStatusOptions.find((option) => option.value === work.status) ??
+                              workItemStatusOptions[0]
+                            }
+                            getItemLabel={(item) => item.label}
+                            getItemKey={(item) => item.value}
+                            onChange={(option) =>
+                              option && handleWorkChange(work.id, { status: option.value })
+                            }
                           />
                           <Text size="xs" view="secondary" className={styles.workTiming}>
                             {hasAssignments

--- a/src/types/initiativeCreation.ts
+++ b/src/types/initiativeCreation.ts
@@ -1,4 +1,9 @@
-import type { InitiativeStatus, TeamRole } from '../data';
+import type {
+  InitiativeApprovalStatus,
+  InitiativeStatus,
+  InitiativeWorkItemStatus,
+  TeamRole
+} from '../data';
 
 export type InitiativeCreationWorkTaskDraft = {
   id: string;
@@ -15,6 +20,23 @@ export type InitiativeCreationWorkDraft = {
   durationDays: number;
   effortDays: number;
   tasks: InitiativeCreationWorkTaskDraft[];
+};
+
+export type InitiativeCreationWorkItemDraft = {
+  id: string;
+  title: string;
+  description: string;
+  owner: string;
+  timeframe: string;
+  status: InitiativeWorkItemStatus;
+};
+
+export type InitiativeCreationApprovalStageDraft = {
+  id: string;
+  title: string;
+  approver: string;
+  status: InitiativeApprovalStatus;
+  comment?: string;
 };
 
 export type InitiativeCreationRoleDraft = {
@@ -45,4 +67,6 @@ export type InitiativeCreationRequest = {
   potentialModules: string[];
   customer: InitiativeCustomerDraft;
   roles: InitiativeCreationRoleDraft[];
+  workItems: InitiativeCreationWorkItemDraft[];
+  approvalStages: InitiativeCreationApprovalStageDraft[];
 };


### PR DESCRIPTION
## Summary
- extend initiative creation flow to capture required skills, timeline items, and approval stages from planner inputs
- expand the creation modal with fields for work ownership, timeframes, statuses, and approval stage management
- add new draft types so initiative requests include work summaries and approval stages for node rendering

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68fcd69acbd88332821a3d1d1880249a