### PR TITLE
Update module outputs to select artifacts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -883,12 +883,13 @@ function App() {
       });
 
       module.dataOut.forEach((output) => {
-        output.consumerIds?.forEach((consumerId) => {
-          const consumerName = moduleNameMap[consumerId];
-          if (consumerName) {
-            collected.push(consumerName);
-          }
-        });
+        if (!output.artifactId) {
+          return;
+        }
+        const producedName = artifactNameMap[output.artifactId];
+        if (producedName) {
+          collected.push(producedName);
+        }
       });
 
       const normalized = collected
@@ -1874,10 +1875,11 @@ function App() {
         .map((module) => ({
           ...module,
           dependencies: module.dependencies.filter((dependencyId) => dependencyId !== moduleId),
-          dataOut: module.dataOut.map((output) => ({
-            ...output,
-            consumerIds: (output.consumerIds ?? []).filter((consumerId) => consumerId !== moduleId)
-          })),
+          dataOut: module.dataOut
+            .filter((output) =>
+              output.artifactId ? !removedArtifactIds.has(output.artifactId) : true
+            )
+            .map((output) => ({ ...output })),
           produces: module.produces.filter((artifactId) => !removedArtifactIds.has(artifactId)),
           dataIn: module.dataIn.filter((input) =>
             input.sourceId ? !removedArtifactIds.has(input.sourceId) : true
@@ -2189,11 +2191,13 @@ function App() {
               const produces = module.produces.includes(artifactId)
                 ? module.produces
                 : [...module.produces, artifactId];
-              const existingOutputIndex = module.dataOut.findIndex((output) => output.label === normalizedName);
+              const existingOutputIndex = module.dataOut.findIndex(
+                (output) => output.artifactId === artifactId || output.label === normalizedName
+              );
               const dataOut = existingOutputIndex >= 0
                 ? module.dataOut.map((output, index) =>
                     index === existingOutputIndex
-                      ? { ...output, label: normalizedName, consumerIds: consumers }
+                      ? { ...output, label: normalizedName, artifactId }
                       : output
                   )
                 : [
@@ -2201,7 +2205,7 @@ function App() {
                     {
                       id: `output-${module.dataOut.length + 1}-${artifactId}`,
                       label: normalizedName,
-                      consumerIds: consumers
+                      artifactId
                     }
                   ];
               next = { ...next, produces, dataOut };
@@ -2295,7 +2299,7 @@ function App() {
                 produces = [...produces, artifactId];
               }
               const outputIndex = dataOut.findIndex(
-                (output) => output.label === existing.name || output.label === normalizedName
+                (output) => output.artifactId === artifactId
               );
               if (outputIndex >= 0) {
                 dataOut = dataOut.map((output, index) =>
@@ -2303,7 +2307,7 @@ function App() {
                     ? {
                         ...output,
                         label: normalizedName,
-                        consumerIds: consumers
+                        artifactId
                       }
                     : output
                 );
@@ -2313,15 +2317,13 @@ function App() {
                   {
                     id: `output-${dataOut.length + 1}-${artifactId}`,
                     label: normalizedName,
-                    consumerIds: consumers
+                    artifactId
                   }
                 ];
               }
             } else if (wasProducer) {
               produces = produces.filter((id) => id !== artifactId);
-              dataOut = dataOut.filter(
-                (output) => output.label !== existing.name && output.label !== normalizedName
-              );
+              dataOut = dataOut.filter((output) => output.artifactId !== artifactId);
             }
 
             const isConsumer = consumers.includes(module.id);
@@ -3451,7 +3453,6 @@ function buildModuleFromDraft(
   }
 
   const dependencies = deduplicateNonEmpty(draft.dependencyIds).filter((id) => id !== moduleId);
-  const produces = deduplicateNonEmpty(draft.produces ?? []);
 
   const preparedInputs = (draft.dataIn.length > 0 ? draft.dataIn : [{ id: '', label: '', sourceId: undefined }]).map((input, index) => ({
     id: input.id?.trim() || `input-${index + 1}`,
@@ -3460,11 +3461,15 @@ function buildModuleFromDraft(
   }));
   const consumedArtifactIds = deduplicateNonEmpty(preparedInputs.map((input) => input.sourceId ?? null));
 
-  const preparedOutputs = (draft.dataOut.length > 0 ? draft.dataOut : [{ id: '', label: '', consumerIds: [] }]).map((output, index) => ({
+  const preparedOutputs = (draft.dataOut.length > 0
+    ? draft.dataOut
+    : [{ id: '', label: '', artifactId: undefined }]
+  ).map((output, index) => ({
     id: output.id?.trim() || `output-${index + 1}`,
     label: output.label.trim() || `Выход ${index + 1}`,
-    consumerIds: deduplicateNonEmpty(output.consumerIds ?? [])
+    artifactId: output.artifactId?.trim() || undefined
   }));
+  const produces = deduplicateNonEmpty(preparedOutputs.map((output) => output.artifactId ?? null));
 
   const technologyStack = deduplicateNonEmpty(draft.technologyStack.map((item) => item.trim())).filter(Boolean);
 
@@ -3584,6 +3589,19 @@ function buildModuleIntegrationMap(modules: ModuleNode[]): Map<string, Set<strin
     map.set(module.id, new Set());
   });
 
+  const artifactConsumers = new Map<string, Set<string>>();
+
+  modules.forEach((module) => {
+    module.dataIn.forEach((input) => {
+      if (!input.sourceId) {
+        return;
+      }
+      const consumers = artifactConsumers.get(input.sourceId) ?? new Set<string>();
+      consumers.add(module.id);
+      artifactConsumers.set(input.sourceId, consumers);
+    });
+  });
+
   modules.forEach((module) => {
     module.dependencies.forEach((dependencyId) => {
       if (!map.has(dependencyId) || dependencyId === module.id) {
@@ -3594,7 +3612,11 @@ function buildModuleIntegrationMap(modules: ModuleNode[]): Map<string, Set<strin
     });
 
     module.dataOut.forEach((output) => {
-      (output.consumerIds ?? []).forEach((consumerId) => {
+      if (!output.artifactId) {
+        return;
+      }
+      const consumers = artifactConsumers.get(output.artifactId);
+      consumers?.forEach((consumerId) => {
         if (!map.has(consumerId) || consumerId === module.id) {
           return;
         }

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -32,7 +32,6 @@ export type ModuleDraftPayload = {
   status: ModuleStatus;
   domainIds: string[];
   dependencyIds: string[];
-  produces: string[];
   dataIn: ModuleInput[];
   dataOut: ModuleOutput[];
   ridOwner: RidOwner;
@@ -1463,7 +1462,7 @@ const ModuleForm: React.FC<ModuleFormProps> = ({
   const handleAddDataOut = () => {
     onChange({
       ...draft,
-      dataOut: [...draft.dataOut, { id: `output-${draft.dataOut.length + 1}`, label: '', consumerIds: [] }]
+      dataOut: [...draft.dataOut, { id: `output-${draft.dataOut.length + 1}`, label: '', artifactId: undefined }]
     });
   };
 
@@ -1979,13 +1978,12 @@ const ModuleForm: React.FC<ModuleFormProps> = ({
               />
               <Combobox<string>
                 size="s"
-                items={moduleItems}
-                value={output.consumerIds ?? []}
-                multiple
+                items={artifactItems}
+                value={output.artifactId ?? null}
                 getItemKey={(item) => item}
-                getItemLabel={(item) => moduleLabelMap[item] ?? item}
-                placeholder="Потребители"
-                onChange={(value) => handleDataOutChange(index, { consumerIds: value ?? [] })}
+                getItemLabel={(item) => artifactLabelMap[item] ?? item}
+                placeholder="Артефакт"
+                onChange={(value) => handleDataOutChange(index, { artifactId: value ?? undefined })}
               />
               <Button
                 size="xs"
@@ -2000,22 +1998,7 @@ const ModuleForm: React.FC<ModuleFormProps> = ({
       </div>
       <label className={styles.field}>
         <Text size="xs" weight="semibold" className={styles.label}>
-          Производимые артефакты
-        </Text>
-        <Combobox<string>
-          size="s"
-          items={artifactItems}
-          value={draft.produces}
-          multiple
-          getItemKey={(item) => item}
-          getItemLabel={(item) => artifactLabelMap[item] ?? item}
-          placeholder="Выберите артефакты"
-          onChange={(value) => handleBasicFieldChange('produces', value ?? [])}
-        />
-      </label>
-      <label className={styles.field}>
-        <Text size="xs" weight="semibold" className={styles.label}>
-          Формула расчёта эффекта
+          Описание алгоритма расчёта модуля
         </Text>
         <textarea
           className={styles.textarea}
@@ -2907,9 +2890,8 @@ function createDefaultModuleDraft(): ModuleDraftPayload {
     status: 'in-dev',
     domainIds: [],
     dependencyIds: [],
-    produces: [],
     dataIn: [{ id: 'input-1', label: '', sourceId: undefined }],
-    dataOut: [{ id: 'output-1', label: '', consumerIds: [] }],
+    dataOut: [{ id: 'output-1', label: '', artifactId: undefined }],
     ridOwner: { company: '', division: '' },
     localization: 'ru',
     userStats: { companies: [{ name: '', licenses: 0 }] },
@@ -2970,12 +2952,8 @@ function moduleToDraft(module: ModuleNode): ModuleDraftPayload {
     status: module.status,
     domainIds: [...module.domains],
     dependencyIds: [...module.dependencies],
-    produces: [...module.produces],
     dataIn: module.dataIn.map((input) => ({ ...input })),
-    dataOut: module.dataOut.map((output) => ({
-      ...output,
-      consumerIds: output.consumerIds ? [...output.consumerIds] : []
-    })),
+    dataOut: module.dataOut.map((output) => ({ ...output })),
     ridOwner: { ...module.ridOwner },
     localization: module.localization,
     userStats: {
@@ -3029,10 +3007,6 @@ function applyModuleDraftPrefill(
     next.domainIds = [...patch.domainIds];
   }
 
-  if (Array.isArray(patch.produces)) {
-    ensureCopy();
-    next.produces = [...patch.produces];
-  }
 
   if (Array.isArray(patch.projectTeam)) {
     ensureCopy();

--- a/src/components/NodeDetails.tsx
+++ b/src/components/NodeDetails.tsx
@@ -1,7 +1,6 @@
 import { Badge } from '@consta/uikit/Badge';
 import { Button } from '@consta/uikit/Button';
 import { Collapse } from '@consta/uikit/Collapse';
-import { Select } from '@consta/uikit/Select';
 import { Tag } from '@consta/uikit/Tag';
 import { Text } from '@consta/uikit/Text';
 import React, { useEffect, useState } from 'react';
@@ -28,11 +27,6 @@ const statusBadgeView: Record<string, 'success' | 'warning' | 'alert' | 'normal'
   production: 'success',
   'in-dev': 'warning',
   deprecated: 'alert'
-};
-
-type ConsumerOption = {
-  id: string;
-  label: string;
 };
 
 type SectionId = 'general' | 'calculation' | 'technical' | 'nonFunctional';
@@ -543,7 +537,7 @@ const NodeDetails: React.FC<NodeDetailsProps> = ({
             onNavigate={onNavigate}
             resolveName={resolveEntityName}
           />
-          <InfoRow label="Формула расчёта">
+          <InfoRow label="Описание алгоритма расчёта модуля">
             <Text size="s" className={styles.code}>
               {node.formula}
             </Text>
@@ -876,25 +870,29 @@ const ModuleOutputSection: React.FC<ModuleOutputSectionProps> = ({
       </Text>
       <ul className={styles.ioList}>
         {items.map((item) => {
-          const consumerOptions: ConsumerOption[] = (item.consumerIds ?? []).map((consumerId) => ({
-            id: consumerId,
-            label: resolveName(consumerId)
-          }));
-
+          const hasArtifact = Boolean(item.artifactId);
+          const artifactLabel = item.artifactId ? resolveName(item.artifactId) : null;
           return (
             <li key={item.id} className={styles.ioItem}>
               <Text size="s" weight="semibold">
                 {item.label}
               </Text>
-              {consumerOptions.length > 0 ? (
-                <ConsumerSelect
-                  options={consumerOptions}
-                  onNavigate={onNavigate}
-                  placeholder="Перейти к потребителю"
-                />
+              {hasArtifact ? (
+                <a
+                  href="#"
+                  className={styles.link}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    if (item.artifactId) {
+                      onNavigate(item.artifactId);
+                    }
+                  }}
+                >
+                  {artifactLabel ?? item.artifactId}
+                </a>
               ) : (
                 <Text size="xs" view="secondary">
-                  Потребители отсутствуют
+                  Артефакт не назначен
                 </Text>
               )}
             </li>
@@ -902,45 +900,6 @@ const ModuleOutputSection: React.FC<ModuleOutputSectionProps> = ({
         })}
       </ul>
     </div>
-  );
-};
-
-type ConsumerSelectProps = {
-  options: ConsumerOption[];
-  placeholder: string;
-  onNavigate: (nodeId: string) => void;
-};
-
-const ConsumerSelect: React.FC<ConsumerSelectProps> = ({ options, placeholder, onNavigate }) => {
-  const [value, setValue] = useState<ConsumerOption | null>(null);
-
-  return (
-    <Select<ConsumerOption>
-      size="xs"
-      placeholder={placeholder}
-      items={options}
-      value={value}
-      getItemLabel={(option) => option.label}
-      getItemKey={(option) => option.id}
-      onChange={(nextValue) => {
-        setValue(nextValue ?? null);
-
-        if (!nextValue) {
-          return;
-        }
-
-        const runNavigation = () => {
-          onNavigate(nextValue.id);
-          setValue(null);
-        };
-
-        if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
-          window.requestAnimationFrame(runNavigation);
-        } else {
-          setTimeout(runNavigation, 0);
-        }
-      }}
-    />
   );
 };
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -22,7 +22,7 @@ export type ModuleInput = {
 export type ModuleOutput = {
   id: string;
   label: string;
-  consumerIds?: string[];
+  artifactId?: string;
 };
 
 export type TeamRole =
@@ -532,11 +532,7 @@ export const modules: ModuleNode[] = [
       {
         id: 'normalized-inputs',
         label: 'Стандартизированный пакет исходных данных',
-        consumerIds: [
-          'module-infraplan-layout',
-          'module-infraplan-economics',
-          'module-dtwin-optimizer'
-        ]
+        artifactId: 'artifact-infraplan-source-pack'
       }
     ],
     formula: 'normalized = preprocess(raw) ⊕ constraints',
@@ -616,7 +612,7 @@ export const modules: ModuleNode[] = [
       {
         id: 'layout-scenarios',
         label: 'Сценарии размещения объектов',
-        consumerIds: ['module-infraplan-economics']
+        artifactId: 'artifact-infraplan-layout'
       }
     ],
     formula: 'total_cost = Σ(distance_i * cost_i) + Σ(site_j * capex_j)',
@@ -698,7 +694,7 @@ export const modules: ModuleNode[] = [
       {
         id: 'investment-scenarios',
         label: 'Инвестиционные сценарии по вариантам',
-        consumerIds: []
+        artifactId: 'artifact-infraplan-economic-report'
       }
     ],
     formula: 'NPV_variant = Σ((cash_flow_t - opex_t) / (1 + WACC)^t) - capex_variant',
@@ -783,7 +779,7 @@ export const modules: ModuleNode[] = [
       {
         id: 'telemetry-cube',
         label: 'Интегрированный куб телеметрии',
-        consumerIds: ['module-dtwin-optimizer']
+        artifactId: 'artifact-dtwin-telemetry-cube'
       }
     ],
     formula: 'metric = smooth(raw_signal, window=5)',
@@ -869,7 +865,7 @@ export const modules: ModuleNode[] = [
       {
         id: 'optimization-orders',
         label: 'Команды оптимизации режимов',
-        consumerIds: ['module-dtwin-remote-control']
+        artifactId: 'artifact-dtwin-optimization-orders'
       }
     ],
     formula: 'optimal_mode = argmax(strategy_score)',
@@ -949,7 +945,7 @@ export const modules: ModuleNode[] = [
       {
         id: 'remote-command-stream',
         label: 'Поток дистанционных команд',
-        consumerIds: []
+        artifactId: 'artifact-dtwin-remote-commands'
       }
     ],
     formula: 'command = translate(order, device_profile)',
@@ -1030,7 +1026,7 @@ export const modules: ModuleNode[] = [
       {
         id: 'approved-workover-plan',
         label: 'Утверждённые программы работ по скважинам',
-        consumerIds: ['module-wwo-execution', 'module-wwo-analytics']
+        artifactId: 'artifact-wwo-plan'
       }
     ],
     formula: 'schedule = optimize(tasks, crews, constraints)',
@@ -1110,7 +1106,7 @@ export const modules: ModuleNode[] = [
       {
         id: 'operations-log',
         label: 'Фактический журнал операций',
-        consumerIds: ['module-wwo-analytics']
+        artifactId: 'artifact-wwo-operations-log'
       }
     ],
     formula: 'compliance_rate = completed_operations / planned_operations',
@@ -1194,7 +1190,8 @@ export const modules: ModuleNode[] = [
     dataOut: [
       {
         id: 'workover-kpi',
-        label: 'Индекс эффективности внутрискважинных работ'
+        label: 'Индекс эффективности внутрискважинных работ',
+        artifactId: 'artifact-wwo-performance-dashboard'
       }
     ],
     formula: 'kpi = Σ(metric_i * weight_i)',
@@ -1267,8 +1264,7 @@ export const modules: ModuleNode[] = [
     dataOut: [
       {
         id: 'lab-insights',
-        label: 'Отчёт по проведённым экспериментам',
-        consumerIds: ['module-dtwin-optimizer', 'module-wwo-analytics']
+        label: 'Отчёт по проведённым экспериментам'
       }
     ],
     formula: 'insight = normalize(stream) ⊕ simulate(layout)',


### PR DESCRIPTION
## Summary
- replace module output consumer selection with an artifact picker in the admin panel and remove the standalone produced artifacts field
- store artifact identifiers with module outputs across the dataset and surface them in node details
- recalculate module relationships based on produced artifacts and derive the produces list from outputs when saving modules

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6903bbe14be4833287602f8121aaede2