### PR TITLE
Add modal for editing expert skills

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,7 @@ import {
   reuseIndexHistory,
   type ArtifactNode,
   type DomainNode,
+  type ExpertSkill,
   type GraphLink,
   type Initiative,
   type InitiativeRequirement,
@@ -115,7 +116,7 @@ function App() {
   );
   const [artifactData, setArtifactData] = useState<ArtifactNode[]>(initialArtifacts);
   const [initiativeData, setInitiativeData] = useState<Initiative[]>(initialInitiatives);
-  const [expertProfiles] = useState(initialExperts);
+  const [expertProfiles, setExpertProfiles] = useState(initialExperts);
   const [selectedDomains, setSelectedDomains] = useState<Set<string>>(
     () => new Set(flattenDomainTree(initialDomainTree).map((domain) => domain.id))
   );
@@ -170,6 +171,11 @@ function App() {
   const [graphActionStatus, setGraphActionStatus] = useState<
     { type: 'success' | 'error'; message: string } | null
   >(null);
+  const handleUpdateExpertSkills = useCallback((expertId: string, skills: ExpertSkill[]) => {
+    setExpertProfiles((prev) =>
+      prev.map((expert) => (expert.id === expertId ? { ...expert, skills } : expert))
+    );
+  }, []);
   useLayoutEffect(() => {
     const element = sidebarRef.current;
     if (!element) {
@@ -3094,6 +3100,7 @@ function App() {
           moduleNameMap={moduleNameMap}
           moduleDomainMap={moduleDomainMap}
           domainNameMap={domainNameMap}
+          onUpdateExpertSkills={handleUpdateExpertSkills}
         />
       </main>
       <main

--- a/src/components/ExpertExplorer.module.css
+++ b/src/components/ExpertExplorer.module.css
@@ -186,6 +186,13 @@
   gap: 4px;
 }
 
+.detailActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+}
+
 .detailBadges {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/ExpertExplorer.tsx
+++ b/src/components/ExpertExplorer.tsx
@@ -20,8 +20,9 @@ import ForceGraph2D, {
   LinkObject,
   NodeObject
 } from 'react-force-graph-2d';
-import type { ExpertProfile } from '../data';
+import type { ExpertProfile, ExpertSkill } from '../data';
 import styles from './ExpertExplorer.module.css';
+import SkillEditorModal from './SkillEditorModal';
 
 type ViewOption = {
   label: string;
@@ -35,6 +36,7 @@ type ExpertExplorerProps = {
   moduleNameMap: Record<string, string>;
   moduleDomainMap: Record<string, string[]>;
   domainNameMap: Record<string, string>;
+  onUpdateExpertSkills: (expertId: string, skills: ExpertSkill[]) => void | Promise<void>;
 };
 
 type SkillFocus = {
@@ -110,7 +112,8 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   experts,
   moduleNameMap,
   moduleDomainMap,
-  domainNameMap
+  domainNameMap,
+  onUpdateExpertSkills
 }) => {
   const { theme } = useTheme();
   const themeClassName = theme?.className;
@@ -125,6 +128,8 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   const [competencyFilter, setCompetencyFilter] = useState<string[]>([]);
   const [consultingFilter, setConsultingFilter] = useState<string[]>([]);
   const [selectedExpertId, setSelectedExpertId] = useState<string | null>(null);
+  const [isSkillEditorOpen, setIsSkillEditorOpen] = useState(false);
+  const [skillEditorExpert, setSkillEditorExpert] = useState<ExpertProfile | null>(null);
   const [focusedSkill, setFocusedSkill] = useState<SkillFocus | null>(null);
 
   const graphRef = useRef<ForceGraphMethods | null>(null);
@@ -260,6 +265,35 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
       setSelectedExpertId(filteredExperts[0].id);
     }
   }, [filteredExperts, selectedExpertId]);
+
+  useEffect(() => {
+    if (isSkillEditorOpen && selectedExpert && (!skillEditorExpert || skillEditorExpert.id !== selectedExpert.id)) {
+      setSkillEditorExpert(selectedExpert);
+    }
+  }, [isSkillEditorOpen, selectedExpert, skillEditorExpert]);
+
+  const handleOpenSkillEditor = useCallback((expert: ExpertProfile) => {
+    setSkillEditorExpert(expert);
+    setIsSkillEditorOpen(true);
+  }, []);
+
+  const handleCloseSkillEditor = useCallback(() => {
+    setIsSkillEditorOpen(false);
+    setSkillEditorExpert(null);
+  }, []);
+
+  const handleSaveSkills = useCallback(
+    async (skills: ExpertSkill[]) => {
+      const targetExpert = skillEditorExpert ?? selectedExpert;
+      if (!targetExpert) {
+        return;
+      }
+      await Promise.resolve(onUpdateExpertSkills(targetExpert.id, skills));
+      setIsSkillEditorOpen(false);
+      setSkillEditorExpert(null);
+    },
+    [onUpdateExpertSkills, selectedExpert, skillEditorExpert]
+  );
 
   useEffect(() => {
     if (!focusedSkill) {
@@ -896,6 +930,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
               moduleNameMap={moduleNameMap}
               moduleDomainMap={moduleDomainMap}
               domainNameMap={domainNameMap}
+              onEditSkills={handleOpenSkillEditor}
             />
           ) : (
             <div className={styles.placeholder}>
@@ -906,6 +941,14 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
           )}
         </aside>
       </section>
+      {isSkillEditorOpen && (skillEditorExpert ?? selectedExpert) && (
+        <SkillEditorModal
+          isOpen={isSkillEditorOpen}
+          expert={(skillEditorExpert ?? selectedExpert)!}
+          onClose={handleCloseSkillEditor}
+          onSave={handleSaveSkills}
+        />
+      )}
     </div>
   );
 };
@@ -915,13 +958,15 @@ type ExpertDetailsProps = {
   moduleNameMap: Record<string, string>;
   moduleDomainMap: Record<string, string[]>;
   domainNameMap: Record<string, string>;
+  onEditSkills: (expert: ExpertProfile) => void;
 };
 
 const ExpertDetails: React.FC<ExpertDetailsProps> = ({
   expert,
   moduleNameMap,
   moduleDomainMap,
-  domainNameMap
+  domainNameMap,
+  onEditSkills
 }) => {
   const availability = availabilityMeta[expert.availability];
   const modules = expert.modules.map((moduleId) => ({
@@ -939,6 +984,14 @@ const ExpertDetails: React.FC<ExpertDetailsProps> = ({
         <Text size="s" view="secondary">
           {expert.title}
         </Text>
+      </div>
+      <div className={styles.detailActions}>
+        <Button
+          size="xs"
+          view="secondary"
+          label="Редактировать навыки"
+          onClick={() => onEditSkills(expert)}
+        />
       </div>
       <Text size="s" view="secondary">
         {expert.summary}

--- a/src/components/SkillEditorModal.module.css
+++ b/src/components/SkillEditorModal.module.css
@@ -1,0 +1,67 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: min(720px, 90vw);
+  max-height: min(80vh, 720px);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.skillList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.skillCard {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border: 1px solid var(--color-bg-border);
+  border-radius: 12px;
+  padding: 16px;
+  background: var(--color-bg-default);
+}
+
+.skillHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.skillActions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.skillMeta {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.skillNameHint {
+  color: var(--color-typo-secondary);
+}
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.addButton {
+  align-self: flex-start;
+}
+
+.error {
+  color: var(--color-typo-alert);
+}

--- a/src/components/SkillEditorModal.tsx
+++ b/src/components/SkillEditorModal.tsx
@@ -1,0 +1,296 @@
+import { Button } from '@consta/uikit/Button';
+import { Modal } from '@consta/uikit/Modal';
+import { Select } from '@consta/uikit/Select';
+import { Text } from '@consta/uikit/Text';
+import { TextField } from '@consta/uikit/TextField';
+import React, { useEffect, useMemo, useState } from 'react';
+import type {
+  ExpertProfile,
+  ExpertSkill,
+  SkillEvidenceStatus,
+  SkillLevel
+} from '../data';
+import { getSkillNameById } from '../data/skills';
+import styles from './SkillEditorModal.module.css';
+
+type SkillEditorModalProps = {
+  expert: ExpertProfile;
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (skills: ExpertSkill[]) => void | Promise<void>;
+};
+
+type SelectOption<Value> = {
+  label: string;
+  value: Value;
+};
+
+const skillLevelLabels: Record<SkillLevel, string> = {
+  A: 'A — Эксперт',
+  B: 'B — Продвинутый',
+  C: 'C — Уверенный',
+  D: 'D — Базовый',
+  E: 'E — Новичок'
+};
+
+const proofStatusLabels: Record<SkillEvidenceStatus, string> = {
+  verified: 'Подтверждено',
+  'in-review': 'На проверке',
+  'self-reported': 'Самооценка'
+};
+
+const skillLevelOptions: SelectOption<SkillLevel>[] = (
+  Object.keys(skillLevelLabels) as SkillLevel[]
+).map((value) => ({
+  value,
+  label: skillLevelLabels[value]
+}));
+
+const proofStatusOptions: SelectOption<SkillEvidenceStatus>[] = (
+  Object.keys(proofStatusLabels) as SkillEvidenceStatus[]
+).map((value) => ({
+  value,
+  label: proofStatusLabels[value]
+}));
+
+const cloneSkill = (skill: ExpertSkill): ExpertSkill => ({
+  ...skill,
+  artifacts: [...skill.artifacts],
+  usage: skill.usage ? { ...skill.usage } : undefined
+});
+
+const createEmptySkill = (): ExpertSkill => ({
+  id: '',
+  level: 'C',
+  proofStatus: 'self-reported',
+  artifacts: [],
+  interest: 'medium',
+  availableFte: 0
+});
+
+const SkillEditorModal: React.FC<SkillEditorModalProps> = ({
+  expert,
+  isOpen,
+  onClose,
+  onSave
+}) => {
+  const [draftSkills, setDraftSkills] = useState<ExpertSkill[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setDraftSkills([]);
+      setError(null);
+      setIsSubmitting(false);
+      return;
+    }
+    setDraftSkills(expert.skills.map(cloneSkill));
+    setError(null);
+    setIsSubmitting(false);
+  }, [expert, isOpen]);
+
+  const hasChanges = useMemo(() => {
+    if (draftSkills.length !== expert.skills.length) {
+      return true;
+    }
+    return draftSkills.some((skill, index) => {
+      const reference = expert.skills[index];
+      return (
+        skill.id !== reference.id ||
+        skill.level !== reference.level ||
+        skill.proofStatus !== reference.proofStatus
+      );
+    });
+  }, [draftSkills, expert.skills]);
+
+  const handleSkillChange = <Key extends keyof ExpertSkill>(
+    index: number,
+    key: Key,
+    value: ExpertSkill[Key]
+  ) => {
+    setDraftSkills((prev) => {
+      const next = [...prev];
+      next[index] = { ...next[index], [key]: value };
+      return next;
+    });
+  };
+
+  const handleRemoveSkill = (index: number) => {
+    setDraftSkills((prev) => prev.filter((_, itemIndex) => itemIndex !== index));
+  };
+
+  const handleAddSkill = () => {
+    setDraftSkills((prev) => [...prev, createEmptySkill()]);
+  };
+
+  const normalizedSkills = useMemo(() =>
+    draftSkills.map((skill) => ({
+      ...skill,
+      id: skill.id.trim(),
+      artifacts: [...skill.artifacts],
+      usage: skill.usage ? { ...skill.usage } : undefined
+    })),
+  [draftSkills]);
+
+  const validationError = useMemo(() => {
+    if (normalizedSkills.some((skill) => skill.id.length === 0)) {
+      return 'Укажите идентификаторы всех навыков.';
+    }
+    const ids = normalizedSkills.map((skill) => skill.id.toLowerCase());
+    const duplicateIndex = ids.findIndex((id, index) => ids.indexOf(id) !== index);
+    if (duplicateIndex >= 0) {
+      return `Навык «${normalizedSkills[duplicateIndex].id}» указан более одного раза.`;
+    }
+    return null;
+  }, [normalizedSkills]);
+
+  const handleSubmit = async () => {
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    if (isSubmitting) {
+      return;
+    }
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      await Promise.resolve(onSave(normalizedSkills));
+    } catch (submitError) {
+      if (submitError instanceof Error) {
+        setError(submitError.message);
+      } else {
+        setError('Не удалось сохранить изменения. Попробуйте ещё раз.');
+      }
+      setIsSubmitting(false);
+      return;
+    }
+    setIsSubmitting(false);
+  };
+
+  return (
+    <Modal isOpen={isOpen} hasOverlay onClickOutside={onClose} onEsc={onClose}>
+      <div className={styles.root}>
+        <div className={styles.header}>
+          <Text size="l" weight="bold">
+            Навыки эксперта
+          </Text>
+          <Text size="s" view="secondary">
+            {expert.fullName}
+        </Text>
+        <Text size="xs" view="ghost">
+          Управляйте перечнем навыков, уровнями и подтверждением.
+        </Text>
+      </div>
+      <div className={styles.skillList}>
+        {draftSkills.length === 0 ? (
+          <Text size="s" view="secondary">
+            У эксперта пока нет навыков. Добавьте первый навык, чтобы продолжить.
+          </Text>
+        ) : (
+          draftSkills.map((skill, index) => {
+            const levelOption = skillLevelOptions.find((option) => option.value === skill.level);
+            const proofOption = proofStatusOptions.find(
+              (option) => option.value === skill.proofStatus
+            );
+            const resolvedName = getSkillNameById(skill.id.trim());
+            return (
+              <div key={`skill-${index}`} className={styles.skillCard}>
+                <div className={styles.skillHeader}>
+                  <TextField
+                    size="s"
+                    label="Идентификатор навыка"
+                    placeholder="Например, data-governance"
+                    value={skill.id}
+                    onChange={(value) => handleSkillChange(index, 'id', value ?? '')}
+                  />
+                  {resolvedName && (
+                    <Text size="xs" className={styles.skillNameHint}>
+                      {resolvedName}
+                    </Text>
+                  )}
+                </div>
+                <div className={styles.skillMeta}>
+                  <Select<SelectOption<SkillLevel>>
+                    size="s"
+                    label="Уровень владения"
+                    items={skillLevelOptions}
+                    value={levelOption ?? skillLevelOptions[0]}
+                    getItemLabel={(item) => item.label}
+                    getItemKey={(item) => item.value}
+                    onChange={(option) =>
+                      option && handleSkillChange(index, 'level', option.value)
+                    }
+                  />
+                  <Select<SelectOption<SkillEvidenceStatus>>
+                    size="s"
+                    label="Статус подтверждения"
+                    items={proofStatusOptions}
+                    value={proofOption ?? proofStatusOptions[0]}
+                    getItemLabel={(item) => item.label}
+                    getItemKey={(item) => item.value}
+                    onChange={(option) =>
+                      option && handleSkillChange(index, 'proofStatus', option.value)
+                    }
+                  />
+                </div>
+                <div className={styles.skillActions}>
+                  <Button
+                    size="xs"
+                    view="ghost"
+                    label="Удалить"
+                    onClick={() => handleRemoveSkill(index)}
+                    disabled={isSubmitting}
+                  />
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+      <Button
+        size="s"
+        view="secondary"
+        label="Добавить навык"
+        className={styles.addButton}
+        onClick={handleAddSkill}
+        disabled={isSubmitting}
+      />
+      <div className={styles.footer}>
+        <div>
+          {(error ?? validationError) && (
+            <Text size="s" view="alert" className={styles.error}>
+              {error ?? validationError}
+            </Text>
+          )}
+          {!hasChanges && !error && !validationError && (
+            <Text size="xs" view="secondary">
+              Изменений не обнаружено.
+            </Text>
+          )}
+        </div>
+        <div className={styles.skillActions}>
+          <Button
+            size="s"
+            view="ghost"
+            label="Отменить"
+            onClick={onClose}
+            disabled={isSubmitting}
+          />
+          <Button
+            size="s"
+            view="primary"
+            label="Сохранить"
+            onClick={handleSubmit}
+            disabled={isSubmitting || (!hasChanges && !validationError)}
+            loading={isSubmitting}
+          />
+        </div>
+      </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default SkillEditorModal;


### PR DESCRIPTION
## Summary
- add a dedicated SkillEditorModal component to manage expert skill sets with validation and confirmation UI
- hook the modal into ExpertExplorer, including a new button and local state to trigger editing for the active expert
- persist updated skills in the main App state so downstream views receive the latest data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fcd6a0c7e48332835fd082426b6345