### PR TITLE
Align admin module form with graph module attributes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1081,14 +1081,15 @@ function App() {
     [graphs, graphSourceIdDraft]
   );
 
-  const defaultDomainId = useMemo(() => {
-    const flattened = flattenDomainTree(domainData);
-    const firstLeaf = flattened.find((domain) => !domain.children || domain.children.length === 0);
-    return firstLeaf ? firstLeaf.id : null;
-  }, [domainData]);
-
-  const leafDomainIds = useMemo(() => collectLeafDomainIds(domainData), [domainData]);
-  const leafDomainIdSet = useMemo(() => new Set(leafDomainIds), [leafDomainIds]);
+  const attachableDomainIds = useMemo(() => collectAttachableDomainIds(domainData), [domainData]);
+  const defaultDomainId = useMemo(
+    () => attachableDomainIds[0] ?? null,
+    [attachableDomainIds]
+  );
+  const attachableDomainIdSet = useMemo(
+    () => new Set(attachableDomainIds),
+    [attachableDomainIds]
+  );
   const catalogDomainIdSet = useMemo(() => new Set(collectCatalogDomainIds(domainData)), [domainData]);
   const domainIdSet = useMemo(
     () => new Set(flattenDomainTree(domainData).map((domain) => domain.id)),
@@ -1675,9 +1676,8 @@ function App() {
               ? [defaultDomainId]
               : [];
 
-      const result = buildModuleFromDraft(moduleId, draft, fallbackDomains, leafDomainIdSet, {
+      const result = buildModuleFromDraft(moduleId, draft, fallbackDomains, attachableDomainIdSet, {
         fallbackName: draft.name.trim() || `Новый модуль ${existingIds.size + 1}`,
-        currentProduces: []
       });
       if (!result) {
         showAdminNotice(
@@ -1741,7 +1741,7 @@ function App() {
     },
     [
       defaultDomainId,
-      leafDomainIdSet,
+      attachableDomainIdSet,
       markGraphDirty,
       moduleData,
       selectedNode,
@@ -1765,9 +1765,8 @@ function App() {
               ? [defaultDomainId]
               : [];
 
-      const result = buildModuleFromDraft(moduleId, draft, fallbackDomains, leafDomainIdSet, {
-        fallbackName: existing.name,
-        currentProduces: existing.produces
+      const result = buildModuleFromDraft(moduleId, draft, fallbackDomains, attachableDomainIdSet, {
+        fallbackName: existing.name
       });
       if (!result) {
         showAdminNotice(
@@ -1823,7 +1822,7 @@ function App() {
         showAdminNotice('success', `Модуль «${recalculatedModule.name}» обновлён.`);
       }
     },
-    [defaultDomainId, leafDomainIdSet, markGraphDirty, moduleData, showAdminNotice]
+    [defaultDomainId, attachableDomainIdSet, markGraphDirty, moduleData, showAdminNotice]
   );
 
   const handleDeleteModule = useCallback(
@@ -2136,7 +2135,7 @@ function App() {
       const producerId = draft.producedBy?.trim();
       const fallbackDomainId =
         draft.domainId ?? (producerId ? moduleById[producerId]?.domains[0] : undefined) ?? defaultDomainId;
-      const domainId = fallbackDomainId && leafDomainIdSet.has(fallbackDomainId) ? fallbackDomainId : null;
+      const domainId = fallbackDomainId && attachableDomainIdSet.has(fallbackDomainId) ? fallbackDomainId : null;
       const consumers = deduplicateNonEmpty(draft.consumerIds);
 
       if (!domainId) {
@@ -2216,7 +2215,7 @@ function App() {
     [
       artifactData,
       defaultDomainId,
-      leafDomainIdSet,
+      attachableDomainIdSet,
       markGraphDirty,
       moduleById,
       showAdminNotice
@@ -2236,7 +2235,7 @@ function App() {
       const normalizedSampleUrl = draft.sampleUrl.trim() || existing.sampleUrl;
       const producerId = draft.producedBy?.trim();
       const candidateDomainId = draft.domainId ?? existing.domainId;
-      if (!candidateDomainId || !leafDomainIdSet.has(candidateDomainId)) {
+      if (!candidateDomainId || !attachableDomainIdSet.has(candidateDomainId)) {
         showAdminNotice('error', 'Не удалось сохранить артефакт: выберите доменную область.');
         return;
       }
@@ -2343,7 +2342,7 @@ function App() {
       );
       showAdminNotice('success', `Артефакт «${normalizedName}» обновлён.`);
     },
-    [artifactData, leafDomainIdSet, markGraphDirty, showAdminNotice]
+    [artifactData, attachableDomainIdSet, markGraphDirty, showAdminNotice]
   );
 
   const handleDeleteArtifact = useCallback(
@@ -3412,7 +3411,7 @@ function buildModuleFromDraft(
   draft: ModuleDraftPayload,
   fallbackDomains: string[],
   allowedDomainIds: Set<string>,
-  options: { fallbackName: string; currentProduces?: string[] }
+  options: { fallbackName: string }
 ): ModuleBuildResult | null {
   const normalizedName = draft.name.trim() || options.fallbackName;
   const normalizedDescription = draft.description.trim() || 'Описание не заполнено';
@@ -3428,7 +3427,7 @@ function buildModuleFromDraft(
   }
 
   const dependencies = deduplicateNonEmpty(draft.dependencyIds).filter((id) => id !== moduleId);
-  const produces = deduplicateNonEmpty(options.currentProduces ?? []);
+  const produces = deduplicateNonEmpty(draft.produces ?? []);
 
   const preparedInputs = (draft.dataIn.length > 0 ? draft.dataIn : [{ id: '', label: '', sourceId: undefined }]).map((input, index) => ({
     id: input.id?.trim() || `input-${index + 1}`,
@@ -4080,10 +4079,22 @@ function flattenDomainTree(domains: DomainNode[]): DomainNode[] {
   return domains.flatMap((domain) => [domain, ...(domain.children ? flattenDomainTree(domain.children) : [])]);
 }
 
-function collectLeafDomainIds(domains: DomainNode[]): string[] {
-  return flattenDomainTree(domains)
-    .filter((domain) => (!domain.children || domain.children.length === 0) && !domain.isCatalogRoot)
-    .map((domain) => domain.id);
+function collectAttachableDomainIds(domains: DomainNode[]): string[] {
+  const result: string[] = [];
+
+  const visit = (nodes: DomainNode[], depth: number) => {
+    nodes.forEach((node) => {
+      if (depth > 0 && !node.isCatalogRoot) {
+        result.push(node.id);
+      }
+      if (node.children) {
+        visit(node.children, depth + 1);
+      }
+    });
+  };
+
+  visit(domains, 0);
+  return result;
 }
 
 function collectCatalogDomainIds(domains: DomainNode[]): string[] {

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -32,6 +32,7 @@ export type ModuleDraftPayload = {
   status: ModuleStatus;
   domainIds: string[];
   dependencyIds: string[];
+  produces: string[];
   dataIn: ModuleInput[];
   dataOut: ModuleOutput[];
   ridOwner: RidOwner;
@@ -269,6 +270,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
     setArtifactDataTypes((prev) => mergeStringCollections(prev, knownArtifactDataTypes));
   }, [knownArtifactDataTypes]);
 
+  const attachableDomainIds = useMemo(() => collectAttachableDomainIds(domains), [domains]);
   const leafDomainIds = useMemo(() => collectLeafDomainIds(domains), [domains]);
   const catalogDomainIds = useMemo(() => collectCatalogDomainIds(domains), [domains]);
   const parentDomainIds = useMemo(
@@ -638,7 +640,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
             mode={selectedModuleId === '__new__' ? 'create' : 'edit'}
             draft={moduleDraft}
             step={moduleStep}
-            domainItems={leafDomainIds}
+            domainItems={attachableDomainIds}
             domainLabelMap={domainLabelMap}
             moduleItems={modules.map((module) => module.id)}
             moduleLabelMap={moduleLabelMap}
@@ -1553,6 +1555,20 @@ const ModuleForm: React.FC<ModuleFormProps> = ({
         </div>
         <Button size="xs" view="secondary" label="Добавить выход" onClick={handleAddDataOut} />
       </div>
+      <label className={styles.field}>
+        <Text size="xs" weight="semibold" className={styles.label}>
+          Производимые артефакты
+        </Text>
+        <Combobox<string>
+          size="s"
+          items={artifactItems}
+          value={draft.produces}
+          multiple
+          getItemKey={(item) => item}
+          getItemLabel={(item) => artifactLabelMap[item] ?? item}
+          onChange={(value) => handleBasicFieldChange('produces', value ?? [])}
+        />
+      </label>
     </>
   );
 
@@ -1649,19 +1665,19 @@ const ModuleForm: React.FC<ModuleFormProps> = ({
         </div>
         {onDelete && <Button size="s" view="clear" label="Удалить модуль" onClick={onDelete} />}
       </div>
-      {moduleSections.map((section, index) => (
+      {moduleSections.map(({ id }, index) => (
         <Collapse
-          key={section}
+          key={id}
           isOpen={current === index}
           onClick={() => goToStep(index)}
           label={
             <div className={styles.collapseLabel}>
               <Text size="s" weight="semibold">
-                {section === 'general'
+                {id === 'general'
                   ? 'Основные сведения'
-                  : section === 'calculation'
+                  : id === 'calculation'
                     ? 'Показатели'
-                    : section === 'technical'
+                    : id === 'technical'
                       ? 'Технические детали'
                       : 'Нефункциональные требования'}
               </Text>
@@ -1672,10 +1688,10 @@ const ModuleForm: React.FC<ModuleFormProps> = ({
           }
         >
           <div className={styles.sectionContent}>
-            {section === 'general' && renderGeneralSection()}
-            {section === 'calculation' && renderCalculationSection()}
-            {section === 'technical' && renderTechnicalSection()}
-            {section === 'nonFunctional' && renderNonFunctionalSection()}
+            {id === 'general' && renderGeneralSection()}
+            {id === 'calculation' && renderCalculationSection()}
+            {id === 'technical' && renderTechnicalSection()}
+            {id === 'nonFunctional' && renderNonFunctionalSection()}
           </div>
           <div className={styles.stepActions}>
             {index > 0 && (
@@ -2190,6 +2206,7 @@ function createDefaultModuleDraft(): ModuleDraftPayload {
     status: 'in-dev',
     domainIds: [],
     dependencyIds: [],
+    produces: [],
     dataIn: [{ id: 'input-1', label: '', sourceId: undefined }],
     dataOut: [{ id: 'output-1', label: '', consumerIds: [] }],
     ridOwner: { company: '', division: '' },
@@ -2252,6 +2269,7 @@ function moduleToDraft(module: ModuleNode): ModuleDraftPayload {
     status: module.status,
     domainIds: [...module.domains],
     dependencyIds: [...module.dependencies],
+    produces: [...module.produces],
     dataIn: module.dataIn.map((input) => ({ ...input })),
     dataOut: module.dataOut.map((output) => ({
       ...output,
@@ -2308,6 +2326,11 @@ function applyModuleDraftPrefill(
   if (Array.isArray(patch.domainIds)) {
     ensureCopy();
     next.domainIds = [...patch.domainIds];
+  }
+
+  if (Array.isArray(patch.produces)) {
+    ensureCopy();
+    next.produces = [...patch.produces];
   }
 
   if (Array.isArray(patch.projectTeam)) {
@@ -2371,6 +2394,24 @@ function buildDomainLabelMap(domains: DomainNode[]): Record<string, string> {
 
   visit(domains, 0);
   return map;
+}
+
+function collectAttachableDomainIds(domains: DomainNode[]): string[] {
+  const ids: string[] = [];
+
+  const visit = (nodes: DomainNode[], depth: number) => {
+    nodes.forEach((node) => {
+      if (depth > 0 && !node.isCatalogRoot) {
+        ids.push(node.id);
+      }
+      if (node.children) {
+        visit(node.children, depth + 1);
+      }
+    });
+  };
+
+  visit(domains, 0);
+  return ids;
 }
 
 function collectLeafDomainIds(domains: DomainNode[]): string[] {

--- a/src/components/InitiativePlanner.module.css
+++ b/src/components/InitiativePlanner.module.css
@@ -57,8 +57,8 @@
 
 .contentGrid {
   display: grid;
-  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
-  gap: 24px;
+  grid-template-columns: minmax(200px, 240px) minmax(0, 1fr);
+  gap: 20px;
   align-items: start;
 }
 
@@ -139,7 +139,8 @@
 
 @media (max-width: 1200px) {
   .contentGrid {
-    grid-template-columns: minmax(240px, 280px) minmax(0, 1fr);
+    grid-template-columns: minmax(180px, 220px) minmax(0, 1fr);
+    gap: 20px;
   }
 }
 


### PR DESCRIPTION
## Summary
- update the module admin form to capture produced artifacts alongside other graph attributes
- restrict module domain selections to non-root domains and carry the choice through module drafts
- adjust module persistence to use the new produced artifacts list and domain helper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fce7d80ec88332bf75569ca9a348e8