### PR TITLE
Fix initiative planner modal after merge

### DIFF
--- a/src/components/InitiativePlanner.tsx
+++ b/src/components/InitiativePlanner.tsx
@@ -279,6 +279,25 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
     });
   };
 
+  const modal = (
+    <InitiativeCreationModal
+      isOpen={isModalOpen}
+      experts={experts}
+      onClose={() => {
+        setIsModalOpen(false);
+        setModalError(null);
+        setModalInitialDraft(null);
+        setModalTargetId(null);
+        setModalMode('create');
+      }}
+      onSubmit={handleSubmitModal}
+      isSubmitting={isModalSubmitting}
+      errorMessage={modalError}
+      mode={modalMode}
+      initialDraft={modalInitialDraft}
+    />
+  );
+
   if (!selectedInitiative) {
     return (
       <section className={styles.container} aria-label="Инициативы">
@@ -317,17 +336,7 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
             </div>
           </Card>
         </div>
-        <InitiativeCreationModal
-          isOpen={isCreateModalOpen}
-          experts={experts}
-          onClose={() => {
-            setIsCreateModalOpen(false);
-            setCreationError(null);
-          }}
-          onSubmit={handleCreateInitiative}
-          isSubmitting={isCreateSubmitting}
-          errorMessage={creationError}
-        />
+        {modal}
       </section>
     );
   }
@@ -652,22 +661,7 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
           </aside>
         </div>
       </div>
-      <InitiativeCreationModal
-        isOpen={isModalOpen}
-        experts={experts}
-        onClose={() => {
-          setIsModalOpen(false);
-          setModalError(null);
-          setModalInitialDraft(null);
-          setModalTargetId(null);
-          setModalMode('create');
-        }}
-        onSubmit={handleSubmitModal}
-        isSubmitting={isModalSubmitting}
-        errorMessage={modalError}
-        mode={modalMode}
-        initialDraft={modalInitialDraft}
-      />
+      {modal}
     </section>
   );
 };


### PR DESCRIPTION
## Summary
- ensure the initiative planner always renders a single creation modal instance
- remove leftover references to undefined modal state from the empty state view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fcd40235448332922e1b2eac4c7828