### PR TITLE
Expand initiative planner layout and rebalance gantt grid

### DIFF
--- a/src/components/InitiativeCreationModal.module.css
+++ b/src/components/InitiativeCreationModal.module.css
@@ -178,8 +178,8 @@
 
 .assignmentGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
 }
 
 .assignmentCard {
@@ -190,6 +190,7 @@
   border-radius: 12px;
   padding: 12px;
   background: var(--color-bg-secondary);
+  min-width: 0;
 }
 
 .assignmentRow {

--- a/src/components/InitiativeGanttChart.module.css
+++ b/src/components/InitiativeGanttChart.module.css
@@ -9,13 +9,13 @@
 .gridLayout {
   display: grid;
   grid-template-columns:
-    minmax(160px, 2fr)
-    minmax(72px, 0.7fr)
-    minmax(72px, 0.7fr)
-    minmax(64px, 0.6fr)
-    minmax(110px, 1fr)
-    minmax(130px, 1.2fr)
-    minmax(420px, 3.5fr);
+    minmax(180px, 2.2fr)
+    minmax(52px, 0.5fr)
+    minmax(56px, 0.5fr)
+    minmax(52px, 0.45fr)
+    minmax(92px, 0.8fr)
+    minmax(120px, 1fr)
+    minmax(480px, 4.5fr);
   gap: 12px;
   align-items: stretch;
 }
@@ -223,24 +223,24 @@
 @media (max-width: 1280px) {
   .row {
     grid-template-columns:
-      minmax(150px, 2fr)
-      minmax(64px, 0.7fr)
-      minmax(64px, 0.7fr)
-      minmax(56px, 0.6fr)
-      minmax(96px, 0.9fr)
-      minmax(110px, 1fr)
-      minmax(320px, 3fr);
+      minmax(160px, 2.1fr)
+      minmax(48px, 0.5fr)
+      minmax(52px, 0.5fr)
+      minmax(48px, 0.45fr)
+      minmax(84px, 0.8fr)
+      minmax(104px, 0.9fr)
+      minmax(360px, 3.5fr);
   }
 
   .headerRow {
     grid-template-columns:
-      minmax(150px, 2fr)
-      minmax(64px, 0.7fr)
-      minmax(64px, 0.7fr)
-      minmax(56px, 0.6fr)
-      minmax(96px, 0.9fr)
-      minmax(110px, 1fr)
-      minmax(320px, 3fr);
+      minmax(160px, 2.1fr)
+      minmax(48px, 0.5fr)
+      minmax(52px, 0.5fr)
+      minmax(48px, 0.45fr)
+      minmax(84px, 0.8fr)
+      minmax(104px, 0.9fr)
+      minmax(360px, 3.5fr);
   }
 }
 

--- a/src/components/InitiativePlanner.module.css
+++ b/src/components/InitiativePlanner.module.css
@@ -6,6 +6,9 @@
   height: 100%;
   box-sizing: border-box;
   overflow: auto;
+  flex: 1 1 auto;
+  min-width: 0;
+  width: 100%;
 }
 
 .header {
@@ -57,9 +60,10 @@
 
 .contentGrid {
   display: grid;
-  grid-template-columns: minmax(200px, 240px) minmax(0, 1fr);
-  gap: 20px;
+  grid-template-columns: minmax(360px, 540px) minmax(0, 1fr);
+  gap: 24px;
   align-items: start;
+  width: 100%;
 }
 
 .emptyState {
@@ -106,6 +110,7 @@
 .rolesSection {
   display: grid;
   gap: 16px;
+  min-width: 0;
 }
 
 .sideColumn {
@@ -113,6 +118,7 @@
   flex-direction: column;
   gap: 16px;
   min-height: 0;
+  min-width: 0;
 }
 
 .timelineCard {
@@ -139,7 +145,7 @@
 
 @media (max-width: 1200px) {
   .contentGrid {
-    grid-template-columns: minmax(180px, 220px) minmax(0, 1fr);
+    grid-template-columns: minmax(320px, 420px) minmax(0, 1fr);
     gap: 20px;
   }
 }


### PR DESCRIPTION
## Summary
- stretch the initiative planner surface to occupy the full viewport width and keep the gantt column dominant
- shrink gantt metadata columns (parallelism, units, priority, role, resource) so the timeline gains horizontal room
- widen initiative creation assignment cards to give skill descriptions more readable space

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69047f2b45408332b6db091845aed83a