### PR TITLE
Align skill levels with awareness-to-expert scale

### DIFF
--- a/src/components/SkillEditorModal.tsx
+++ b/src/components/SkillEditorModal.tsx
@@ -26,11 +26,11 @@ type SelectOption<Value> = {
 };
 
 const skillLevelLabels: Record<SkillLevel, string> = {
-  A: 'A — Эксперт',
-  B: 'B — Продвинутый',
-  C: 'C — Уверенный',
-  D: 'D — Базовый',
-  E: 'E — Новичок'
+  A: 'A — Awareness',
+  W: 'W — Working',
+  P: 'P — Practitioner',
+  Ad: 'Ad — Advanced',
+  E: 'E — Expert'
 };
 
 const proofStatusLabels: Record<SkillEvidenceStatus, string> = {
@@ -39,9 +39,9 @@ const proofStatusLabels: Record<SkillEvidenceStatus, string> = {
   'self-reported': 'Самооценка'
 };
 
-const skillLevelOptions: SelectOption<SkillLevel>[] = (
-  Object.keys(skillLevelLabels) as SkillLevel[]
-).map((value) => ({
+const skillLevelOrder: SkillLevel[] = ['A', 'W', 'P', 'Ad', 'E'];
+
+const skillLevelOptions: SelectOption<SkillLevel>[] = skillLevelOrder.map((value) => ({
   value,
   label: skillLevelLabels[value]
 }));
@@ -61,7 +61,7 @@ const cloneSkill = (skill: ExpertSkill): ExpertSkill => ({
 
 const createEmptySkill = (): ExpertSkill => ({
   id: '',
-  level: 'C',
+  level: 'P',
   proofStatus: 'self-reported',
   artifacts: [],
   interest: 'medium',

--- a/src/data.ts
+++ b/src/data.ts
@@ -49,7 +49,7 @@ export type RidOwner = {
 
 export type ExpertAvailability = 'available' | 'partial' | 'busy';
 
-export type SkillLevel = 'A' | 'B' | 'C' | 'D' | 'E';
+export type SkillLevel = 'A' | 'W' | 'P' | 'Ad' | 'E';
 
 export type SkillEvidenceStatus = 'verified' | 'in-review' | 'self-reported';
 
@@ -1557,7 +1557,7 @@ export const initiativeNodes: InitiativeNode[] = [
     skills: [
       {
         id: 'data-normalization',
-        level: 'A',
+        level: 'E',
         proofStatus: 'verified',
         usage: {
           from: '2023-01-15',
@@ -1570,7 +1570,7 @@ export const initiativeNodes: InitiativeNode[] = [
       },
       {
         id: 'streaming-pipelines',
-        level: 'B',
+        level: 'Ad',
         proofStatus: 'verified',
         usage: {
           from: '2022-09-01',
@@ -1583,7 +1583,7 @@ export const initiativeNodes: InitiativeNode[] = [
       },
       {
         id: 'data-governance',
-        level: 'B',
+        level: 'Ad',
         proofStatus: 'in-review',
         usage: {
           from: '2023-05-01',
@@ -1633,7 +1633,7 @@ export const initiativeNodes: InitiativeNode[] = [
     skills: [
       {
         id: 'layout-optimization',
-        level: 'A',
+        level: 'E',
         proofStatus: 'verified',
         usage: {
           from: '2022-02-01',
@@ -1646,7 +1646,7 @@ export const initiativeNodes: InitiativeNode[] = [
       },
       {
         id: 'geo-apis',
-        level: 'B',
+        level: 'Ad',
         proofStatus: 'self-reported',
         usage: {
           from: '2021-07-01',
@@ -1659,7 +1659,7 @@ export const initiativeNodes: InitiativeNode[] = [
       },
       {
         id: 'infrastructure-economics',
-        level: 'C',
+        level: 'P',
         proofStatus: 'in-review',
         usage: {
           from: '2023-06-01',
@@ -1709,7 +1709,7 @@ export const initiativeNodes: InitiativeNode[] = [
     skills: [
       {
         id: 'financial-modeling',
-        level: 'A',
+        level: 'E',
         proofStatus: 'verified',
         usage: {
           from: '2022-01-01',
@@ -1722,7 +1722,7 @@ export const initiativeNodes: InitiativeNode[] = [
       },
       {
         id: 'scenario-planning',
-        level: 'B',
+        level: 'Ad',
         proofStatus: 'verified',
         usage: {
           from: '2023-03-01',
@@ -1735,7 +1735,7 @@ export const initiativeNodes: InitiativeNode[] = [
       },
       {
         id: 'ma-support',
-        level: 'C',
+        level: 'P',
         proofStatus: 'in-review',
         usage: {
           from: '2022-11-01',
@@ -1787,7 +1787,7 @@ export const initiativeNodes: InitiativeNode[] = [
     skills: [
       {
         id: 'telemetry-streaming',
-        level: 'A',
+        level: 'E',
         proofStatus: 'verified',
         usage: {
           from: '2022-04-01',
@@ -1800,7 +1800,7 @@ export const initiativeNodes: InitiativeNode[] = [
       },
       {
         id: 'iot-integration',
-        level: 'B',
+        level: 'Ad',
         proofStatus: 'in-review',
         usage: {
           from: '2023-02-01',
@@ -1812,7 +1812,7 @@ export const initiativeNodes: InitiativeNode[] = [
       },
       {
         id: 'sre-monitoring',
-        level: 'B',
+        level: 'Ad',
         proofStatus: 'self-reported',
         usage: {
           from: '2021-11-01',
@@ -1864,7 +1864,7 @@ export const initiativeNodes: InitiativeNode[] = [
     skills: [
       {
         id: 'production-ml',
-        level: 'A',
+        level: 'E',
         proofStatus: 'verified',
         usage: {
           from: '2022-08-01',
@@ -1877,7 +1877,7 @@ export const initiativeNodes: InitiativeNode[] = [
       },
       {
         id: 'mlops-production',
-        level: 'B',
+        level: 'Ad',
         proofStatus: 'verified',
         usage: {
           from: '2023-01-10',
@@ -1890,7 +1890,7 @@ export const initiativeNodes: InitiativeNode[] = [
       },
       {
         id: 'value-discovery',
-        level: 'C',
+        level: 'P',
         proofStatus: 'in-review',
         usage: {
           from: '2023-06-01',
@@ -1940,7 +1940,7 @@ export const initiativeNodes: InitiativeNode[] = [
     skills: [
       {
         id: 'remote-ops-integration',
-        level: 'A',
+        level: 'E',
         proofStatus: 'verified',
         usage: {
           from: '2021-09-01',
@@ -1953,7 +1953,7 @@ export const initiativeNodes: InitiativeNode[] = [
       },
       {
         id: 'remote-ops-security',
-        level: 'B',
+        level: 'Ad',
         proofStatus: 'in-review',
         usage: {
           from: '2022-05-01',
@@ -1965,7 +1965,7 @@ export const initiativeNodes: InitiativeNode[] = [
       },
       {
         id: 'change-management',
-        level: 'C',
+        level: 'P',
         proofStatus: 'self-reported',
         usage: {
           from: '2023-04-01',
@@ -2017,7 +2017,7 @@ export const initiativeNodes: InitiativeNode[] = [
     skills: [
       {
         id: 'wwo-planning',
-        level: 'A',
+        level: 'E',
         proofStatus: 'verified',
         usage: {
           from: '2021-03-01',
@@ -2030,7 +2030,7 @@ export const initiativeNodes: InitiativeNode[] = [
       },
       {
         id: 'contractor-management',
-        level: 'B',
+        level: 'Ad',
         proofStatus: 'verified',
         usage: {
           from: '2022-05-01',
@@ -2043,7 +2043,7 @@ export const initiativeNodes: InitiativeNode[] = [
       },
       {
         id: 'process-digitization',
-        level: 'C',
+        level: 'P',
         proofStatus: 'in-review',
         usage: {
           from: '2023-09-01',
@@ -2093,7 +2093,7 @@ export const initiativeNodes: InitiativeNode[] = [
     skills: [
       {
         id: 'field-dispatching',
-        level: 'A',
+        level: 'E',
         proofStatus: 'verified',
         usage: {
           from: '2022-06-01',
@@ -2106,7 +2106,7 @@ export const initiativeNodes: InitiativeNode[] = [
       },
       {
         id: 'mobile-solutions',
-        level: 'B',
+        level: 'Ad',
         proofStatus: 'in-review',
         usage: {
           from: '2023-01-01',
@@ -2118,7 +2118,7 @@ export const initiativeNodes: InitiativeNode[] = [
       },
       {
         id: 'hse-compliance',
-        level: 'C',
+        level: 'P',
         proofStatus: 'self-reported',
         usage: {
           from: '2022-09-01',
@@ -2169,7 +2169,7 @@ export const initiativeNodes: InitiativeNode[] = [
     skills: [
       {
         id: 'wwo-analytics',
-        level: 'A',
+        level: 'E',
         proofStatus: 'verified',
         usage: {
           from: '2022-03-01',
@@ -2182,7 +2182,7 @@ export const initiativeNodes: InitiativeNode[] = [
       },
       {
         id: 'forecasting',
-        level: 'B',
+        level: 'Ad',
         proofStatus: 'in-review',
         usage: {
           from: '2023-02-01',
@@ -2195,7 +2195,7 @@ export const initiativeNodes: InitiativeNode[] = [
       },
       {
         id: 'data-storytelling',
-        level: 'B',
+        level: 'Ad',
         proofStatus: 'self-reported',
         usage: {
           from: '2021-10-01',

--- a/src/utils/initiativeMatching.test.ts
+++ b/src/utils/initiativeMatching.test.ts
@@ -93,7 +93,7 @@ describe('buildRoleMatchReports', () => {
       skills: [
         {
           id: 'data-normalization',
-          level: 'A',
+          level: 'E',
           proofStatus: 'verified',
           artifacts: [],
           interest: 'high',

--- a/src/utils/initiativeMatching.ts
+++ b/src/utils/initiativeMatching.ts
@@ -21,11 +21,11 @@ import type { InitiativeRoleWork } from '../data';
 const MS_IN_DAY = 86_400_000;
 
 const skillLevelMap: Record<ExpertSkill['level'], SkillLevel> = {
-  A: 'expert',
-  B: 'advanced',
-  C: 'intermediate',
-  D: 'novice',
-  E: 'novice'
+  A: 'novice',
+  W: 'intermediate',
+  P: 'advanced',
+  Ad: 'expert',
+  E: 'expert'
 };
 
 const defaultRoleLevel: Partial<Record<TeamRole, SkillLevel>> = {


### PR DESCRIPTION
## Summary
- update the shared SkillLevel type and expert seed data to match the awareness → expert scale used by the catalog
- refresh the skill editor labels and defaults so users see the new descriptors when editing
- adjust initiative matching logic and tests to interpret the updated level identifiers correctly

## Testing
- npm exec -- tsx --test src/services/matching.test.ts src/utils/initiativeMatching.test.ts

------
https://chatgpt.com/codex/tasks/task_e_6903f01212d48332a2fa77f8a4c5bdcd