### PR TITLE
Prevent camera reset after layout normalization

### DIFF
--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -365,14 +365,14 @@ const GraphView: React.FC<GraphViewProps> = ({
       return;
     }
 
-    const graph = graphRef.current;
-    graph.zoomToFit?.(400, 80);
+    restoreCamera();
 
+    const graph = graphRef.current;
     const reheat = (graph as ForceGraphMethods & { d3ReheatSimulation?: () => void }).d3ReheatSimulation;
     if (typeof reheat === 'function') {
       reheat();
     }
-  }, [normalizationRequest, nodes.length]);
+  }, [normalizationRequest, nodes.length, restoreCamera]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary
- reuse the existing camera state when layout normalization runs so the view no longer jumps back to the initial position
- keep the physics simulation reheated after normalization without forcing a zoom-to-fit

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6903b03f3cf0833296f00a27359d55c7