### PR TITLE
Simplify analytics panel layout

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -182,17 +182,17 @@
 }
 
 .graphSection {
-  display: grid;
-  grid-template-rows: minmax(0, 1fr) auto;
+  display: flex;
+  flex-direction: column;
   gap: 16px;
   height: 100%;
   min-height: 0;
 }
 
 .graphContainer {
-  height: 100%;
-  min-height: 0;
   display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .analytics {
@@ -200,6 +200,9 @@
   border-radius: 12px;
   background: var(--color-bg-default);
   box-shadow: var(--shadow-layer);
+  display: flex;
+  flex-shrink: 0;
+  width: 100%;
 }
 
 .details {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,6 +104,9 @@ type AdminNotice = {
   message: string;
 };
 
+const isAnalyticsPanelEnabled =
+  (import.meta.env.VITE_ENABLE_ANALYTICS_PANEL ?? 'true').toLowerCase() !== 'false';
+
 function App() {
   const [graphs, setGraphs] = useState<GraphSummary[]>([]);
   const [activeGraphId, setActiveGraphId] = useState<string | null>(null);
@@ -930,6 +933,8 @@ function App() {
     () => moduleData.filter((module) => matchesModuleFilters(module)),
     [moduleData, matchesModuleFilters]
   );
+
+  const shouldShowAnalytics = isAnalyticsPanelEnabled && filteredModules.length > 0;
 
   const artifactMap = useMemo(
     () => new Map(artifactData.map((artifact) => [artifact.id, artifact])),
@@ -3051,9 +3056,11 @@ function App() {
                 onLayoutChange={handleLayoutChange}
               />
             </div>
-            <div className={styles.analytics}>
-              <AnalyticsPanel modules={filteredModules} domainNameMap={domainNameMap} />
-            </div>
+            {shouldShowAnalytics && (
+              <div className={styles.analytics}>
+                <AnalyticsPanel modules={filteredModules} domainNameMap={domainNameMap} />
+              </div>
+            )}
           </section>
           <aside className={styles.details}>
             <NodeDetails

--- a/src/components/AnalyticsPanel.module.css
+++ b/src/components/AnalyticsPanel.module.css
@@ -1,21 +1,12 @@
 .container {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 12px;
 }
 
 .card {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-}
-
-.chartCard {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.chartTitle {
-  margin-bottom: 8px;
+  gap: 4px;
+  min-width: 180px;
 }

--- a/src/components/AnalyticsPanel.tsx
+++ b/src/components/AnalyticsPanel.tsx
@@ -1,4 +1,3 @@
-import { Bar, BarProps } from '@consta/charts/Bar';
 import { Card } from '@consta/uikit/Card';
 import { Text } from '@consta/uikit/Text';
 import React, { useMemo } from 'react';
@@ -11,66 +10,66 @@ type AnalyticsPanelProps = {
 };
 
 const AnalyticsPanel: React.FC<AnalyticsPanelProps> = ({ modules, domainNameMap }) => {
-  const data = useMemo(() => {
-    const totals = modules.reduce<Record<string, { count: number; label: string }>>((acc, module) => {
+  const metrics = useMemo(() => {
+    if (modules.length === 0) {
+      return [] as const;
+    }
+
+    const coverage = average(modules.map((module) => module.metrics.coverage ?? 0));
+    const reuse = average(modules.map((module) => Math.round(module.reuseScore * 100)));
+    const domainCount = modules.reduce((acc, module) => {
       module.domains.forEach((domainId) => {
-        const label = domainNameMap[domainId] ?? domainId;
-        const current = acc[domainId] ?? { count: 0, label };
-        acc[domainId] = {
-          label,
-          count: current.count + 1
-        };
+        acc.add(domainNameMap[domainId] ?? domainId);
       });
       return acc;
-    }, {});
+    }, new Set<string>());
 
-    return Object.entries(totals)
-      .map(([domainId, value]) => ({
-        domainId,
-        domainLabel: value.label,
-        count: value.count
-      }))
-      .sort((a, b) => b.count - a.count)
-      .slice(0, 6);
+    return [
+      {
+        id: 'modules',
+        label: 'Модулей в графе',
+        value: modules.length.toString()
+      },
+      {
+        id: 'domains',
+        label: 'Активных доменов',
+        value: domainCount.size.toString()
+      },
+      {
+        id: 'coverage',
+        label: 'Среднее покрытие тестами',
+        value: `${Math.round(coverage)}%`
+      },
+      {
+        id: 'reuse',
+        label: 'Средний индекс переиспользуемости',
+        value: `${Math.round(reuse)}%`
+      }
+    ] as const;
   }, [domainNameMap, modules]);
 
-  const chartProps: BarProps = {
-    data,
-    xField: 'count',
-    yField: 'domainLabel',
-    legend: false,
-    height: 220,
-    autoFit: true,
-    seriesField: 'domainLabel'
-  };
-
-  const coverage = average(modules.map((module) => module.metrics.coverage ?? 0));
-  const reuse = average(modules.map((module) => Math.round(module.reuseScore * 100)));
+  if (metrics.length === 0) {
+    return null;
+  }
 
   return (
     <div className={styles.container}>
-      <Card verticalSpace="l" horizontalSpace="l" shadow={false} className={styles.card}>
-        <Text size="s" weight="semibold">
-          Среднее покрытие тестами
-        </Text>
-        <Text size="3xl" weight="bold">
-          {Math.round(coverage)}%
-        </Text>
-      </Card>
-      <Card verticalSpace="l" horizontalSpace="l" shadow={false} className={styles.card}>
-        <Text size="s" weight="semibold">
-          Средний индекс переиспользуемости
-        </Text>
-        <Text size="3xl" weight="bold">
-          {Math.round(reuse)}%
-        </Text>
-      </Card>
-      <Card verticalSpace="l" horizontalSpace="l" shadow={false} className={styles.chartCard}>
-        <Text size="s" weight="semibold" className={styles.chartTitle}>
-          Модули по доменам (топ-6)
-        </Text>
-        <Bar {...chartProps} />
-      </Card>
+      {metrics.map((metric) => (
+        <Card
+          key={metric.id}
+          verticalSpace="l"
+          horizontalSpace="l"
+          shadow={false}
+          className={styles.card}
+        >
+          <Text size="s" weight="semibold">
+            {metric.label}
+          </Text>
+          <Text size="2xl" weight="bold">
+            {metric.value}
+          </Text>
+        </Card>
+      ))}
     </div>
   );
 };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,11 @@
 /// <reference types="vite/client" />
 
 declare module '*.module.css';
+
+interface ImportMetaEnv {
+  readonly VITE_ENABLE_ANALYTICS_PANEL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- replace the analytics panel chart with a compact row of metric cards and hide the widget when no data is available
- refactor the graph section layout so the graph expands to fill space when analytics is disabled
- add an environment flag to toggle the analytics panel visibility at build time

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fcd6a786348332b644187cb0efcc24