### PR TITLE
Fix admin module form sections and resize initiative planner grid

### DIFF
--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -1649,19 +1649,19 @@ const ModuleForm: React.FC<ModuleFormProps> = ({
         </div>
         {onDelete && <Button size="s" view="clear" label="Удалить модуль" onClick={onDelete} />}
       </div>
-      {moduleSections.map((section, index) => (
+      {moduleSections.map(({ id }, index) => (
         <Collapse
-          key={section}
+          key={id}
           isOpen={current === index}
           onClick={() => goToStep(index)}
           label={
             <div className={styles.collapseLabel}>
               <Text size="s" weight="semibold">
-                {section === 'general'
+                {id === 'general'
                   ? 'Основные сведения'
-                  : section === 'calculation'
+                  : id === 'calculation'
                     ? 'Показатели'
-                    : section === 'technical'
+                    : id === 'technical'
                       ? 'Технические детали'
                       : 'Нефункциональные требования'}
               </Text>
@@ -1672,10 +1672,10 @@ const ModuleForm: React.FC<ModuleFormProps> = ({
           }
         >
           <div className={styles.sectionContent}>
-            {section === 'general' && renderGeneralSection()}
-            {section === 'calculation' && renderCalculationSection()}
-            {section === 'technical' && renderTechnicalSection()}
-            {section === 'nonFunctional' && renderNonFunctionalSection()}
+            {id === 'general' && renderGeneralSection()}
+            {id === 'calculation' && renderCalculationSection()}
+            {id === 'technical' && renderTechnicalSection()}
+            {id === 'nonFunctional' && renderNonFunctionalSection()}
           </div>
           <div className={styles.stepActions}>
             {index > 0 && (

--- a/src/components/InitiativePlanner.module.css
+++ b/src/components/InitiativePlanner.module.css
@@ -57,8 +57,8 @@
 
 .contentGrid {
   display: grid;
-  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
-  gap: 24px;
+  grid-template-columns: minmax(200px, 240px) minmax(0, 1fr);
+  gap: 20px;
   align-items: start;
 }
 
@@ -139,7 +139,8 @@
 
 @media (max-width: 1200px) {
   .contentGrid {
-    grid-template-columns: minmax(240px, 280px) minmax(0, 1fr);
+    grid-template-columns: minmax(180px, 220px) minmax(0, 1fr);
+    gap: 20px;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the admin module form renders all attribute groups by wiring collapses to section ids
- rebalance the initiative planner layout to prioritize the timeline lane over the info column

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fce7d80ec88332bf75569ca9a348e8