### PR TITLE
Make initiative role panel collapsible and sync Gantt resources

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -579,14 +579,37 @@ function App() {
           if (!hasExpert && role.required > 0 && nextPinned.length > role.required) {
             nextPinned = nextPinned.slice(nextPinned.length - role.required);
           }
-          const changed =
+          const pinnedChanged =
             nextPinned.length !== role.pinnedExpertIds.length ||
             nextPinned.some((id, index) => role.pinnedExpertIds[index] !== id);
-          if (!changed) {
+
+          let workItemsChanged = false;
+          let updatedWorkItems: typeof role.workItems = role.workItems;
+
+          if (role.workItems && role.workItems.length > 0) {
+            const nextWorkItems = role.workItems.map((item, index) => {
+              const nextAssigned =
+                nextPinned.length > 0 ? nextPinned[index % nextPinned.length] : undefined;
+              if (nextAssigned === item.assignedExpertId) {
+                return item;
+              }
+              workItemsChanged = true;
+              return { ...item, assignedExpertId: nextAssigned };
+            });
+            if (workItemsChanged) {
+              updatedWorkItems = nextWorkItems;
+            }
+          }
+
+          if (!pinnedChanged && !workItemsChanged) {
             return role;
           }
           updated = true;
-          return { ...role, pinnedExpertIds: nextPinned };
+          return {
+            ...role,
+            pinnedExpertIds: nextPinned,
+            ...(role.workItems ? { workItems: updatedWorkItems } : {})
+          };
         });
         if (!updated) {
           return initiative;

--- a/src/components/InitiativeCreationModal.tsx
+++ b/src/components/InitiativeCreationModal.tsx
@@ -237,21 +237,44 @@ const createApprovalStageDraft = (): ApprovalStageDraft => ({
 
 const buildWorksFromCreationDraft = (draft: InitiativeCreationRequest): WorkDraft[] => {
   const workMap = new Map<string, WorkDraft>();
+  const workItemMetadata = new Map(
+    draft.workItems.map((item) => [item.id, item])
+  );
 
   draft.roles.forEach((role) => {
     role.workItems.forEach((item, index) => {
       const workId = item.id || `${role.id}-work-${index + 1}`;
+      const metadata = workItemMetadata.get(workId);
       let work = workMap.get(workId);
 
       if (!work) {
         work = {
           id: workId,
-          title: item.title,
-          description: item.description,
-          assumptions: item.assumptions ?? '',
+          title: item.title || metadata?.title || '',
+          description: item.description || metadata?.description || '',
+          assumptions: item.assumptions?.trim() ?? '',
+          owner: metadata?.owner ?? '',
+          timeframe: metadata?.timeframe ?? '',
+          status: metadata?.status ?? 'discovery',
           assignments: []
         };
         workMap.set(workId, work);
+      } else {
+        if (!work.owner && metadata?.owner) {
+          work.owner = metadata.owner;
+        }
+        if (!work.timeframe && metadata?.timeframe) {
+          work.timeframe = metadata.timeframe;
+        }
+        if (!metadata && !work.status) {
+          work.status = 'discovery';
+        } else if (metadata?.status) {
+          work.status = metadata.status;
+        }
+      }
+
+      if (metadata) {
+        workItemMetadata.delete(workId);
       }
 
       const tasks = item.tasks ?? [];
@@ -271,8 +294,32 @@ const buildWorksFromCreationDraft = (draft: InitiativeCreationRequest): WorkDraf
     });
   });
 
+  workItemMetadata.forEach((metadata, workId) => {
+    const existing = workMap.get(workId);
+    if (existing) {
+      existing.title = existing.title || metadata.title;
+      existing.description = existing.description || metadata.description;
+      existing.owner = metadata.owner;
+      existing.timeframe = metadata.timeframe;
+      existing.status = metadata.status;
+      return;
+    }
+
+    workMap.set(workId, {
+      id: workId,
+      title: metadata.title,
+      description: metadata.description,
+      assumptions: '',
+      owner: metadata.owner,
+      timeframe: metadata.timeframe,
+      status: metadata.status,
+      assignments: [createWorkAssignmentDraft()]
+    });
+  });
+
   const works = Array.from(workMap.values()).map((work) => ({
     ...work,
+    assumptions: work.assumptions ?? '',
     assignments:
       work.assignments.length > 0 ? work.assignments : [createWorkAssignmentDraft()]
   }));

--- a/src/components/InitiativeCreationModal.tsx
+++ b/src/components/InitiativeCreationModal.tsx
@@ -282,7 +282,7 @@ const buildWorksFromCreationDraft = (draft: InitiativeCreationRequest): WorkDraf
         id: createId(),
         role: role.role,
         task: tasks[0]?.skill ?? '',
-        description: item.description,
+        description: item.description ?? '',
         effortDays: Math.max(1, Math.round(item.effortDays)),
         startDay: Math.max(0, Math.round(item.startDay)),
         durationDays: Math.max(1, Math.round(item.durationDays)),

--- a/src/components/InitiativePlanner.module.css
+++ b/src/components/InitiativePlanner.module.css
@@ -184,7 +184,26 @@
 .roleHeader {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.roleInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.roleActions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.roleCardCollapsed {
   gap: 12px;
 }
 

--- a/src/components/InitiativePlanner.tsx
+++ b/src/components/InitiativePlanner.tsx
@@ -130,6 +130,21 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
     setOpenCandidates(new Set());
   }, [selectedId]);
 
+  const initiativeOptions = useMemo<SelectItem<string>[]>(
+    () => initiatives.map((initiative) => ({ label: initiative.name, value: initiative.id })),
+    [initiatives]
+  );
+
+  const selectValue = useMemo(
+    () => initiativeOptions.find((option) => option.value === selectedId) ?? null,
+    [initiativeOptions, selectedId]
+  );
+
+  const selectedInitiative = useMemo(
+    () => initiatives.find((initiative) => initiative.id === selectedId) ?? null,
+    [initiatives, selectedId]
+  );
+
   useEffect(() => {
     if (!selectedInitiative) {
       setCollapsedRoles(new Set());
@@ -159,21 +174,6 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
     lastInitiativeIdRef.current = selectedInitiative.id;
     lastRoleIdsRef.current = currentRoleIds;
   }, [selectedInitiative]);
-
-  const initiativeOptions = useMemo<SelectItem<string>[]>(
-    () => initiatives.map((initiative) => ({ label: initiative.name, value: initiative.id })),
-    [initiatives]
-  );
-
-  const selectValue = useMemo(
-    () => initiativeOptions.find((option) => option.value === selectedId) ?? null,
-    [initiativeOptions, selectedId]
-  );
-
-  const selectedInitiative = useMemo(
-    () => initiatives.find((initiative) => initiative.id === selectedId) ?? null,
-    [initiatives, selectedId]
-  );
 
   const expertMap = useMemo(() => {
     const map = new Map<string, ExpertProfile>();

--- a/src/components/InitiativePlanner.tsx
+++ b/src/components/InitiativePlanner.tsx
@@ -5,7 +5,7 @@ import { Select } from '@consta/uikit/Select';
 import { Steps } from '@consta/uikit/Steps';
 import { Text } from '@consta/uikit/Text';
 import clsx from 'clsx';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   ExpertProfile,
   Initiative,
@@ -108,12 +108,15 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
   const [riskDescription, setRiskDescription] = useState('');
   const [riskSeverity, setRiskSeverity] = useState<InitiativeRisk['severity']>('medium');
   const [openCandidates, setOpenCandidates] = useState<Set<CandidateKey>>(new Set());
+  const [collapsedRoles, setCollapsedRoles] = useState<Set<string>>(new Set());
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalMode, setModalMode] = useState<'create' | 'edit'>('create');
   const [modalTargetId, setModalTargetId] = useState<string | null>(null);
   const [modalInitialDraft, setModalInitialDraft] = useState<InitiativeCreationRequest | null>(null);
   const [isModalSubmitting, setIsModalSubmitting] = useState(false);
   const [modalError, setModalError] = useState<string | null>(null);
+  const lastInitiativeIdRef = useRef<string | null>(null);
+  const lastRoleIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     if (!selectedId && initiatives.length > 0) {
@@ -126,6 +129,36 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
     setRiskSeverity('medium');
     setOpenCandidates(new Set());
   }, [selectedId]);
+
+  useEffect(() => {
+    if (!selectedInitiative) {
+      setCollapsedRoles(new Set());
+      lastInitiativeIdRef.current = null;
+      lastRoleIdsRef.current = new Set();
+      return;
+    }
+
+    const currentRoleIds = new Set(selectedInitiative.roles.map((role) => role.id));
+
+    setCollapsedRoles((prev) => {
+      if (lastInitiativeIdRef.current !== selectedInitiative.id) {
+        return new Set(currentRoleIds);
+      }
+
+      const next = new Set(Array.from(prev).filter((roleId) => currentRoleIds.has(roleId)));
+
+      selectedInitiative.roles.forEach((role) => {
+        if (!lastRoleIdsRef.current.has(role.id)) {
+          next.add(role.id);
+        }
+      });
+
+      return next;
+    });
+
+    lastInitiativeIdRef.current = selectedInitiative.id;
+    lastRoleIdsRef.current = currentRoleIds;
+  }, [selectedInitiative]);
 
   const initiativeOptions = useMemo<SelectItem<string>[]>(
     () => initiatives.map((initiative) => ({ label: initiative.name, value: initiative.id })),
@@ -279,6 +312,18 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
     });
   };
 
+  const handleToggleRoleCollapse = (roleId: string) => {
+    setCollapsedRoles((prev) => {
+      const next = new Set(prev);
+      if (next.has(roleId)) {
+        next.delete(roleId);
+      } else {
+        next.add(roleId);
+      }
+      return next;
+    });
+  };
+
   const modal = (
     <InitiativeCreationModal
       isOpen={isModalOpen}
@@ -369,11 +414,19 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
   const renderRoleCard = (role: Initiative['roles'][number]) => {
     const pinnedSet = new Set(role.pinnedExpertIds);
     const sortedCandidates = [...role.candidates].sort((a, b) => b.score - a.score);
+    const isCollapsed = collapsedRoles.has(role.id);
+    const candidateListId = `${role.id}-candidates`;
 
     return (
-      <Card key={role.id} className={styles.roleCard} verticalSpace="xl" horizontalSpace="xl">
+      <Card
+        key={role.id}
+        className={clsx(styles.roleCard, isCollapsed && styles.roleCardCollapsed)}
+        verticalSpace="xl"
+        horizontalSpace="xl"
+        data-collapsed={isCollapsed}
+      >
         <div className={styles.roleHeader}>
-          <div>
+          <div className={styles.roleInfo}>
             <Text size="s" weight="semibold">
               {role.role}
             </Text>
@@ -381,23 +434,32 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
               Требуется: {role.required} · Закреплено: {role.pinnedExpertIds.length}
             </Text>
           </div>
-          {pinnedSet.size > 0 && (
-            <Badge size="s" status="success" label="Есть закрепления" />
-          )}
+          <div className={styles.roleActions}>
+            {pinnedSet.size > 0 && <Badge size="s" status="success" label="Есть закрепления" />}
+            <Button
+              size="xs"
+              view="ghost"
+              label={isCollapsed ? 'Развернуть' : 'Свернуть'}
+              onClick={() => handleToggleRoleCollapse(role.id)}
+              aria-expanded={!isCollapsed}
+              aria-controls={candidateListId}
+            />
+          </div>
         </div>
-        <div className={styles.candidateList}>
-          {sortedCandidates.map((candidate) => {
-            const candidateKey: CandidateKey = `${role.id}:${candidate.expertId}`;
-            const expert = expertMap.get(candidate.expertId);
-            const isPinned = pinnedSet.has(candidate.expertId);
-            const isOpen = openCandidates.has(candidateKey);
-            const scoreLabel = `${Math.round(candidate.score)} баллов`;
+        {!isCollapsed && (
+          <div className={styles.candidateList} id={candidateListId}>
+            {sortedCandidates.map((candidate) => {
+              const candidateKey: CandidateKey = `${role.id}:${candidate.expertId}`;
+              const expert = expertMap.get(candidate.expertId);
+              const isPinned = pinnedSet.has(candidate.expertId);
+              const isOpen = openCandidates.has(candidateKey);
+              const scoreLabel = `${Math.round(candidate.score)} баллов`;
 
-            return (
-              <div
-                key={candidateKey}
-                className={clsx(styles.candidateCard, isPinned && styles.candidatePinned)}
-              >
+              return (
+                <div
+                  key={candidateKey}
+                  className={clsx(styles.candidateCard, isPinned && styles.candidatePinned)}
+                >
                 <div className={styles.candidateHeader}>
                   <div className={styles.candidateTitle}>
                     <Text size="s" weight="semibold">
@@ -463,8 +525,9 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
                 )}
               </div>
             );
-          })}
-        </div>
+            })}
+          </div>
+        )}
       </Card>
     );
   };


### PR DESCRIPTION
## Summary
- make initiative role cards collapsible by default in the initiative planner
- restyle the role header to host the new collapse control
- propagate role pinning changes into work-item resource assignments for the timeline

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fd652d5cdc83328f03f19742260ab8