### PR TITLE
feat: render graphs in 3d

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-force-graph": "1.44.2",
-        "react-force-graph-2d": "^1.29.0",
+        "react-force-graph-2d": "1.29.0",
+        "react-force-graph-3d": "1.29.0",
         "sql.js": "1.11.0"
       },
       "devDependencies": {
@@ -7014,6 +7015,23 @@
       "license": "MIT",
       "dependencies": {
         "force-graph": "^1.51",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/react-force-graph-3d": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/react-force-graph-3d/-/react-force-graph-3d-1.29.0.tgz",
+      "integrity": "sha512-YCD4W+SA9oeK7mMXZ9pXAGSbDZ3+6IYxv8nPZcqqYeiP1nqZIB/cbMveD3S2bH9EqsGrUMW5qFXjAm5topSblw==",
+      "license": "MIT",
+      "dependencies": {
+        "3d-force-graph": "^1.79",
         "prop-types": "15",
         "react-kapsule": "^2.5"
       },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-force-graph": "1.44.2",
-    "react-force-graph-2d": "^1.29.0",
+    "react-force-graph-2d": "1.29.0",
+    "react-force-graph-3d": "1.29.0",
     "sql.js": "1.11.0"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3910,7 +3910,7 @@ function normalizeLayoutPositions(
       return;
     }
 
-    const { x, y, fx, fy } = position;
+    const { x, y, z, fx, fy, fz } = position;
     if (typeof x !== 'number' || !Number.isFinite(x) || typeof y !== 'number' || !Number.isFinite(y)) {
       normalized[id] = position;
       return;
@@ -3919,6 +3919,10 @@ function normalizeLayoutPositions(
     const normalizedX = roundCoordinate(centerX + (x - centerX) * scale);
     const normalizedY = roundCoordinate(centerY + (y - centerY) * scale);
     const next: GraphLayoutNodePosition = { x: normalizedX, y: normalizedY };
+
+    if (typeof z === 'number' && Number.isFinite(z)) {
+      next.z = roundCoordinate(z);
+    }
 
     if (typeof fx === 'number' && Number.isFinite(fx)) {
       const normalizedFx = roundCoordinate(centerX + (fx - centerX) * scale);
@@ -3932,6 +3936,14 @@ function normalizeLayoutPositions(
       const normalizedFy = roundCoordinate(centerY + (fy - centerY) * scale);
       next.fy = normalizedFy;
       if (normalizedFy !== fy) {
+        changed = true;
+      }
+    }
+
+    if (typeof fz === 'number' && Number.isFinite(fz)) {
+      const normalizedFz = roundCoordinate(fz);
+      next.fz = normalizedFz;
+      if (normalizedFz !== fz) {
         changed = true;
       }
     }
@@ -4034,6 +4046,12 @@ function layoutPositionsEqual(
     return false;
   }
 
+  const prevZ = prev.z ?? null;
+  const nextZ = next.z ?? null;
+  if (prevZ !== nextZ) {
+    return false;
+  }
+
   const prevFx = prev.fx ?? null;
   const nextFx = next.fx ?? null;
   if (prevFx !== nextFx) {
@@ -4042,7 +4060,13 @@ function layoutPositionsEqual(
 
   const prevFy = prev.fy ?? null;
   const nextFy = next.fy ?? null;
-  return prevFy === nextFy;
+  if (prevFy !== nextFy) {
+    return false;
+  }
+
+  const prevFz = prev.fz ?? null;
+  const nextFz = next.fz ?? null;
+  return prevFz === nextFz;
 }
 
 function resolveInitialModulePosition(

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -384,6 +384,33 @@ const GraphView: React.FC<GraphViewProps> = ({
   }, [graphData]);
 
   useEffect(() => {
+    const graph = graphRef.current;
+    if (!graph) {
+      return;
+    }
+
+    const renderer = graph.renderer?.();
+    const scene = graph.scene?.();
+    const camera = graph.camera?.();
+    const controls = graph.controls?.();
+
+    if (!renderer || !scene || !camera) {
+      return;
+    }
+
+    const renderFrame = () => {
+      controls?.update?.();
+      renderer.render(scene, camera);
+    };
+
+    renderer.setAnimationLoop(renderFrame);
+
+    return () => {
+      renderer.setAnimationLoop(null);
+    };
+  }, [graphData, dimensions.width, dimensions.height]);
+
+  useEffect(() => {
     if (!graphRef.current) {
       return;
     }
@@ -1047,6 +1074,7 @@ const GraphView: React.FC<GraphViewProps> = ({
           ref={graphRef}
           width={dimensions.width || 600}
           height={dimensions.height || 400}
+          backgroundColor="rgba(0, 0, 0, 0)"
           graphData={graphData}
           nodeLabel={(node: ForceNode) => node.name ?? node.id}
           linkColor={(link: ForceLink) =>

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -964,9 +964,6 @@ const GraphView: React.FC<GraphViewProps> = ({
     (node: ForceNode) => {
       if (node && typeof node.id === 'string') {
         const layout = layoutPositions[node.id];
-        const hasFixedX = typeof layout?.fx === 'number' && Number.isFinite(layout.fx);
-        const hasFixedY = typeof layout?.fy === 'number' && Number.isFinite(layout.fy);
-        const hasFixedZ = typeof layout?.fz === 'number' && Number.isFinite(layout.fz);
 
         const resolvedX = resolveCoordinate(
           node.x,
@@ -989,7 +986,7 @@ const GraphView: React.FC<GraphViewProps> = ({
 
         if (resolvedX !== null) {
           node.x = resolvedX;
-          node.fx = hasFixedX ? resolvedX : undefined;
+          node.fx = resolvedX;
         } else {
           node.fx = undefined;
           if (layout?.x !== undefined) {
@@ -999,7 +996,7 @@ const GraphView: React.FC<GraphViewProps> = ({
 
         if (resolvedY !== null) {
           node.y = resolvedY;
-          node.fy = hasFixedY ? resolvedY : undefined;
+          node.fy = resolvedY;
         } else {
           node.fy = undefined;
           if (layout?.y !== undefined) {
@@ -1009,11 +1006,13 @@ const GraphView: React.FC<GraphViewProps> = ({
 
         if (resolvedZ !== null) {
           node.z = resolvedZ;
-          node.fz = hasFixedZ ? resolvedZ : undefined;
+          node.fz = resolvedZ;
         } else {
           node.fz = undefined;
           if (layout?.z !== undefined) {
             node.z = layout.z;
+          } else {
+            ensureDefaultDepth(node);
           }
         }
 
@@ -1103,15 +1102,19 @@ function applyLayoutPosition(
   layoutPositions: Record<string, GraphLayoutNodePosition>
 ) {
   const layout = layoutPositions[node.id];
+
   if (!layout) {
+    ensureDefaultDepth(node);
     return;
   }
 
   node.x = layout.x;
   node.y = layout.y;
 
-  if (typeof layout.z === 'number') {
+  if (typeof layout.z === 'number' && Number.isFinite(layout.z)) {
     node.z = layout.z;
+  } else {
+    ensureDefaultDepth(node);
   }
 
   if (typeof layout.fx === 'number') {
@@ -1131,6 +1134,53 @@ function applyLayoutPosition(
   } else if (node.fz !== undefined) {
     node.fz = undefined;
   }
+}
+
+function ensureDefaultDepth(node: ForceNode): void {
+  if (typeof node.z === 'number' && Number.isFinite(node.z)) {
+    return;
+  }
+
+  node.z = resolveDefaultDepth(node);
+}
+
+function resolveDefaultDepth(node: ForceNode): number {
+  const baseSpacing = 180;
+  let layerIndex: number;
+
+  switch (node.type) {
+    case 'initiative':
+      layerIndex = 2;
+      break;
+    case 'domain':
+      layerIndex = 1;
+      break;
+    case 'module':
+      layerIndex = 0;
+      break;
+    case 'artifact':
+    default:
+      layerIndex = -1;
+      break;
+  }
+
+  const jitter = computeStableJitter(node.id, 14) * 6;
+  return layerIndex * baseSpacing + jitter;
+}
+
+function computeStableJitter(id: string, span: number): number {
+  let hash = 0;
+
+  for (let index = 0; index < id.length; index += 1) {
+    hash = (hash * 31 + id.charCodeAt(index)) % 2147483647;
+  }
+
+  if (!Number.isFinite(hash)) {
+    return 0;
+  }
+
+  const normalized = hash % span;
+  return normalized - span / 2;
 }
 
 function roundCoordinate(value: number): number {

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -3,11 +3,12 @@ import { Loader } from '@consta/uikit/Loader';
 import { useTheme } from '@consta/uikit/Theme';
 import { forceCollide } from 'd3-force-3d';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import ForceGraph2D, {
+import ForceGraph3D, {
   ForceGraphMethods,
   LinkObject,
   NodeObject
-} from 'react-force-graph-2d';
+} from 'react-force-graph-3d';
+import { CanvasTexture, LinearFilter, Sprite, SpriteMaterial, Vector3 } from 'three';
 import type {
   ArtifactNode,
   DomainNode,
@@ -20,6 +21,15 @@ import type { GraphLayoutNodePosition } from '../types/graph';
 import styles from './GraphView.module.css';
 
 const CAMERA_STORAGE_KEY = 'graph-view:camera-main';
+
+type NodeSpriteData = {
+  canvas: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D;
+  texture: CanvasTexture;
+  sprite: Sprite;
+  pixelRatio: number;
+  size: number;
+};
 
 type GraphNode =
   | ({ type: 'module' } & ModuleNode)
@@ -47,12 +57,32 @@ type GraphViewProps = {
   ) => void;
 };
 
-type ForceNode = NodeObject & GraphNode;
+type ForceNode = (NodeObject & GraphNode) & { __spriteData?: NodeSpriteData };
 type ForceLink = LinkObject & GraphLink;
 
 type CameraState = {
-  center: { x: number; y: number };
-  zoom: number;
+  position: { x: number; y: number; z: number };
+  target: { x: number; y: number; z: number };
+};
+
+type ForceGraph3DMethods = ForceGraphMethods & {
+  cameraPosition?: (
+    position?: Partial<{ x: number; y: number; z: number }>,
+    lookAt?: { x: number; y: number; z: number },
+    transitionMs?: number
+  ) => unknown;
+  camera?: () => { position: Vector3 };
+  controls?: () => {
+    target: Vector3;
+    addEventListener?: (type: string, listener: () => void) => void;
+    removeEventListener?: (type: string, listener: () => void) => void;
+  };
+  graph2ScreenCoords?: (x: number, y: number, z?: number) => { x: number; y: number };
+  screen2GraphCoords?: (
+    x: number,
+    y: number,
+    distance?: number
+  ) => { x: number; y: number; z: number } | undefined;
 };
 
 function readStoredCameraState(): CameraState | null {
@@ -70,22 +100,33 @@ function readStoredCameraState(): CameraState | null {
     if (
       parsed &&
       typeof parsed === 'object' &&
-      'zoom' in parsed &&
-      'center' in parsed &&
-      parsed.center &&
-      typeof (parsed as { zoom: unknown }).zoom === 'number' &&
-      Number.isFinite((parsed as { zoom: number }).zoom) &&
-      (parsed as { zoom: number }).zoom > 0 &&
-      typeof (parsed as { center: { x: unknown } }).center.x === 'number' &&
-      Number.isFinite((parsed as { center: { x: number } }).center.x) &&
-      typeof (parsed as { center: { y: unknown } }).center.y === 'number' &&
-      Number.isFinite((parsed as { center: { y: number } }).center.y)
+      'position' in parsed &&
+      'target' in parsed &&
+      parsed.position &&
+      parsed.target &&
+      typeof (parsed as { position: { x: unknown } }).position.x === 'number' &&
+      Number.isFinite((parsed as { position: { x: number } }).position.x) &&
+      typeof (parsed as { position: { y: unknown } }).position.y === 'number' &&
+      Number.isFinite((parsed as { position: { y: number } }).position.y) &&
+      typeof (parsed as { position: { z: unknown } }).position.z === 'number' &&
+      Number.isFinite((parsed as { position: { z: number } }).position.z) &&
+      typeof (parsed as { target: { x: unknown } }).target.x === 'number' &&
+      Number.isFinite((parsed as { target: { x: number } }).target.x) &&
+      typeof (parsed as { target: { y: unknown } }).target.y === 'number' &&
+      Number.isFinite((parsed as { target: { y: number } }).target.y) &&
+      typeof (parsed as { target: { z: unknown } }).target.z === 'number' &&
+      Number.isFinite((parsed as { target: { z: number } }).target.z)
     ) {
       return {
-        zoom: (parsed as { zoom: number }).zoom,
-        center: {
-          x: (parsed as { center: { x: number } }).center.x,
-          y: (parsed as { center: { y: number } }).center.y
+        position: {
+          x: (parsed as { position: { x: number } }).position.x,
+          y: (parsed as { position: { y: number } }).position.y,
+          z: (parsed as { position: { z: number } }).position.z
+        },
+        target: {
+          x: (parsed as { target: { x: number } }).target.x,
+          y: (parsed as { target: { y: number } }).target.y,
+          z: (parsed as { target: { z: number } }).target.z
         }
       };
     }
@@ -132,7 +173,7 @@ const GraphView: React.FC<GraphViewProps> = ({
 
   const palette = useMemo(() => resolvePalette(themeClassName), [themeClassName]);
   const initialCameraState = useMemo(() => readStoredCameraState(), []);
-  const graphRef = useRef<ForceGraphMethods | null>(null);
+  const graphRef = useRef<ForceGraph3DMethods | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const nodeCacheRef = useRef<Map<string, ForceNode>>(new Map());
   const lastReportedLayoutRef = useRef<string>('');
@@ -337,7 +378,7 @@ const GraphView: React.FC<GraphViewProps> = ({
 
   useEffect(() => {
     if (import.meta.env.DEV && typeof window !== 'undefined' && graphRef.current) {
-      (window as typeof window & { __forceGraphRef?: ForceGraphMethods }).__forceGraphRef =
+      (window as typeof window & { __forceGraphRef?: ForceGraph3DMethods }).__forceGraphRef =
         graphRef.current;
     }
   }, [graphData]);
@@ -347,7 +388,7 @@ const GraphView: React.FC<GraphViewProps> = ({
       return;
     }
 
-    const reheat = (graphRef.current as ForceGraphMethods & {
+    const reheat = (graphRef.current as ForceGraph3DMethods & {
       d3ReheatSimulation?: () => void;
     }).d3ReheatSimulation;
 
@@ -365,34 +406,28 @@ const GraphView: React.FC<GraphViewProps> = ({
   }, []);
 
   const captureCameraState = useCallback(() => {
-    const { width, height } = getViewportSize();
-    if (!graphRef.current || width <= 0 || height <= 0) {
+    if (!graphRef.current) {
       return;
     }
 
     const graph = graphRef.current;
-    const zoomValue = typeof graph.zoom === 'function' ? (graph.zoom() as number) : undefined;
+    const camera = graph.camera?.();
+    const controls = graph.controls?.();
 
-    if (!Number.isFinite(zoomValue) || !zoomValue || zoomValue <= 0) {
+    if (!camera || !controls) {
       return;
     }
 
-    const center = graph.screen2GraphCoords?.(width / 2, height / 2);
-    if (
-      center &&
-      typeof center.x === 'number' &&
-      Number.isFinite(center.x) &&
-      typeof center.y === 'number' &&
-      Number.isFinite(center.y)
-    ) {
-      const nextState: CameraState = {
-        center: { x: center.x, y: center.y },
-        zoom: zoomValue
-      };
-      cameraStateRef.current = nextState;
-      writeStoredCameraState(nextState);
-    }
-  }, [getViewportSize]);
+    const position = camera.position;
+    const target = controls.target;
+
+    const nextState: CameraState = {
+      position: { x: position.x, y: position.y, z: position.z },
+      target: { x: target.x, y: target.y, z: target.z }
+    };
+    cameraStateRef.current = nextState;
+    writeStoredCameraState(nextState);
+  }, []);
 
   const scheduleCameraCapture = useCallback(
     (delay = 0) => {
@@ -420,30 +455,48 @@ const GraphView: React.FC<GraphViewProps> = ({
   );
 
   const restoreCamera = useCallback(() => {
-    const { width, height } = getViewportSize();
-    if (!graphRef.current || width <= 0 || height <= 0) {
+    if (!graphRef.current) {
       return;
     }
 
     const graph = graphRef.current;
     const saved = cameraStateRef.current;
 
-    if (saved) {
-      if (typeof graph.zoom === 'function') {
-        graph.zoom(saved.zoom, 220);
-      }
-      graph.centerAt(saved.center.x, saved.center.y, 220);
+    if (saved && typeof graph.cameraPosition === 'function') {
+      graph.cameraPosition(saved.position, saved.target, 220);
       scheduleCameraCapture(260);
       return;
     }
 
-    graph.zoomToFit?.(240, 60);
+    graph.zoomToFit?.(260, 80);
     scheduleCameraCapture(320);
-  }, [getViewportSize, scheduleCameraCapture]);
+  }, [scheduleCameraCapture]);
 
   useEffect(() => {
     restoreCamera();
   }, [graphData, restoreCamera]);
+
+  useEffect(() => {
+    const graph = graphRef.current;
+    if (!graph) {
+      return;
+    }
+
+    const controls = graph.controls?.();
+    if (!controls || typeof controls.addEventListener !== 'function') {
+      return;
+    }
+
+    const handleChange = () => {
+      scheduleCameraCapture(160);
+    };
+
+    controls.addEventListener('change', handleChange);
+
+    return () => {
+      controls.removeEventListener?.('change', handleChange);
+    };
+  }, [graphData, scheduleCameraCapture]);
 
   useEffect(() => {
     if (!normalizationRequest || nodes.length === 0) {
@@ -457,7 +510,7 @@ const GraphView: React.FC<GraphViewProps> = ({
       return;
     }
 
-    const reheat = (graph as ForceGraphMethods & { d3ReheatSimulation?: () => void }).d3ReheatSimulation;
+    const reheat = (graph as ForceGraph3DMethods & { d3ReheatSimulation?: () => void }).d3ReheatSimulation;
     if (typeof reheat === 'function') {
       reheat();
     }
@@ -569,6 +622,52 @@ const GraphView: React.FC<GraphViewProps> = ({
     configureSimulation();
   }, [configureSimulation]);
 
+  const nodeThreeObject = useCallback(
+    (node: ForceNode) => {
+      const existing = node.__spriteData;
+      if (!existing) {
+        const data = createNodeSpriteData(
+          node,
+          highlightedNode,
+          palette,
+          visibleDomainIds,
+          visibleModuleStatuses
+        );
+        node.__spriteData = data;
+        return data.sprite;
+      }
+
+      refreshNodeSpriteData(
+        node,
+        existing,
+        highlightedNode,
+        palette,
+        visibleDomainIds,
+        visibleModuleStatuses
+      );
+      return existing.sprite;
+    },
+    [highlightedNode, palette, visibleDomainIds, visibleModuleStatuses]
+  );
+
+  useEffect(() => {
+    nodeCacheRef.current.forEach((node) => {
+      const data = node.__spriteData;
+      if (!data) {
+        return;
+      }
+      refreshNodeSpriteData(
+        node,
+        data,
+        highlightedNode,
+        palette,
+        visibleDomainIds,
+        visibleModuleStatuses
+      );
+    });
+    graphRef.current?.refresh?.();
+  }, [highlightedNode, palette, visibleDomainIds, visibleModuleStatuses]);
+
   useEffect(() => {
     if (!highlightedNode) {
       setIsFocusedView(false);
@@ -591,7 +690,18 @@ const GraphView: React.FC<GraphViewProps> = ({
     }
 
     const graph = graphRef.current;
-    const screenCoords = graph.graph2ScreenCoords?.(target.x, target.y);
+    const camera = graph.camera?.();
+    const controls = graph.controls?.();
+
+    if (!camera || !controls) {
+      return;
+    }
+
+    const screenCoords = graph.graph2ScreenCoords?.(
+      target.x,
+      target.y,
+      typeof target.z === 'number' ? target.z : 0
+    );
     if (!screenCoords) {
       return;
     }
@@ -603,17 +713,36 @@ const GraphView: React.FC<GraphViewProps> = ({
       screenCoords.y < margin ||
       screenCoords.y > height - margin;
 
-    if (needsPan) {
-      graph.centerAt(target.x, target.y, 400);
-      const zoomValue =
-        typeof graph.zoom === 'function' ? (graph.zoom() as number) : cameraStateRef.current?.zoom ?? 1;
+    if (needsPan && typeof graph.cameraPosition === 'function') {
+      const currentTarget = controls.target;
+      const currentPosition = camera.position;
+      const directionVector = new Vector3(
+        currentPosition.x - currentTarget.x,
+        currentPosition.y - currentTarget.y,
+        currentPosition.z - currentTarget.z
+      );
+      const distance = directionVector.length() || 320;
+      const direction = directionVector.length() > 0 ? directionVector.normalize() : new Vector3(0, 0, 1);
+      const targetVector = new Vector3(
+        target.x,
+        target.y,
+        typeof target.z === 'number' ? target.z : 0
+      );
+      const nextPosition = targetVector.clone().add(direction.multiplyScalar(distance));
+
+      graph.cameraPosition(
+        { x: nextPosition.x, y: nextPosition.y, z: nextPosition.z },
+        { x: targetVector.x, y: targetVector.y, z: targetVector.z },
+        420
+      );
+
       const nextState: CameraState = {
-        center: { x: target.x, y: target.y },
-        zoom: zoomValue
+        position: { x: nextPosition.x, y: nextPosition.y, z: nextPosition.z },
+        target: { x: targetVector.x, y: targetVector.y, z: targetVector.z }
       };
       cameraStateRef.current = nextState;
       writeStoredCameraState(nextState);
-      scheduleCameraCapture(420);
+      scheduleCameraCapture(480);
     }
   }, [getViewportSize, highlightedNode, scheduleCameraCapture]);
 
@@ -624,23 +753,52 @@ const GraphView: React.FC<GraphViewProps> = ({
       }
 
       const graph = graphRef.current;
-      const label = node.name ?? node.id;
-      const viewport = getViewportSize();
-      const targetZoom = computeFocusZoom(viewport, label);
-
-      if (typeof graph.zoom === 'function') {
-        graph.zoom(targetZoom, 400);
+      if (typeof graph.cameraPosition !== 'function') {
+        return false;
       }
-      graph.centerAt(node.x, node.y, 400);
+
+      const camera = graph.camera?.();
+      const controls = graph.controls?.();
+
+      if (!camera || !controls) {
+        return false;
+      }
+
+      const currentTarget = controls.target;
+      const currentPosition = camera.position;
+      const directionVector = new Vector3(
+        currentPosition.x - currentTarget.x,
+        currentPosition.y - currentTarget.y,
+        currentPosition.z - currentTarget.z
+      );
+      const currentDistance = directionVector.length() || 320;
+      const direction = directionVector.length() > 0 ? directionVector.normalize() : new Vector3(0, 0, 1);
+
+      const viewport = getViewportSize();
+      const label = node.name ?? node.id;
+      const desiredDistance = computeFocusDistance(viewport, label, currentDistance);
+
+      const targetVector = new Vector3(
+        node.x,
+        node.y,
+        typeof node.z === 'number' ? node.z : 0
+      );
+      const nextPosition = targetVector.clone().add(direction.multiplyScalar(desiredDistance));
+
+      graph.cameraPosition(
+        { x: nextPosition.x, y: nextPosition.y, z: nextPosition.z },
+        { x: targetVector.x, y: targetVector.y, z: targetVector.z },
+        420
+      );
 
       const nextState: CameraState = {
-        center: { x: node.x, y: node.y },
-        zoom: targetZoom
+        position: { x: nextPosition.x, y: nextPosition.y, z: nextPosition.z },
+        target: { x: targetVector.x, y: targetVector.y, z: targetVector.z }
       };
       cameraStateRef.current = nextState;
       writeStoredCameraState(nextState);
       lastFocusedNodeRef.current = node.id;
-      scheduleCameraCapture(420);
+      scheduleCameraCapture(480);
       return true;
     },
     [getViewportSize, scheduleCameraCapture]
@@ -725,35 +883,6 @@ const GraphView: React.FC<GraphViewProps> = ({
     showEntireGraph();
   }, [showEntireGraph]);
 
-  const handleZoomTransform = useCallback(
-    (transform?: { k: number; x: number; y: number }) => {
-      const { width, height } = getViewportSize();
-      if (!transform || width <= 0 || height <= 0) {
-        return;
-      }
-
-      const { k, x, y } = transform;
-      if (!Number.isFinite(k) || k <= 0) {
-        return;
-      }
-
-      const nextState: CameraState = {
-        center: {
-          x: (width / 2 - x) / k,
-          y: (height / 2 - y) / k
-        },
-        zoom: k
-      };
-      cameraStateRef.current = nextState;
-      writeStoredCameraState(nextState);
-    },
-    [getViewportSize]
-  );
-
-  const handleZoomEnd = useCallback(() => {
-    scheduleCameraCapture(0);
-  }, [scheduleCameraCapture]);
-
   const emitLayoutUpdate = useCallback(
     (reason: LayoutChangeReason) => {
       if (!onLayoutChange) {
@@ -776,12 +905,20 @@ const GraphView: React.FC<GraphViewProps> = ({
         y: roundCoordinate(node.y)
       };
 
+      if (typeof node.z === 'number' && !Number.isNaN(node.z)) {
+        payload.z = roundCoordinate(node.z);
+      }
+
       if (typeof node.fx === 'number' && !Number.isNaN(node.fx)) {
         payload.fx = roundCoordinate(node.fx);
       }
 
       if (typeof node.fy === 'number' && !Number.isNaN(node.fy)) {
         payload.fy = roundCoordinate(node.fy);
+      }
+
+      if (typeof node.fz === 'number' && !Number.isNaN(node.fz)) {
+        payload.fz = roundCoordinate(node.fz);
       }
 
       entries.push([id, payload]);
@@ -802,6 +939,7 @@ const GraphView: React.FC<GraphViewProps> = ({
         const layout = layoutPositions[node.id];
         const hasFixedX = typeof layout?.fx === 'number' && Number.isFinite(layout.fx);
         const hasFixedY = typeof layout?.fy === 'number' && Number.isFinite(layout.fy);
+        const hasFixedZ = typeof layout?.fz === 'number' && Number.isFinite(layout.fz);
 
         const resolvedX = resolveCoordinate(
           node.x,
@@ -814,6 +952,12 @@ const GraphView: React.FC<GraphViewProps> = ({
           node.fy,
           layout?.y ?? null,
           layout?.fy ?? null
+        );
+        const resolvedZ = resolveCoordinate(
+          node.z,
+          node.fz,
+          layout?.z ?? null,
+          layout?.fz ?? null
         );
 
         if (resolvedX !== null) {
@@ -836,11 +980,24 @@ const GraphView: React.FC<GraphViewProps> = ({
           }
         }
 
+        if (resolvedZ !== null) {
+          node.z = resolvedZ;
+          node.fz = hasFixedZ ? resolvedZ : undefined;
+        } else {
+          node.fz = undefined;
+          if (layout?.z !== undefined) {
+            node.z = layout.z;
+          }
+        }
+
         if (typeof node.vx === 'number') {
           node.vx = 0;
         }
         if (typeof node.vy === 'number') {
           node.vy = 0;
+        }
+        if (typeof node.vz === 'number') {
+          node.vz = 0;
         }
 
         nodeCacheRef.current.set(node.id, node);
@@ -886,7 +1043,7 @@ const GraphView: React.FC<GraphViewProps> = ({
         </div>
       ) : null}
       <React.Suspense fallback={<Loader size="m" />}>
-        <ForceGraph2D
+        <ForceGraph3D
           ref={graphRef}
           width={dimensions.width || 600}
           height={dimensions.height || 400}
@@ -895,18 +1052,8 @@ const GraphView: React.FC<GraphViewProps> = ({
           linkColor={(link: ForceLink) =>
             resolveLinkColor(link, palette, visibleDomainIds, visibleModuleStatuses, moduleStatusMap)
           }
-          nodeCanvasObject={(node: ForceNode, ctx, globalScale) => {
-            drawNode(
-              node,
-              ctx,
-              globalScale,
-              highlightedNode,
-              palette,
-              visibleDomainIds,
-              visibleModuleStatuses
-            );
-          }}
-          nodeCanvasObjectMode={() => 'replace'}
+          nodeThreeObject={(node) => nodeThreeObject(node as ForceNode)}
+          nodeThreeObjectExtend
           onNodeClick={(node) => {
             onSelect(node as ForceNode);
           }}
@@ -915,8 +1062,8 @@ const GraphView: React.FC<GraphViewProps> = ({
           }}
           onNodeDragEnd={handleNodeDragEnd}
           onEngineStop={handleEngineStop}
-          onZoom={handleZoomTransform}
-          onZoomEnd={handleZoomEnd}
+          enableNodeDrag
+          enableNavigationControls
         />
       </React.Suspense>
     </div>
@@ -935,6 +1082,10 @@ function applyLayoutPosition(
   node.x = layout.x;
   node.y = layout.y;
 
+  if (typeof layout.z === 'number') {
+    node.z = layout.z;
+  }
+
   if (typeof layout.fx === 'number') {
     node.fx = layout.fx;
   } else if (node.fx !== undefined) {
@@ -945,6 +1096,12 @@ function applyLayoutPosition(
     node.fy = layout.fy;
   } else if (node.fy !== undefined) {
     node.fy = undefined;
+  }
+
+  if (typeof layout.fz === 'number') {
+    node.fz = layout.fz;
+  } else if (node.fz !== undefined) {
+    node.fz = undefined;
   }
 }
 
@@ -1013,6 +1170,81 @@ type GraphPalette = {
   linkConsumes: string;
   linkInitiative: string;
 };
+
+function createNodeSpriteData(
+  node: ForceNode,
+  highlighted: string | null,
+  palette: GraphPalette,
+  visibleDomainIds: Set<string>,
+  visibleModuleStatuses: Set<ModuleStatus>
+): NodeSpriteData {
+  const size = 192;
+  const pixelRatio = typeof window !== 'undefined' ? Math.min(window.devicePixelRatio || 1, 2.5) : 1;
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.round(size * pixelRatio);
+  canvas.height = Math.round(size * pixelRatio);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Failed to create canvas context for node sprite');
+  }
+
+  const texture = new CanvasTexture(canvas);
+  texture.minFilter = LinearFilter;
+  texture.magFilter = LinearFilter;
+  texture.needsUpdate = true;
+
+  const material = new SpriteMaterial({
+    map: texture,
+    transparent: true,
+    depthWrite: false
+  });
+
+  const sprite = new Sprite(material);
+  sprite.center.set(0.5, 0.5);
+
+  const data: NodeSpriteData = { canvas, ctx, texture, sprite, pixelRatio, size };
+  refreshNodeSpriteData(node, data, highlighted, palette, visibleDomainIds, visibleModuleStatuses);
+  return data;
+}
+
+function refreshNodeSpriteData(
+  node: ForceNode,
+  data: NodeSpriteData,
+  highlighted: string | null,
+  palette: GraphPalette,
+  visibleDomainIds: Set<string>,
+  visibleModuleStatuses: Set<ModuleStatus>
+): void {
+  const { ctx, pixelRatio, size, texture, sprite } = data;
+  ctx.save();
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.clearRect(0, 0, size * pixelRatio, size * pixelRatio);
+  ctx.scale(pixelRatio, pixelRatio);
+  ctx.translate(size / 2, size / 2);
+
+  const stubNode = { ...node, x: 0, y: 0 } as ForceNode;
+  drawNode(stubNode, ctx, 1, highlighted, palette, visibleDomainIds, visibleModuleStatuses);
+
+  ctx.restore();
+  texture.needsUpdate = true;
+
+  const isHighlighted = highlighted === node.id;
+  const scale = resolveSpriteScale(node, isHighlighted);
+  sprite.scale.set(scale, scale, scale);
+  sprite.renderOrder = isHighlighted ? 10 : 1;
+}
+
+function resolveSpriteScale(node: ForceNode, isHighlighted: boolean): number {
+  const base =
+    node.type === 'initiative'
+      ? 34
+      : node.type === 'module'
+        ? 28
+        : node.type === 'domain'
+          ? 26
+          : 24;
+  return isHighlighted ? base * 1.1 : base;
+}
 
 function drawNode(
   node: ForceNode,
@@ -1339,6 +1571,18 @@ function computeFocusZoom(
   const baseZoom = 2.4 + viewportRatio * 1.2; // 2.4 .. 3.6
   const labelAdjustment = clamp(label.length / 24, 0, 0.6);
   return clamp(baseZoom + labelAdjustment, 2.6, 4.2);
+}
+
+function computeFocusDistance(
+  dimensions: { width: number; height: number },
+  label: string,
+  currentDistance: number
+): number {
+  const zoom = computeFocusZoom(dimensions, label);
+  const normalizedZoom = clamp(zoom, 2.6, 4.2);
+  const baseline = clamp(currentDistance || 320, 220, 760);
+  const distance = baseline / (normalizedZoom / 2.6);
+  return clamp(distance, 160, 540);
 }
 
 const DEFAULT_PALETTE: GraphPalette = {

--- a/src/services/graphStorage.ts
+++ b/src/services/graphStorage.ts
@@ -125,7 +125,7 @@ export function normalizeLayoutSnapshot(
       return acc;
     }
 
-    const { x, y, fx, fy } = position as GraphLayoutSnapshot['nodes'][string];
+    const { x, y, z, fx, fy, fz } = position as GraphLayoutSnapshot['nodes'][string];
 
     if (typeof x !== 'number' || Number.isNaN(x) || typeof y !== 'number' || Number.isNaN(y)) {
       return acc;
@@ -133,12 +133,20 @@ export function normalizeLayoutSnapshot(
 
     const next: GraphLayoutSnapshot['nodes'][string] = { x, y };
 
+    if (typeof z === 'number' && !Number.isNaN(z)) {
+      next.z = z;
+    }
+
     if (typeof fx === 'number' && !Number.isNaN(fx)) {
       next.fx = fx;
     }
 
     if (typeof fy === 'number' && !Number.isNaN(fy)) {
       next.fy = fy;
+    }
+
+    if (typeof fz === 'number' && !Number.isNaN(fz)) {
+      next.fz = fz;
     }
 
     acc.push([id, next]);

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -11,8 +11,10 @@ export const GRAPH_SNAPSHOT_VERSION = 3;
 export type GraphLayoutNodePosition = {
   x: number;
   y: number;
+  z?: number;
   fx?: number;
   fy?: number;
+  fz?: number;
 };
 
 export type GraphLayoutSnapshot = {


### PR DESCRIPTION
## Summary
- switch the main graph view to react-force-graph-3d with persistent camera controls and custom sprite rendering
- extend graph layout persistence to include optional z/fz coordinates in storage and normalization flows
- add the 3D force graph dependency alongside the existing 2D renderer

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69074516970c833280c0ca78b115d442