### PR TITLE
Improve initiative planner empty state and layout

### DIFF
--- a/src/components/InitiativePlanner.module.css
+++ b/src/components/InitiativePlanner.module.css
@@ -57,9 +57,50 @@
 
 .contentGrid {
   display: grid;
-  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
   gap: 24px;
   align-items: start;
+}
+
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  flex: 1 1 auto;
+  padding: 48px 24px;
+}
+
+.emptyCard {
+  max-width: 720px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  align-items: center;
+  text-align: center;
+}
+
+.emptyActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+}
+
+.emptyHints {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.emptyHintItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: center;
 }
 
 .rolesSection {
@@ -94,6 +135,27 @@
   flex: 1 1 auto;
   min-height: 320px;
   overflow: auto;
+}
+
+@media (max-width: 1200px) {
+  .contentGrid {
+    grid-template-columns: minmax(240px, 280px) minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 960px) {
+  .contentGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .emptyCard {
+    text-align: left;
+    align-items: stretch;
+  }
+
+  .emptyHintItem {
+    justify-content: flex-start;
+  }
 }
 
 .customerCard {

--- a/src/components/InitiativePlanner.tsx
+++ b/src/components/InitiativePlanner.tsx
@@ -255,9 +255,52 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
   if (!selectedInitiative) {
     return (
       <section className={styles.container} aria-label="Инициативы">
-        <Text size="s" view="secondary">
-          Инициативы не найдены. Добавьте их в данных графа, чтобы начать планирование команды.
-        </Text>
+        <div className={styles.emptyState}>
+          <Card className={styles.emptyCard} verticalSpace="2xl" horizontalSpace="2xl">
+            <div>
+              <Text size="2xl" weight="bold">
+                Пока нет инициатив для планирования
+              </Text>
+              <Text size="s" view="secondary">
+                Создайте первую инициативу, чтобы сформировать команду и увидеть дорожку планирования работ.
+              </Text>
+            </div>
+            <div className={styles.emptyActions}>
+              <Button size="m" view="primary" label="Создать инициативу" onClick={handleOpenCreate} />
+            </div>
+            <div className={styles.emptyHints}>
+              <div className={styles.emptyHintItem}>
+                <Badge size="xs" view="stroked" label="1" />
+                <Text size="xs" view="secondary">
+                  Добавьте краткое описание и владельца — так участникам будет проще понять контекст.
+                </Text>
+              </div>
+              <div className={styles.emptyHintItem}>
+                <Badge size="xs" view="stroked" label="2" />
+                <Text size="xs" view="secondary">
+                  Укажите домены и требуемые роли, чтобы подобрать подходящих экспертов.
+                </Text>
+              </div>
+              <div className={styles.emptyHintItem}>
+                <Badge size="xs" view="stroked" label="3" />
+                <Text size="xs" view="secondary">
+                  Заполните работы по ролям — после этого появится диаграмма с дорожкой реализации.
+                </Text>
+              </div>
+            </div>
+          </Card>
+        </div>
+        <InitiativeCreationModal
+          isOpen={isCreateModalOpen}
+          experts={experts}
+          onClose={() => {
+            setIsCreateModalOpen(false);
+            setCreationError(null);
+          }}
+          onSubmit={handleCreateInitiative}
+          isSubmitting={isCreateSubmitting}
+          errorMessage={creationError}
+        />
       </section>
     );
   }


### PR DESCRIPTION
## Summary
- adjust initiative planner grid so the roles column keeps a compact width and the plan track expands
- add a full empty state with CTA and onboarding hints when no initiatives are available
- tweak responsive breakpoints so the layout stacks vertically on narrow screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fcd6a78cb883329fccdaa9b73199d8