### PR TITLE
feat: expand skill evidence workflow

### DIFF
--- a/src/components/InitiativeCreationModal.tsx
+++ b/src/components/InitiativeCreationModal.tsx
@@ -13,6 +13,7 @@ import type {
   InitiativeApprovalStatus,
   InitiativeStatus,
   InitiativeWorkItemStatus,
+  ModuleNode,
   TeamRole
 } from '../data';
 import { getSkillNameById, getSkillsByRole } from '../data/skills';

--- a/src/components/SkillEditorModal.module.css
+++ b/src/components/SkillEditorModal.module.css
@@ -47,6 +47,56 @@
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
+.evidenceSection {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  border: 1px dashed var(--color-bg-border);
+  border-radius: 10px;
+  background: var(--color-bg-secondary);
+}
+
+.evidenceHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.evidenceList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.evidenceCard {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--color-bg-border);
+  border-radius: 8px;
+  background: var(--color-bg-default);
+}
+
+.evidenceFields {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.evidenceActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.evidenceEmpty {
+  padding: 8px 12px;
+  border-radius: 6px;
+  background: var(--color-bg-default);
+}
+
 .skillNameHint {
   color: var(--color-typo-secondary);
 }
@@ -56,6 +106,11 @@
   justify-content: space-between;
   gap: 12px;
   flex-wrap: wrap;
+}
+
+.actionsGroup {
+  display: flex;
+  gap: 8px;
 }
 
 .addButton {

--- a/src/components/SkillEditorModal.tsx
+++ b/src/components/SkillEditorModal.tsx
@@ -4,11 +4,13 @@ import { Select } from '@consta/uikit/Select';
 import { Text } from '@consta/uikit/Text';
 import { TextField } from '@consta/uikit/TextField';
 import React, { useEffect, useMemo, useState } from 'react';
-import type {
-  ExpertProfile,
-  ExpertSkill,
-  SkillEvidenceStatus,
-  SkillLevel
+import {
+  type ExpertProfile,
+  type ExpertSkill,
+  type SkillEvidenceRecord,
+  type SkillEvidenceStatus,
+  type SkillLevel,
+  initiatives
 } from '../data';
 import { getSkillNameById } from '../data/skills';
 import styles from './SkillEditorModal.module.css';
@@ -34,9 +36,11 @@ const skillLevelLabels: Record<SkillLevel, string> = {
 };
 
 const proofStatusLabels: Record<SkillEvidenceStatus, string> = {
-  verified: 'Подтверждено',
-  'in-review': 'На проверке',
-  'self-reported': 'Самооценка'
+  claimed: 'Заявлено',
+  screened: 'На скрининге',
+  observed: 'Подтверждено наблюдением',
+  validated: 'Подтверждено',
+  refuted: 'Опровергнуто'
 };
 
 const skillLevelOptions: SelectOption<SkillLevel>[] = (
@@ -53,8 +57,73 @@ const proofStatusOptions: SelectOption<SkillEvidenceStatus>[] = (
   label: proofStatusLabels[value]
 }));
 
+const evidenceStatusValues: SkillEvidenceStatus[] = ['observed', 'validated', 'refuted'];
+
+const evidenceStatusOptions: SelectOption<SkillEvidenceStatus>[] = proofStatusOptions.filter((option) =>
+  evidenceStatusValues.includes(option.value)
+);
+
+const defaultEvidenceStatus: SkillEvidenceStatus = evidenceStatusValues[0];
+
+const normalizeEvidenceEntry = (entry: SkillEvidenceRecord): SkillEvidenceRecord => {
+  const normalized: SkillEvidenceRecord = {
+    status: entry.status
+  };
+
+  if (entry.initiativeId) {
+    const trimmedId = entry.initiativeId.trim();
+    if (trimmedId) {
+      normalized.initiativeId = trimmedId;
+    }
+  }
+
+  if (entry.comment) {
+    const trimmedComment = entry.comment.trim();
+    if (trimmedComment) {
+      normalized.comment = trimmedComment;
+    }
+  }
+
+  const artifacts = (entry.artifactIds ?? [])
+    .map((artifact) => artifact.trim())
+    .filter((artifact) => artifact.length > 0);
+
+  if (artifacts.length > 0) {
+    normalized.artifactIds = artifacts;
+  }
+
+  return normalized;
+};
+
+const normalizeSkillDraft = (skill: ExpertSkill): ExpertSkill => {
+  const normalizedEvidence = (skill.evidence ?? []).map(normalizeEvidenceEntry);
+  const normalizedUsage = skill.usage
+    ? {
+        ...skill.usage,
+        from: typeof skill.usage.from === 'string' ? skill.usage.from.trim() : skill.usage.from,
+        to: typeof skill.usage.to === 'string' && skill.usage.to ? skill.usage.to.trim() : skill.usage.to,
+        description:
+          typeof skill.usage.description === 'string' && skill.usage.description
+            ? skill.usage.description.trim()
+            : skill.usage.description
+      }
+    : undefined;
+
+  return {
+    ...skill,
+    id: skill.id.trim(),
+    evidence: normalizedEvidence,
+    artifacts: skill.artifacts.map((artifact) => artifact.trim()).filter((artifact) => artifact.length > 0),
+    usage: normalizedUsage
+  };
+};
+
 const cloneSkill = (skill: ExpertSkill): ExpertSkill => ({
   ...skill,
+  evidence: (skill.evidence ?? []).map((entry) => ({
+    ...entry,
+    artifactIds: entry.artifactIds ? [...entry.artifactIds] : undefined
+  })),
   artifacts: [...skill.artifacts],
   usage: skill.usage ? { ...skill.usage } : undefined
 });
@@ -62,7 +131,8 @@ const cloneSkill = (skill: ExpertSkill): ExpertSkill => ({
 const createEmptySkill = (): ExpertSkill => ({
   id: '',
   level: 'C',
-  proofStatus: 'self-reported',
+  proofStatus: 'claimed',
+  evidence: [],
   artifacts: [],
   interest: 'medium',
   availableFte: 0
@@ -90,19 +160,35 @@ const SkillEditorModal: React.FC<SkillEditorModalProps> = ({
     setIsSubmitting(false);
   }, [expert, isOpen]);
 
-  const hasChanges = useMemo(() => {
-    if (draftSkills.length !== expert.skills.length) {
-      return true;
-    }
-    return draftSkills.some((skill, index) => {
-      const reference = expert.skills[index];
-      return (
-        skill.id !== reference.id ||
-        skill.level !== reference.level ||
-        skill.proofStatus !== reference.proofStatus
-      );
-    });
-  }, [draftSkills, expert.skills]);
+  const initiativeOptions = useMemo(
+    () =>
+      [
+        {
+          value: '',
+          label: 'Не выбрана'
+        },
+        ...initiatives.map<SelectOption<string>>((initiative) => ({
+          value: initiative.id,
+          label: initiative.name
+        }))
+      ],
+    []
+  );
+
+  const normalizedDraft = useMemo(
+    () => draftSkills.map((skill) => normalizeSkillDraft(skill)),
+    [draftSkills]
+  );
+
+  const referenceSkills = useMemo(
+    () => expert.skills.map((skill) => normalizeSkillDraft(skill)),
+    [expert.skills]
+  );
+
+  const hasChanges = useMemo(
+    () => JSON.stringify(normalizedDraft) !== JSON.stringify(referenceSkills),
+    [normalizedDraft, referenceSkills]
+  );
 
   const handleSkillChange = <Key extends keyof ExpertSkill>(
     index: number,
@@ -116,34 +202,78 @@ const SkillEditorModal: React.FC<SkillEditorModalProps> = ({
     });
   };
 
+  const handleEvidenceChange = (
+    skillIndex: number,
+    evidenceIndex: number,
+    changes: Partial<SkillEvidenceRecord>
+  ) => {
+    setDraftSkills((prev) => {
+      const next = [...prev];
+      const skill = next[skillIndex];
+      if (!skill) {
+        return prev;
+      }
+      const evidence = [...skill.evidence];
+      const current = evidence[evidenceIndex];
+      if (!current) {
+        return prev;
+      }
+      evidence[evidenceIndex] = { ...current, ...changes };
+      next[skillIndex] = { ...skill, evidence };
+      return next;
+    });
+  };
+
   const handleRemoveSkill = (index: number) => {
     setDraftSkills((prev) => prev.filter((_, itemIndex) => itemIndex !== index));
+  };
+
+  const handleRemoveEvidence = (skillIndex: number, evidenceIndex: number) => {
+    setDraftSkills((prev) => {
+      const next = [...prev];
+      const skill = next[skillIndex];
+      if (!skill) {
+        return prev;
+      }
+      const evidence = skill.evidence.filter((_, itemIndex) => itemIndex !== evidenceIndex);
+      next[skillIndex] = { ...skill, evidence };
+      return next;
+    });
   };
 
   const handleAddSkill = () => {
     setDraftSkills((prev) => [...prev, createEmptySkill()]);
   };
 
-  const normalizedSkills = useMemo(() =>
-    draftSkills.map((skill) => ({
-      ...skill,
-      id: skill.id.trim(),
-      artifacts: [...skill.artifacts],
-      usage: skill.usage ? { ...skill.usage } : undefined
-    })),
-  [draftSkills]);
+  const handleAddEvidence = (skillIndex: number) => {
+    setDraftSkills((prev) => {
+      const next = [...prev];
+      const skill = next[skillIndex];
+      if (!skill) {
+        return prev;
+      }
+      const evidenceEntry: SkillEvidenceRecord = {
+        status: defaultEvidenceStatus,
+        initiativeId: '',
+        artifactIds: [],
+        comment: ''
+      };
+      next[skillIndex] = { ...skill, evidence: [...skill.evidence, evidenceEntry] };
+      return next;
+    });
+  };
 
   const validationError = useMemo(() => {
-    if (normalizedSkills.some((skill) => skill.id.length === 0)) {
+    if (normalizedDraft.some((skill) => skill.id.length === 0)) {
       return 'Укажите идентификаторы всех навыков.';
     }
-    const ids = normalizedSkills.map((skill) => skill.id.toLowerCase());
+    const ids = normalizedDraft.map((skill) => skill.id.toLowerCase());
     const duplicateIndex = ids.findIndex((id, index) => ids.indexOf(id) !== index);
     if (duplicateIndex >= 0) {
-      return `Навык «${normalizedSkills[duplicateIndex].id}» указан более одного раза.`;
+      return `Навык «${normalizedDraft[duplicateIndex].id}» указан более одного раза.`;
     }
     return null;
-  }, [normalizedSkills]);
+  }, [normalizedDraft]);
 
   const handleSubmit = async () => {
     if (validationError) {
@@ -156,7 +286,7 @@ const SkillEditorModal: React.FC<SkillEditorModalProps> = ({
     setError(null);
     setIsSubmitting(true);
     try {
-      await Promise.resolve(onSave(normalizedSkills));
+      await Promise.resolve(onSave(normalizedDraft));
     } catch (submitError) {
       if (submitError instanceof Error) {
         setError(submitError.message);
@@ -178,116 +308,226 @@ const SkillEditorModal: React.FC<SkillEditorModalProps> = ({
           </Text>
           <Text size="s" view="secondary">
             {expert.fullName}
-        </Text>
-        <Text size="xs" view="ghost">
-          Управляйте перечнем навыков, уровнями и подтверждением.
-        </Text>
-      </div>
-      <div className={styles.skillList}>
-        {draftSkills.length === 0 ? (
-          <Text size="s" view="secondary">
-            У эксперта пока нет навыков. Добавьте первый навык, чтобы продолжить.
           </Text>
-        ) : (
-          draftSkills.map((skill, index) => {
-            const levelOption = skillLevelOptions.find((option) => option.value === skill.level);
-            const proofOption = proofStatusOptions.find(
-              (option) => option.value === skill.proofStatus
-            );
-            const resolvedName = getSkillNameById(skill.id.trim());
-            return (
-              <div key={`skill-${index}`} className={styles.skillCard}>
-                <div className={styles.skillHeader}>
-                  <TextField
-                    size="s"
-                    label="Идентификатор навыка"
-                    placeholder="Например, data-governance"
-                    value={skill.id}
-                    onChange={(value) => handleSkillChange(index, 'id', value ?? '')}
-                  />
-                  {resolvedName && (
-                    <Text size="xs" className={styles.skillNameHint}>
-                      {resolvedName}
-                    </Text>
-                  )}
-                </div>
-                <div className={styles.skillMeta}>
-                  <Select<SelectOption<SkillLevel>>
-                    size="s"
-                    label="Уровень владения"
-                    items={skillLevelOptions}
-                    value={levelOption ?? skillLevelOptions[0]}
-                    getItemLabel={(item) => item.label}
-                    getItemKey={(item) => item.value}
-                    onChange={(option) =>
-                      option && handleSkillChange(index, 'level', option.value)
-                    }
-                  />
-                  <Select<SelectOption<SkillEvidenceStatus>>
-                    size="s"
-                    label="Статус подтверждения"
-                    items={proofStatusOptions}
-                    value={proofOption ?? proofStatusOptions[0]}
-                    getItemLabel={(item) => item.label}
-                    getItemKey={(item) => item.value}
-                    onChange={(option) =>
-                      option && handleSkillChange(index, 'proofStatus', option.value)
-                    }
-                  />
-                </div>
-                <div className={styles.skillActions}>
-                  <Button
-                    size="xs"
-                    view="ghost"
-                    label="Удалить"
-                    onClick={() => handleRemoveSkill(index)}
-                    disabled={isSubmitting}
-                  />
-                </div>
-              </div>
-            );
-          })
-        )}
-      </div>
-      <Button
-        size="s"
-        view="secondary"
-        label="Добавить навык"
-        className={styles.addButton}
-        onClick={handleAddSkill}
-        disabled={isSubmitting}
-      />
-      <div className={styles.footer}>
-        <div>
-          {(error ?? validationError) && (
-            <Text size="s" view="alert" className={styles.error}>
-              {error ?? validationError}
+          <Text size="xs" view="ghost">
+            Управляйте перечнем навыков, уровнями и подтверждением.
+          </Text>
+        </div>
+        <div className={styles.skillList}>
+          {draftSkills.length === 0 ? (
+            <Text size="s" view="secondary">
+              У эксперта пока нет навыков. Добавьте первый навык, чтобы продолжить.
             </Text>
-          )}
-          {!hasChanges && !error && !validationError && (
-            <Text size="xs" view="secondary">
-              Изменений не обнаружено.
-            </Text>
+          ) : (
+            draftSkills.map((skill, index) => {
+              const levelOption = skillLevelOptions.find((option) => option.value === skill.level);
+              const proofOption = proofStatusOptions.find((option) => option.value === skill.proofStatus);
+              const resolvedName = getSkillNameById(skill.id.trim());
+
+              return (
+                <div key={`skill-${index}`} className={styles.skillCard}>
+                  <div className={styles.skillHeader}>
+                    <TextField
+                      size="s"
+                      label="Идентификатор навыка"
+                      placeholder="Например, data-governance"
+                      value={skill.id}
+                      onChange={(value) => handleSkillChange(index, 'id', value ?? '')}
+                    />
+                    {resolvedName && (
+                      <Text size="xs" className={styles.skillNameHint}>
+                        {resolvedName}
+                      </Text>
+                    )}
+                  </div>
+                  <div className={styles.skillMeta}>
+                    <Select<SelectOption<SkillLevel>>
+                      size="s"
+                      label="Уровень владения"
+                      items={skillLevelOptions}
+                      value={levelOption ?? skillLevelOptions[0]}
+                      getItemLabel={(item) => item.label}
+                      getItemKey={(item) => item.value}
+                      onChange={(option) => option && handleSkillChange(index, 'level', option.value)}
+                    />
+                    <Select<SelectOption<SkillEvidenceStatus>>
+                      size="s"
+                      label="Статус подтверждения"
+                      items={proofStatusOptions}
+                      value={proofOption ?? proofStatusOptions[0]}
+                      getItemLabel={(item) => item.label}
+                      getItemKey={(item) => item.value}
+                      onChange={(option) => option && handleSkillChange(index, 'proofStatus', option.value)}
+                    />
+                  </div>
+                  <div className={styles.evidenceSection}>
+                    <div className={styles.evidenceHeader}>
+                      <Text size="s" weight="semibold">
+                        Подтверждения
+                      </Text>
+                      <Text size="xs" view="secondary">
+                        Зафиксируйте инициативы, где навык наблюдался, подтверждён или опровергнут.
+                      </Text>
+                    </div>
+                    {skill.evidence.length === 0 ? (
+                      <Text size="xs" view="ghost" className={styles.evidenceEmpty}>
+                        Подтверждения ещё не добавлены.
+                      </Text>
+                    ) : (
+                      <div className={styles.evidenceList}>
+                        {skill.evidence.map((evidence, evidenceIndex) => {
+                          const statusOption =
+                            evidenceStatusOptions.find((option) => option.value === evidence.status) ??
+                            evidenceStatusOptions[0];
+                          const initiativeValue = evidence.initiativeId ?? '';
+                          const initiativeOption = initiativeOptions.find(
+                            (option) => option.value === initiativeValue
+                          );
+
+                          return (
+                            <div
+                              key={`skill-${index}-evidence-${evidenceIndex}`}
+                              className={styles.evidenceCard}
+                            >
+                              <div className={styles.evidenceFields}>
+                                <Select<SelectOption<SkillEvidenceStatus>>
+                                  size="s"
+                                  label="Статус"
+                                  items={evidenceStatusOptions}
+                                  value={statusOption}
+                                  getItemLabel={(item) => item.label}
+                                  getItemKey={(item) => item.value}
+                                  onChange={(option) =>
+                                    handleEvidenceChange(index, evidenceIndex, {
+                                      status: option?.value ?? defaultEvidenceStatus
+                                    })
+                                  }
+                                />
+                                <Select<SelectOption<string>>
+                                  size="s"
+                                  label="Инициатива"
+                                  items={initiativeOptions}
+                                  value={initiativeOption ?? initiativeOptions[0]}
+                                  getItemLabel={(item) => item.label}
+                                  getItemKey={(item) => item.value}
+                                  onChange={(option) =>
+                                    handleEvidenceChange(index, evidenceIndex, {
+                                      initiativeId: option?.value ?? ''
+                                    })
+                                  }
+                                />
+                                <TextField
+                                  size="s"
+                                  label="Артефакты (ID через запятую)"
+                                  placeholder="Например, artifact-123, artifact-456"
+                                  value={(evidence.artifactIds ?? []).join(', ')}
+                                  onChange={(value) =>
+                                    handleEvidenceChange(index, evidenceIndex, {
+                                      artifactIds: value
+                                        ? value
+                                            .split(/[\n,]/)
+                                            .map((item) => item.trim())
+                                            .filter((item) => item.length > 0)
+                                        : []
+                                    })
+                                  }
+                                />
+                                <TextField
+                                  size="s"
+                                  label="Комментарий"
+                                  placeholder="Короткое описание подтверждения"
+                                  value={evidence.comment ?? ''}
+                                  onChange={(value) =>
+                                    handleEvidenceChange(index, evidenceIndex, {
+                                      comment: value ?? ''
+                                    })
+                                  }
+                                />
+                              </div>
+                              <div className={styles.evidenceActions}>
+                                <Button
+                                  size="xs"
+                                  view="ghost"
+                                  label="Очистить инициативу"
+                                  onClick={() =>
+                                    handleEvidenceChange(index, evidenceIndex, { initiativeId: '' })
+                                  }
+                                  disabled={isSubmitting}
+                                />
+                                <Button
+                                  size="xs"
+                                  view="ghost"
+                                  label="Удалить подтверждение"
+                                  onClick={() => handleRemoveEvidence(index, evidenceIndex)}
+                                  disabled={isSubmitting}
+                                />
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                    <Button
+                      size="xs"
+                      view="secondary"
+                      label="Добавить подтверждение"
+                      onClick={() => handleAddEvidence(index)}
+                      disabled={isSubmitting}
+                    />
+                  </div>
+                  <div className={styles.skillActions}>
+                    <Button
+                      size="xs"
+                      view="ghost"
+                      label="Удалить навык"
+                      onClick={() => handleRemoveSkill(index)}
+                      disabled={isSubmitting}
+                    />
+                  </div>
+                </div>
+              );
+            })
           )}
         </div>
-        <div className={styles.skillActions}>
-          <Button
-            size="s"
-            view="ghost"
-            label="Отменить"
-            onClick={onClose}
-            disabled={isSubmitting}
-          />
-          <Button
-            size="s"
-            view="primary"
-            label="Сохранить"
-            onClick={handleSubmit}
-            disabled={isSubmitting || (!hasChanges && !validationError)}
-            loading={isSubmitting}
-          />
+        <Button
+          size="s"
+          view="secondary"
+          label="Добавить навык"
+          className={styles.addButton}
+          onClick={handleAddSkill}
+          disabled={isSubmitting}
+        />
+        <div className={styles.footer}>
+          <div>
+            {(error ?? validationError) && (
+              <Text size="s" view="alert" className={styles.error}>
+                {error ?? validationError}
+              </Text>
+            )}
+            {!hasChanges && !error && !validationError && (
+              <Text size="xs" view="secondary">
+                Изменений не обнаружено.
+              </Text>
+            )}
+          </div>
+          <div className={styles.actionsGroup}>
+            <Button
+              size="s"
+              view="ghost"
+              label="Отменить"
+              onClick={onClose}
+              disabled={isSubmitting}
+            />
+            <Button
+              size="s"
+              view="primary"
+              label="Сохранить"
+              onClick={handleSubmit}
+              disabled={isSubmitting || (!hasChanges && !validationError)}
+              loading={isSubmitting}
+            />
+          </div>
         </div>
-      </div>
       </div>
     </Modal>
   );

--- a/src/data.ts
+++ b/src/data.ts
@@ -51,7 +51,19 @@ export type ExpertAvailability = 'available' | 'partial' | 'busy';
 
 export type SkillLevel = 'A' | 'B' | 'C' | 'D' | 'E';
 
-export type SkillEvidenceStatus = 'verified' | 'in-review' | 'self-reported';
+export type SkillEvidenceStatus =
+  | 'claimed'
+  | 'screened'
+  | 'observed'
+  | 'validated'
+  | 'refuted';
+
+export type SkillEvidenceRecord = {
+  status: SkillEvidenceStatus;
+  initiativeId?: string;
+  artifactIds?: string[];
+  comment?: string;
+};
 
 export type SkillInterestLevel = 'high' | 'medium' | 'low';
 
@@ -65,6 +77,7 @@ export type ExpertSkill = {
   id: string;
   level: SkillLevel;
   proofStatus: SkillEvidenceStatus;
+  evidence: SkillEvidenceRecord[];
   usage?: SkillUsage;
   artifacts: string[];
   interest: SkillInterestLevel;
@@ -1558,7 +1571,15 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'data-normalization',
         level: 'A',
-        proofStatus: 'verified',
+        proofStatus: 'validated',
+        evidence: [
+          {
+            status: 'validated',
+            initiativeId: 'initiative-digital-pad',
+            artifactIds: ['artifact-infraplan-source-pack'],
+            comment: 'Пилотирование конвейера нормализации данных для цифровой площадки'
+          }
+        ],
         usage: {
           from: '2023-01-15',
           to: '2024-04-01',
@@ -1571,7 +1592,15 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'streaming-pipelines',
         level: 'B',
-        proofStatus: 'verified',
+        proofStatus: 'validated',
+        evidence: [
+          {
+            status: 'validated',
+            initiativeId: 'initiative-remote-operations',
+            artifactIds: ['artifact-dtwin-telemetry-cube'],
+            comment: 'Потоковые пайплайны телеметрии для ситуационных центров'
+          }
+        ],
         usage: {
           from: '2022-09-01',
           to: '2024-02-20',
@@ -1584,7 +1613,14 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'data-governance',
         level: 'B',
-        proofStatus: 'in-review',
+        proofStatus: 'screened',
+        evidence: [
+          {
+            status: 'screened',
+            initiativeId: 'initiative-digital-pad',
+            comment: 'Структуризация справочников и матрицы владения'
+          }
+        ],
         usage: {
           from: '2023-05-01',
           description: 'Разработка матрицы владения инженерными данными и процессов каталогизации'
@@ -1634,7 +1670,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'layout-optimization',
         level: 'A',
-        proofStatus: 'verified',
+        proofStatus: 'validated',
+        evidence: [],
         usage: {
           from: '2022-02-01',
           to: '2024-03-15',
@@ -1647,7 +1684,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'geo-apis',
         level: 'B',
-        proofStatus: 'self-reported',
+        proofStatus: 'claimed',
+        evidence: [],
         usage: {
           from: '2021-07-01',
           to: '2023-12-10',
@@ -1660,7 +1698,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'infrastructure-economics',
         level: 'C',
-        proofStatus: 'in-review',
+        proofStatus: 'screened',
+        evidence: [],
         usage: {
           from: '2023-06-01',
           description: 'Совместные расчёты экономических эффектов для сценариев размещения'
@@ -1710,7 +1749,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'financial-modeling',
         level: 'A',
-        proofStatus: 'verified',
+        proofStatus: 'validated',
+        evidence: [],
         usage: {
           from: '2022-01-01',
           to: '2024-04-20',
@@ -1723,7 +1763,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'scenario-planning',
         level: 'B',
-        proofStatus: 'verified',
+        proofStatus: 'validated',
+        evidence: [],
         usage: {
           from: '2023-03-01',
           to: '2024-01-30',
@@ -1736,7 +1777,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'ma-support',
         level: 'C',
-        proofStatus: 'in-review',
+        proofStatus: 'screened',
+        evidence: [],
         usage: {
           from: '2022-11-01',
           description: 'Экспертиза сделок по покупке активов в Арктическом регионе'
@@ -1788,7 +1830,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'telemetry-streaming',
         level: 'A',
-        proofStatus: 'verified',
+        proofStatus: 'validated',
+        evidence: [],
         usage: {
           from: '2022-04-01',
           to: '2024-03-01',
@@ -1801,7 +1844,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'iot-integration',
         level: 'B',
-        proofStatus: 'in-review',
+        proofStatus: 'screened',
+        evidence: [],
         usage: {
           from: '2023-02-01',
           description: 'Интеграция промышленного IoT с ситуационными центрами и Digital Twin'
@@ -1813,7 +1857,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'sre-monitoring',
         level: 'B',
-        proofStatus: 'self-reported',
+        proofStatus: 'claimed',
+        evidence: [],
         usage: {
           from: '2021-11-01',
           to: '2023-10-01',
@@ -1865,7 +1910,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'production-ml',
         level: 'A',
-        proofStatus: 'verified',
+        proofStatus: 'validated',
+        evidence: [],
         usage: {
           from: '2022-08-01',
           to: '2024-02-15',
@@ -1878,7 +1924,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'mlops-production',
         level: 'B',
-        proofStatus: 'verified',
+        proofStatus: 'validated',
+        evidence: [],
         usage: {
           from: '2023-01-10',
           to: '2024-03-10',
@@ -1891,7 +1938,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'value-discovery',
         level: 'C',
-        proofStatus: 'in-review',
+        proofStatus: 'screened',
+        evidence: [],
         usage: {
           from: '2023-06-01',
           description: 'Фасилитация discovery-сессий с производством по выбору сценариев'
@@ -1941,7 +1989,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'remote-ops-integration',
         level: 'A',
-        proofStatus: 'verified',
+        proofStatus: 'validated',
+        evidence: [],
         usage: {
           from: '2021-09-01',
           to: '2024-02-28',
@@ -1954,7 +2003,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'remote-ops-security',
         level: 'B',
-        proofStatus: 'in-review',
+        proofStatus: 'screened',
+        evidence: [],
         usage: {
           from: '2022-05-01',
           description: 'Оценка и настройка кибербезопасности дистанционных операций'
@@ -1966,7 +2016,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'change-management',
         level: 'C',
-        proofStatus: 'self-reported',
+        proofStatus: 'claimed',
+        evidence: [],
         usage: {
           from: '2023-04-01',
           to: '2024-01-10',
@@ -2018,7 +2069,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'wwo-planning',
         level: 'A',
-        proofStatus: 'verified',
+        proofStatus: 'validated',
+        evidence: [],
         usage: {
           from: '2021-03-01',
           to: '2024-02-01',
@@ -2031,7 +2083,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'contractor-management',
         level: 'B',
-        proofStatus: 'verified',
+        proofStatus: 'validated',
+        evidence: [],
         usage: {
           from: '2022-05-01',
           to: '2024-03-20',
@@ -2044,7 +2097,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'process-digitization',
         level: 'C',
-        proofStatus: 'in-review',
+        proofStatus: 'screened',
+        evidence: [],
         usage: {
           from: '2023-09-01',
           description: 'Перевод регламентов WWO в цифровые шаблоны'
@@ -2094,7 +2148,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'field-dispatching',
         level: 'A',
-        proofStatus: 'verified',
+        proofStatus: 'validated',
+        evidence: [],
         usage: {
           from: '2022-06-01',
           to: '2024-04-05',
@@ -2107,7 +2162,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'mobile-solutions',
         level: 'B',
-        proofStatus: 'in-review',
+        proofStatus: 'screened',
+        evidence: [],
         usage: {
           from: '2023-01-01',
           description: 'Внедрение мобильных приложений для полевых сотрудников'
@@ -2119,7 +2175,14 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'hse-compliance',
         level: 'C',
-        proofStatus: 'self-reported',
+        proofStatus: 'refuted',
+        evidence: [
+          {
+            status: 'refuted',
+            initiativeId: 'initiative-remote-operations',
+            comment: 'Проверка показала отсутствие практического опыта по HSE'
+          }
+        ],
         usage: {
           from: '2022-09-01',
           to: '2023-12-01',
@@ -2170,7 +2233,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'wwo-analytics',
         level: 'A',
-        proofStatus: 'verified',
+        proofStatus: 'validated',
+        evidence: [],
         usage: {
           from: '2022-03-01',
           to: '2024-03-25',
@@ -2183,7 +2247,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'forecasting',
         level: 'B',
-        proofStatus: 'in-review',
+        proofStatus: 'screened',
+        evidence: [],
         usage: {
           from: '2023-02-01',
           to: '2024-01-15',
@@ -2196,7 +2261,8 @@ export const initiativeNodes: InitiativeNode[] = [
       {
         id: 'data-storytelling',
         level: 'B',
-        proofStatus: 'self-reported',
+        proofStatus: 'claimed',
+        evidence: [],
         usage: {
           from: '2021-10-01',
           description: 'Обучение аналитиков storytelling и презентации данных'

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -7,10 +7,11 @@ export type SkillSource = 'SFIA' | 'IIBA' | 'INCOSE';
 export type SkillLevelId = 'A' | 'W' | 'P' | 'Ad' | 'E';
 
 export type EvidenceStatusId =
-  | 'declared'
+  | 'claimed'
+  | 'screened'
   | 'observed'
-  | 'documented'
-  | 'verified';
+  | 'validated'
+  | 'refuted';
 
 export type SkillLevelDescriptor = {
   id: SkillLevelId;
@@ -86,28 +87,33 @@ export const skillLevels: SkillLevelDescriptor[] = [
 
 export const evidenceStatuses: EvidenceStatusDescriptor[] = [
   {
-    id: 'declared',
-    label: 'Декларировано',
+    id: 'claimed',
+    label: 'Заявлено',
     description:
-      'Навык заявлен специалистом и подтверждён планом развития, но отсутствуют артефакты применения.'
+      'Навык декларирован специалистом, подтверждения применения и артефактов пока отсутствуют.'
+  },
+  {
+    id: 'screened',
+    label: 'Скрининг',
+    description:
+      'Навык прошёл предварительную проверку, требуется наблюдение в инициативе или сбор артефактов.'
   },
   {
     id: 'observed',
     label: 'Наблюдалось',
     description:
-      'Навык проявлялся в работе, наличие подтверждения от руководителя или наставника.'
+      'Навык проявлялся в работе и подтверждён отзывами руководителя, наставника или команды.'
   },
   {
-    id: 'documented',
-    label: 'Задокументировано',
+    id: 'validated',
+    label: 'Подтверждено',
     description:
-      'Существуют артефакты применения навыка: артефакты проектов, инструкции, записи выступлений.'
+      'Навык проверен экспертами и подкреплён артефактами, сертификацией или аудиторским заключением.'
   },
   {
-    id: 'verified',
-    label: 'Верифицировано',
-    description:
-      'Навык проверен внешними или внутренними экспертами, подкреплён сертификацией или аудитом.'
+    id: 'refuted',
+    label: 'Опровергнуто',
+    description: 'Навык был проверен и признан неприменяемым или некорректно заявленным.'
   }
 ];
 
@@ -120,7 +126,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'hard',
     sources: ['IIBA'],
     recommendedLevel: 'P',
-    evidenceStatus: 'documented',
+    evidenceStatus: 'screened',
     roles: ['Аналитик', 'Владелец продукта', 'Руководитель проекта']
   },
   'systems-thinking': {
@@ -142,7 +148,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'hard',
     sources: ['SFIA'],
     recommendedLevel: 'Ad',
-    evidenceStatus: 'verified',
+    evidenceStatus: 'validated',
     roles: ['Архитектор', 'Backend']
   },
   'data-visualization': {
@@ -153,7 +159,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'hard',
     sources: ['SFIA'],
     recommendedLevel: 'W',
-    evidenceStatus: 'documented',
+    evidenceStatus: 'screened',
     roles: ['Аналитик', 'Frontend']
   },
   'user-research': {
@@ -185,7 +191,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'hard',
     sources: ['SFIA'],
     recommendedLevel: 'P',
-    evidenceStatus: 'documented',
+    evidenceStatus: 'screened',
     roles: ['Тестировщик', 'Backend']
   },
   'frontend-engineering': {
@@ -196,7 +202,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'hard',
     sources: ['SFIA'],
     recommendedLevel: 'P',
-    evidenceStatus: 'documented',
+    evidenceStatus: 'screened',
     roles: ['Frontend']
   },
   'knowledge-management': {
@@ -207,7 +213,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'soft',
     sources: ['INCOSE'],
     recommendedLevel: 'W',
-    evidenceStatus: 'declared',
+    evidenceStatus: 'claimed',
     roles: ['Руководитель проекта', 'Эксперт R&D']
   },
   'domain-geology': {
@@ -229,7 +235,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'hard',
     sources: ['SFIA'],
     recommendedLevel: 'P',
-    evidenceStatus: 'documented',
+    evidenceStatus: 'screened',
     roles: ['Аналитик', 'Эксперт R&D']
   },
   'streaming-pipelines': {
@@ -240,7 +246,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'hard',
     sources: ['SFIA'],
     recommendedLevel: 'Ad',
-    evidenceStatus: 'verified',
+    evidenceStatus: 'validated',
     roles: ['Архитектор', 'Backend']
   },
   'data-governance': {
@@ -251,7 +257,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'hard',
     sources: ['SFIA'],
     recommendedLevel: 'P',
-    evidenceStatus: 'documented',
+    evidenceStatus: 'screened',
     roles: ['Аналитик', 'Руководитель проекта']
   },
   'layout-optimization': {
@@ -273,7 +279,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'hard',
     sources: ['SFIA'],
     recommendedLevel: 'P',
-    evidenceStatus: 'documented',
+    evidenceStatus: 'screened',
     roles: ['Backend', 'Архитектор']
   },
   'infrastructure-economics': {
@@ -295,7 +301,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'hard',
     sources: ['IIBA'],
     recommendedLevel: 'P',
-    evidenceStatus: 'documented',
+    evidenceStatus: 'screened',
     roles: ['Аналитик', 'Владелец продукта']
   },
   'scenario-planning': {
@@ -317,7 +323,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'domain',
     sources: ['IIBA'],
     recommendedLevel: 'P',
-    evidenceStatus: 'documented',
+    evidenceStatus: 'screened',
     roles: ['Аналитик', 'Владелец продукта']
   },
   'telemetry-streaming': {
@@ -328,7 +334,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'hard',
     sources: ['SFIA'],
     recommendedLevel: 'Ad',
-    evidenceStatus: 'verified',
+    evidenceStatus: 'validated',
     roles: ['Архитектор', 'Backend']
   },
   'iot-integration': {
@@ -350,7 +356,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'hard',
     sources: ['SFIA'],
     recommendedLevel: 'P',
-    evidenceStatus: 'documented',
+    evidenceStatus: 'screened',
     roles: ['Архитектор', 'Backend']
   },
   'production-ml': {
@@ -361,7 +367,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'hard',
     sources: ['SFIA'],
     recommendedLevel: 'Ad',
-    evidenceStatus: 'verified',
+    evidenceStatus: 'validated',
     roles: ['Эксперт R&D', 'Аналитик']
   },
   'mlops-production': {
@@ -372,7 +378,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'hard',
     sources: ['SFIA'],
     recommendedLevel: 'Ad',
-    evidenceStatus: 'documented',
+    evidenceStatus: 'screened',
     roles: ['Эксперт R&D', 'Backend']
   },
   'value-discovery': {
@@ -449,7 +455,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'hard',
     sources: ['INCOSE'],
     recommendedLevel: 'P',
-    evidenceStatus: 'documented',
+    evidenceStatus: 'screened',
     roles: ['Руководитель проекта', 'Эксперт R&D']
   },
   'data-storytelling': {
@@ -482,7 +488,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'hard',
     sources: ['SFIA'],
     recommendedLevel: 'P',
-    evidenceStatus: 'documented',
+    evidenceStatus: 'screened',
     roles: ['Аналитик', 'Эксперт R&D']
   },
   'mobile-solutions': {
@@ -493,7 +499,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'hard',
     sources: ['SFIA'],
     recommendedLevel: 'P',
-    evidenceStatus: 'documented',
+    evidenceStatus: 'screened',
     roles: ['Frontend', 'Владелец продукта']
   },
   'wwo-analytics': {
@@ -504,7 +510,7 @@ export const skills: Record<string, SkillDefinition> = {
     category: 'hard',
     sources: ['INCOSE'],
     recommendedLevel: 'P',
-    evidenceStatus: 'documented',
+    evidenceStatus: 'screened',
     roles: ['Аналитик', 'Эксперт R&D']
   },
   'hse-compliance': {

--- a/src/services/expertSkills.ts
+++ b/src/services/expertSkills.ts
@@ -4,6 +4,11 @@ import type {
   SkillEvidenceStatus
 } from '../data';
 
+const collectSkillStatuses = (skill: ExpertSkill): SkillEvidenceStatus[] => {
+  const evidenceStatuses = skill.evidence?.map((entry) => entry.status) ?? [];
+  return Array.from(new Set([skill.proofStatus, ...evidenceStatuses]));
+};
+
 /**
  * Возвращает последнюю дату использования навыка.
  * При наличии периода приоритет отдаётся дате окончания, иначе — дате начала.
@@ -57,7 +62,10 @@ export const filterSkillsByEvidenceStatus = (
   const statuses = Array.isArray(status) ? status : [status];
   const uniqueStatuses = new Set(statuses);
 
-  return skills.filter((skill) => uniqueStatuses.has(skill.proofStatus));
+  return skills.filter((skill) => {
+    const skillStatuses = collectSkillStatuses(skill);
+    return skillStatuses.some((item) => uniqueStatuses.has(item));
+  });
 };
 
 /**

--- a/src/services/matching.ts
+++ b/src/services/matching.ts
@@ -1,4 +1,4 @@
-import { type ExpertProfile } from '../data';
+import { type ExpertProfile, type SkillEvidenceStatus } from '../data';
 
 const LEVEL_WEIGHTS = {
   novice: 0.4,
@@ -8,6 +8,14 @@ const LEVEL_WEIGHTS = {
 } as const;
 
 const DEFAULT_FRESHNESS_HALF_LIFE_DAYS = 180;
+
+const STATUS_CONFIDENCE: Record<SkillEvidenceStatus, number> = {
+  claimed: 0.35,
+  screened: 0.55,
+  observed: 0.75,
+  validated: 1,
+  refuted: 0
+};
 
 export type SkillLevel = keyof typeof LEVEL_WEIGHTS;
 
@@ -31,6 +39,8 @@ export type ExpertSkillEvidence = {
   name: string;
   level: SkillLevel;
   lastUsedDaysAgo: number;
+  status: SkillEvidenceStatus;
+  sourceInitiatives: string[];
 };
 
 export type MatchableExpertProfile = ExpertProfile & {
@@ -86,6 +96,36 @@ export type InitiativeMatchReport = {
 };
 
 const LOG_2 = Math.log(2);
+
+function formatInitiativeSuffix(ids: string[]): string {
+  if (ids.length === 0) {
+    return '';
+  }
+  if (ids.length === 1) {
+    return ` (инициатива ${ids[0]})`;
+  }
+  return ` (инициативы: ${ids.join(', ')})`;
+}
+
+function buildStatusGap(
+  skillName: string,
+  status: SkillEvidenceStatus,
+  initiatives: string[]
+): string | null {
+  const suffix = formatInitiativeSuffix(initiatives);
+  switch (status) {
+    case 'claimed':
+      return `Навык «${skillName}» пока только заявлен без подтверждений${suffix}.`;
+    case 'screened':
+      return `Навык «${skillName}» на этапе скрининга${suffix}; требуется наблюдение или проверка.`;
+    case 'observed':
+      return `Навык «${skillName}» подтверждён наблюдениями${suffix}, рекомендуется собрать артефакты.`;
+    case 'refuted':
+      return `Навык «${skillName}» был опровергнут${suffix}.`;
+    default:
+      return null;
+  }
+}
 
 function collectRequirementTargets(requirement: SkillRequirement): string[] {
   const targets = new Set<string>();
@@ -150,7 +190,6 @@ function calculateSkillCoverage(
 ): SkillCoverageReport {
   const evidence = findEvidence(expert, requirement);
   const hasProfileSkill = hasSkillInProfile(expert, requirement);
-  const hasSkill = Boolean(evidence) || hasProfileSkill;
 
   const requiredLevelWeight = requirement.requiredLevel
     ? LEVEL_WEIGHTS[requirement.requiredLevel]
@@ -160,34 +199,57 @@ function calculateSkillCoverage(
   let freshnessFactor = 0;
   const gaps: string[] = [];
 
-  if (!hasSkill) {
-    gaps.push(`Нет подтвержденного навыка «${requirement.name}»`);
-  }
+  let statusConfidence = 0;
+  let effectiveEvidence = evidence ?? undefined;
 
   if (evidence) {
-    const levelWeight = LEVEL_WEIGHTS[evidence.level];
-    levelFactor = Math.min(levelWeight / requiredLevelWeight, 1);
+    statusConfidence = STATUS_CONFIDENCE[evidence.status] ?? 0;
+    const statusGap = buildStatusGap(requirement.name, evidence.status, evidence.sourceInitiatives);
+    if (statusGap) {
+      gaps.push(statusGap);
+    }
+    if (evidence.status === 'refuted') {
+      effectiveEvidence = undefined;
+    }
+  }
+
+  if (!evidence && hasProfileSkill) {
+    statusConfidence = Math.max(statusConfidence, STATUS_CONFIDENCE.claimed);
+    gaps.push(`Навык «${requirement.name}» есть в профиле, но без подтверждения уровня/свежести`);
+  }
+
+  if (!effectiveEvidence && statusConfidence === 0 && !hasProfileSkill) {
+    gaps.push(`Нет подтвержденного навыка «${requirement.name}».`);
+  }
+
+  if (effectiveEvidence) {
+    const levelWeight = LEVEL_WEIGHTS[effectiveEvidence.level];
+    const levelRatio = Math.min(levelWeight / requiredLevelWeight, 1);
     const halfLife = requirement.freshnessHalfLifeDays ?? DEFAULT_FRESHNESS_HALF_LIFE_DAYS;
-    freshnessFactor = calculateFreshnessFactor(evidence.lastUsedDaysAgo, halfLife);
-    if (levelFactor < 1) {
+    const baseFreshness = calculateFreshnessFactor(effectiveEvidence.lastUsedDaysAgo, halfLife);
+
+    levelFactor = levelRatio * statusConfidence;
+    freshnessFactor = baseFreshness * statusConfidence;
+
+    if (levelRatio < 1) {
       gaps.push(
-        `Уровень владения «${requirement.name}» ниже требуемого (${evidence.level} < ${
+        `Уровень владения «${requirement.name}» ниже требуемого (${effectiveEvidence.level} < ${
           requirement.requiredLevel ?? 'expert'
         })`
       );
     }
-    if (freshnessFactor < 0.6) {
+    if (baseFreshness < 0.6) {
       gaps.push(
-        `Навык «${requirement.name}» может быть устаревшим (использовался ${evidence.lastUsedDaysAgo} дней назад)`
+        `Навык «${requirement.name}» может быть устаревшим (использовался ${effectiveEvidence.lastUsedDaysAgo} дней назад)`
       );
     }
-  } else if (hasProfileSkill) {
-    levelFactor = 0.65;
-    freshnessFactor = 0.6;
-    gaps.push(`Навык «${requirement.name}» есть в профиле, но без подтверждения уровня/свежести`);
+  } else if (!effectiveEvidence && statusConfidence > 0) {
+    levelFactor = 0.65 * statusConfidence;
+    freshnessFactor = 0.6 * statusConfidence;
   }
 
-  const coverageScore = requirement.weight * (hasSkill ? 1 : 0);
+  const coverageScore = requirement.weight * Math.min(statusConfidence, 1);
+  const hasSkill = coverageScore > 0;
 
   return {
     skill: requirement,
@@ -195,7 +257,7 @@ function calculateSkillCoverage(
     coverageScore,
     levelFactor,
     freshnessFactor,
-    gaps
+    gaps: Array.from(new Set(gaps))
   };
 }
 

--- a/src/utils/initiativeMatching.test.ts
+++ b/src/utils/initiativeMatching.test.ts
@@ -94,7 +94,15 @@ describe('buildRoleMatchReports', () => {
         {
           id: 'data-normalization',
           level: 'A',
-          proofStatus: 'verified',
+          proofStatus: 'validated',
+          evidence: [
+            {
+              status: 'validated',
+              initiativeId: 'initiative-digital-pad',
+              artifactIds: ['artifact-data-normalization'],
+              comment: 'Подтверждено на проектах инфра-планирования'
+            }
+          ],
           artifacts: [],
           interest: 'high',
           availableFte: 0.5,

--- a/src/utils/initiativeMatching.ts
+++ b/src/utils/initiativeMatching.ts
@@ -14,7 +14,8 @@ import {
   type ExpertProfile,
   type ExpertSkill,
   type InitiativeCandidate,
-  type TeamRole
+  type TeamRole,
+  initiatives as initiativeCatalog
 } from '../data';
 import type { InitiativeRoleWork } from '../data';
 
@@ -27,6 +28,8 @@ const skillLevelMap: Record<ExpertSkill['level'], SkillLevel> = {
   D: 'novice',
   E: 'novice'
 };
+
+const initiativeNameMap = new Map(initiativeCatalog.map((item) => [item.id, item.name]));
 
 const defaultRoleLevel: Partial<Record<TeamRole, SkillLevel>> = {
   Архитектор: 'expert',
@@ -77,11 +80,28 @@ function toSkillEvidence(skill: ExpertSkill): ExpertSkillEvidence {
     ? undefined
     : Math.max(0, Math.round((Date.now() - timestamp) / MS_IN_DAY));
 
+  const initiativeIds = new Set<string>();
+  skill.evidence
+    .filter((entry) => entry.initiativeId)
+    .forEach((entry) => {
+      const trimmed = entry.initiativeId?.trim();
+      if (trimmed) {
+        initiativeIds.add(trimmed);
+      }
+    });
+
+  const initiativeRefs = Array.from(initiativeIds).map((id) => {
+    const name = initiativeNameMap.get(id);
+    return name ? `${name} (${id})` : id;
+  });
+
   return {
     id: skill.id,
     name,
     level: skillLevelMap[skill.level] ?? 'novice',
-    lastUsedDaysAgo: daysAgo ?? 365
+    lastUsedDaysAgo: daysAgo ?? 365,
+    status: skill.proofStatus,
+    sourceInitiatives: initiativeRefs
   };
 }
 


### PR DESCRIPTION
## Summary
- extend the skill data model with the full claimed/screened/observed/validated/refuted lifecycle and structured evidence records linked to initiatives and artifacts
- update the skill catalog, expert sample data, and editor UI to capture initiative-based confirmations and comments for each skill
- adjust evidence filtering, matching logic, and related tests to weight the new statuses and surface initiative context in match gaps

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6903f012a11883328d1454e060158e31