### PR TITLE
Fix catalog switch handlers in admin panel

### DIFF
--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -2129,7 +2129,9 @@ const ModuleForm: React.FC<ModuleFormProps> = ({
         <Switch
           size="s"
           checked={draft.licenseServerIntegrated}
-          onChange={({ checked }) => handleBasicFieldChange('licenseServerIntegrated', !!checked)}
+          onChange={({ target }) =>
+            handleBasicFieldChange('licenseServerIntegrated', target.checked)
+          }
         />
       </div>
       <div className={styles.subSection}>
@@ -2513,7 +2515,9 @@ const DomainForm: React.FC<DomainFormProps> = ({
           <Switch
             size="s"
             checked={draft.isCatalogRoot}
-            onChange={({ checked }) => onChange({ ...draft, isCatalogRoot: !!checked })}
+            onChange={({ target }) =>
+              onChange({ ...draft, isCatalogRoot: target.checked })
+            }
           />
         </label>
       </div>


### PR DESCRIPTION
## Summary
- ensure Consta Switch handlers rely on the checkbox target state for catalog and license toggles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fd5fca572c8332aa68922d63807f3c