### PR TITLE
Sanitize hydrated work metadata fields

### DIFF
--- a/src/components/InitiativeCreationModal.tsx
+++ b/src/components/InitiativeCreationModal.tsx
@@ -237,21 +237,44 @@ const createApprovalStageDraft = (): ApprovalStageDraft => ({
 
 const buildWorksFromCreationDraft = (draft: InitiativeCreationRequest): WorkDraft[] => {
   const workMap = new Map<string, WorkDraft>();
+  const workItemMetadata = new Map(
+    draft.workItems.map((item) => [item.id, item])
+  );
 
   draft.roles.forEach((role) => {
     role.workItems.forEach((item, index) => {
       const workId = item.id || `${role.id}-work-${index + 1}`;
+      const metadata = workItemMetadata.get(workId);
       let work = workMap.get(workId);
 
       if (!work) {
         work = {
           id: workId,
-          title: item.title,
-          description: item.description,
-          assumptions: item.assumptions ?? '',
+          title: item.title || metadata?.title || '',
+          description: item.description || metadata?.description || '',
+          assumptions: item.assumptions?.trim() ?? '',
+          owner: metadata?.owner ?? '',
+          timeframe: metadata?.timeframe ?? '',
+          status: metadata?.status ?? 'discovery',
           assignments: []
         };
         workMap.set(workId, work);
+      } else {
+        if (!work.owner && metadata?.owner) {
+          work.owner = metadata.owner;
+        }
+        if (!work.timeframe && metadata?.timeframe) {
+          work.timeframe = metadata.timeframe;
+        }
+        if (!metadata && !work.status) {
+          work.status = 'discovery';
+        } else if (metadata?.status) {
+          work.status = metadata.status;
+        }
+      }
+
+      if (metadata) {
+        workItemMetadata.delete(workId);
       }
 
       const tasks = item.tasks ?? [];
@@ -259,7 +282,7 @@ const buildWorksFromCreationDraft = (draft: InitiativeCreationRequest): WorkDraf
         id: createId(),
         role: role.role,
         task: tasks[0]?.skill ?? '',
-        description: item.description,
+        description: item.description ?? '',
         effortDays: Math.max(1, Math.round(item.effortDays)),
         startDay: Math.max(0, Math.round(item.startDay)),
         durationDays: Math.max(1, Math.round(item.durationDays)),
@@ -271,8 +294,46 @@ const buildWorksFromCreationDraft = (draft: InitiativeCreationRequest): WorkDraf
     });
   });
 
+  workItemMetadata.forEach((metadata, workId) => {
+    const existing = workMap.get(workId);
+    if (existing) {
+      const nextTitle = metadata.title ?? '';
+      const nextDescription = metadata.description ?? '';
+      const nextOwner = metadata.owner ?? '';
+      const nextTimeframe = metadata.timeframe ?? '';
+      const nextStatus = metadata.status;
+
+      existing.title = existing.title || nextTitle;
+      existing.description = existing.description || nextDescription;
+      if (nextOwner) {
+        existing.owner = nextOwner;
+      }
+      if (nextTimeframe) {
+        existing.timeframe = nextTimeframe;
+      }
+      if (nextStatus) {
+        existing.status = nextStatus;
+      } else if (!existing.status) {
+        existing.status = 'discovery';
+      }
+      return;
+    }
+
+    workMap.set(workId, {
+      id: workId,
+      title: metadata.title ?? '',
+      description: metadata.description ?? '',
+      assumptions: '',
+      owner: metadata.owner ?? '',
+      timeframe: metadata.timeframe ?? '',
+      status: metadata.status ?? 'discovery',
+      assignments: [createWorkAssignmentDraft()]
+    });
+  });
+
   const works = Array.from(workMap.values()).map((work) => ({
     ...work,
+    assumptions: work.assumptions ?? '',
     assignments:
       work.assignments.length > 0 ? work.assignments : [createWorkAssignmentDraft()]
   }));


### PR DESCRIPTION
## Summary
- default hydrated work metadata fields to empty strings so trim() is never called on undefined
- preserve existing owner/timeframe/status values when metadata fields are missing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fe26d0d664833284e8791376409e04