### PR TITLE
feat: add task planning form for employee workload tab

### DIFF
--- a/src/components/EmployeeWorkloadTrack.module.css
+++ b/src/components/EmployeeWorkloadTrack.module.css
@@ -1,9 +1,12 @@
-.layout {
+.wrapper {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 24px;
-  width: 100%;
-  align-items: flex-start;
+}
+
+.viewTabs {
+  display: flex;
+  justify-content: flex-start;
 }
 
 .card {
@@ -11,20 +14,15 @@
   flex-direction: column;
   gap: 16px;
   min-width: 0;
+  width: 100%;
 }
 
 .taskCard {
-  position: sticky;
-  top: 24px;
   gap: 20px;
-  flex: 0 1 360px;
-  width: min(100%, 400px);
 }
 
 .workloadCard {
   min-height: 360px;
-  flex: 1 1 640px;
-  min-width: 0;
 }
 
 .header {
@@ -234,26 +232,9 @@
   gap: 2px;
 }
 
-@media (max-width: 1440px) {
-  .taskCard {
-    flex-basis: 340px;
-    width: min(100%, 360px);
-  }
-}
-
 @media (max-width: 1024px) {
-  .taskCard {
-    position: static;
-    flex: 1 1 100%;
-    width: 100%;
-  }
-
   .taskFormFields {
     grid-template-columns: 1fr;
-  }
-
-  .workloadCard {
-    flex: 1 1 100%;
   }
 
   .taskRow {

--- a/src/components/EmployeeWorkloadTrack.module.css
+++ b/src/components/EmployeeWorkloadTrack.module.css
@@ -1,7 +1,25 @@
+.layout {
+  display: grid;
+  grid-template-columns: minmax(320px, 380px) minmax(0, 1fr);
+  gap: 24px;
+  width: 100%;
+  align-items: flex-start;
+}
+
 .card {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  min-width: 0;
+}
+
+.taskCard {
+  position: sticky;
+  top: 24px;
+  gap: 20px;
+}
+
+.workloadCard {
   min-height: 360px;
 }
 
@@ -24,6 +42,131 @@
   flex-wrap: wrap;
   gap: 12px;
   align-items: center;
+}
+
+.taskHeader {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.taskHeaderInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.taskForm {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.taskFormFields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px 16px;
+}
+
+.taskFormActions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.taskTable {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.taskRow {
+  display: grid;
+  grid-template-columns: minmax(180px, 1.2fr) 110px 130px 120px minmax(180px, 1fr);
+  gap: 12px;
+  align-items: center;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--color-bg-border);
+  background: var(--color-bg-secondary);
+}
+
+.taskRowHeader {
+  padding: 0;
+  background: transparent;
+  border: none;
+}
+
+.taskRowActive {
+  background: var(--color-bg-default);
+  border-color: var(--color-bg-link);
+  box-shadow: 0 0 0 1px var(--color-bg-link) inset;
+}
+
+.taskNameButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.taskNameButton:hover,
+.taskNameButton:focus-visible {
+  text-decoration: underline;
+}
+
+.assigneeInfo {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.assigneeIndicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--color-bg-border);
+}
+
+.assigneeIndicator[data-level='free'] {
+  background: #2fd196;
+}
+
+.assigneeIndicator[data-level='focus'] {
+  background: #ffa600;
+}
+
+.assigneeIndicator[data-level='busy'] {
+  background: #ff5f5f;
+}
+
+.taskDetails {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid var(--color-bg-border);
+  background: var(--color-bg-secondary);
+}
+
+.taskDetailsMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.taskDetailsAssignee {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .legend {
@@ -85,4 +228,33 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+}
+
+@media (max-width: 1440px) {
+  .layout {
+    grid-template-columns: minmax(300px, 360px) minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 1024px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .taskCard {
+    position: static;
+  }
+
+  .taskFormFields {
+    grid-template-columns: 1fr;
+  }
+
+  .taskRow {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 8px;
+  }
+
+  .taskRowHeader {
+    display: none;
+  }
 }

--- a/src/components/EmployeeWorkloadTrack.module.css
+++ b/src/components/EmployeeWorkloadTrack.module.css
@@ -1,6 +1,6 @@
 .layout {
-  display: grid;
-  grid-template-columns: minmax(320px, 380px) minmax(0, 1fr);
+  display: flex;
+  flex-wrap: wrap;
   gap: 24px;
   width: 100%;
   align-items: flex-start;
@@ -17,10 +17,14 @@
   position: sticky;
   top: 24px;
   gap: 20px;
+  flex: 0 1 360px;
+  width: min(100%, 400px);
 }
 
 .workloadCard {
   min-height: 360px;
+  flex: 1 1 640px;
+  min-width: 0;
 }
 
 .header {
@@ -83,7 +87,7 @@
 
 .taskRow {
   display: grid;
-  grid-template-columns: minmax(180px, 1.2fr) 110px 130px 120px minmax(180px, 1fr);
+  grid-template-columns: minmax(0, 1.2fr) minmax(90px, 0.6fr) minmax(110px, 0.7fr) minmax(110px, 0.7fr) minmax(0, 1fr);
   gap: 12px;
   align-items: center;
   padding: 12px 16px;
@@ -231,22 +235,25 @@
 }
 
 @media (max-width: 1440px) {
-  .layout {
-    grid-template-columns: minmax(300px, 360px) minmax(0, 1fr);
+  .taskCard {
+    flex-basis: 340px;
+    width: min(100%, 360px);
   }
 }
 
 @media (max-width: 1024px) {
-  .layout {
-    grid-template-columns: 1fr;
-  }
-
   .taskCard {
     position: static;
+    flex: 1 1 100%;
+    width: 100%;
   }
 
   .taskFormFields {
     grid-template-columns: 1fr;
+  }
+
+  .workloadCard {
+    flex: 1 1 100%;
   }
 
   .taskRow {

--- a/src/components/EmployeeWorkloadTrack.tsx
+++ b/src/components/EmployeeWorkloadTrack.tsx
@@ -1,8 +1,11 @@
 import { Badge } from '@consta/uikit/Badge';
+import { Button } from '@consta/uikit/Button';
 import { Card } from '@consta/uikit/Card';
+import { Select } from '@consta/uikit/Select';
 import { Tabs } from '@consta/uikit/Tabs';
 import { Text } from '@consta/uikit/Text';
-import React, { useMemo, useState } from 'react';
+import { TextField } from '@consta/uikit/TextField';
+import React, { useCallback, useMemo, useState } from 'react';
 import GanttTimeline, {
   type GanttTimelineRow,
   type GanttTimelineTaskKind,
@@ -32,6 +35,24 @@ type EmployeeWorkload = {
   availability: string;
   focus: string;
   tasks: WorkloadTask[];
+};
+
+type TaskPriority = 'low' | 'medium' | 'high';
+type TaskStatus = 'new' | 'in-progress' | 'paused' | 'rejected' | 'completed';
+
+type TaskListItem = {
+  id: string;
+  name: string;
+  priority: TaskPriority;
+  dueDate: string;
+  status: TaskStatus;
+  assigneeId: string | null;
+  description: string;
+};
+
+type SelectOption<Value extends string> = {
+  label: string;
+  value: Value;
 };
 
 const mockEmployees: EmployeeWorkload[] = [
@@ -178,8 +199,142 @@ const mockEmployees: EmployeeWorkload[] = [
   }
 ];
 
+const priorityOptions: SelectOption<TaskPriority>[] = [
+  { label: 'Низкий', value: 'low' },
+  { label: 'Средний', value: 'medium' },
+  { label: 'Высокий', value: 'high' }
+];
+
+const statusOptions: SelectOption<TaskStatus>[] = [
+  { label: 'Новая', value: 'new' },
+  { label: 'В работе', value: 'in-progress' },
+  { label: 'На паузе', value: 'paused' },
+  { label: 'Отклонено', value: 'rejected' },
+  { label: 'Выполнено', value: 'completed' }
+];
+
+const statusBadges: Record<TaskStatus, { label: string; badgeStatus: 'normal' | 'system' | 'success' | 'warning' | 'alert' | 'error' }> = {
+  'new': { label: 'Новая', badgeStatus: 'system' },
+  'in-progress': { label: 'В работе', badgeStatus: 'warning' },
+  'paused': { label: 'На паузе', badgeStatus: 'alert' },
+  'rejected': { label: 'Отклонено', badgeStatus: 'error' },
+  'completed': { label: 'Выполнено', badgeStatus: 'success' }
+};
+
+const priorityBadges: Record<TaskPriority, { label: string; badgeStatus: 'normal' | 'system' | 'success' | 'warning' | 'alert' | 'error' }> = {
+  'low': { label: 'Низкий', badgeStatus: 'normal' },
+  'medium': { label: 'Средний', badgeStatus: 'warning' },
+  'high': { label: 'Высокий', badgeStatus: 'alert' }
+};
+
+const initialTaskList: TaskListItem[] = [
+  {
+    id: 'team-task-1',
+    name: 'Скрининг участков',
+    priority: 'medium',
+    dueDate: '2024-03-11',
+    status: 'paused',
+    assigneeId: 'emp-1',
+    description:
+      'Провести аналитический скрининг участков и подготовить рекомендации для инвест-совета.'
+  },
+  {
+    id: 'team-task-2',
+    name: 'Первичный расчёт экономики',
+    priority: 'high',
+    dueDate: '2024-02-15',
+    status: 'in-progress',
+    assigneeId: 'emp-2',
+    description: 'Собрать исходные данные и подготовить первичный расчёт показателей экономики проекта.'
+  },
+  {
+    id: 'team-task-3',
+    name: 'Формирование паспорта инвест-проекта',
+    priority: 'medium',
+    dueDate: '2024-03-29',
+    status: 'new',
+    assigneeId: 'emp-3',
+    description:
+      'Согласовать исходные данные, актуализировать паспорт проекта и подтвердить ответственных исполнителей.'
+  },
+  {
+    id: 'team-task-4',
+    name: 'Разбор запускных параметров тепловой схемы',
+    priority: 'low',
+    dueDate: '2024-03-29',
+    status: 'new',
+    assigneeId: null,
+    description: 'Подготовить рекомендации по корректировке запускных параметров и согласовать их с технологами.'
+  },
+  {
+    id: 'team-task-5',
+    name: 'Актуализация профилей добычи',
+    priority: 'low',
+    dueDate: '2024-03-29',
+    status: 'new',
+    assigneeId: 'emp-4',
+    description: 'Собрать данные по текущим профилям добычи и обновить отчётность для инвестиционного комитета.'
+  },
+  {
+    id: 'team-task-6',
+    name: 'Расчёт кустов без учёта инфраструктуры',
+    priority: 'medium',
+    dueDate: '2024-03-29',
+    status: 'new',
+    assigneeId: null,
+    description: 'Подготовить сравнительный анализ кустовых расчётов без учёта инфраструктурных ограничений.'
+  },
+  {
+    id: 'team-task-7',
+    name: 'Формирование сценариев отсечения КП',
+    priority: 'medium',
+    dueDate: '2024-03-29',
+    status: 'new',
+    assigneeId: null,
+    description: 'Разработать сценарии отсечения КП и согласовать с командой архитекторов.'
+  },
+  {
+    id: 'team-task-8',
+    name: 'Расчёт экономики',
+    priority: 'high',
+    dueDate: '2024-04-12',
+    status: 'rejected',
+    assigneeId: 'emp-2',
+    description: 'Подготовить альтернативный расчёт экономики с учётом новых вводных от финансового блока.'
+  },
+  {
+    id: 'team-task-9',
+    name: 'План даты ввода',
+    priority: 'medium',
+    dueDate: '2024-03-29',
+    status: 'completed',
+    assigneeId: 'emp-1',
+    description: 'Согласовать график ввода объектов и передать его в проектный офис.'
+  }
+];
+
 const EmployeeWorkloadTrack: React.FC = () => {
   const [scale, setScale] = useState<TimelineScaleTab>(timelineScaleTabs[1]);
+  const [tasks, setTasks] = useState<TaskListItem[]>(initialTaskList);
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(
+    initialTaskList[0]?.id ?? null
+  );
+  const [taskDraft, setTaskDraft] = useState<{
+    name: string;
+    priority: TaskPriority;
+    dueDate: string;
+    status: TaskStatus;
+    assigneeId: string | null;
+    description: string;
+  }>({
+    name: '',
+    priority: 'medium',
+    dueDate: '',
+    status: 'new',
+    assigneeId: null,
+    description: ''
+  });
+  const [formError, setFormError] = useState<string | null>(null);
 
   const timelineRows = useMemo<GanttTimelineRow[]>(() => {
     return mockEmployees.map((employee) => {
@@ -236,8 +391,388 @@ const EmployeeWorkloadTrack: React.FC = () => {
     });
   }, []);
 
+  const assigneeOptions = useMemo<SelectOption<string>[]>(() => {
+    return mockEmployees.map((employee) => ({
+      label: employee.fullName,
+      value: employee.id
+    }));
+  }, []);
+
+  const employeeNameMap = useMemo<Record<string, string>>(() => {
+    return mockEmployees.reduce<Record<string, string>>((acc, employee) => {
+      acc[employee.id] = employee.fullName;
+      return acc;
+    }, {});
+  }, []);
+
+  const selectedTask = useMemo(() => {
+    return tasks.find((task) => task.id === selectedTaskId) ?? null;
+  }, [selectedTaskId, tasks]);
+
+  const formatDate = useCallback((value: string) => {
+    if (!value) {
+      return 'Не указана';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return 'Не указана';
+    }
+    return new Intl.DateTimeFormat('ru-RU', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric'
+    }).format(date);
+  }, []);
+
+  const calculateParallelTasks = useCallback(
+    (assigneeId: string, referenceTask: TaskListItem) => {
+      const dueDate = referenceTask.dueDate ? new Date(referenceTask.dueDate) : null;
+      const employee = mockEmployees.find((item) => item.id === assigneeId);
+
+      const overlappingProjectTasks = (() => {
+        if (!employee || !dueDate || Number.isNaN(dueDate.getTime())) {
+          return 0;
+        }
+
+        return employee.tasks.filter((projectTask) => {
+          const startDate = new Date(projectTask.start);
+          const endDate = new Date(projectTask.end);
+          if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+            return false;
+          }
+          return startDate.getTime() <= dueDate.getTime() && dueDate.getTime() <= endDate.getTime();
+        }).length;
+      })();
+
+      const overlappingTeamTasks = tasks.filter((task) => {
+        if (task.id === referenceTask.id) {
+          return false;
+        }
+        if (task.assigneeId !== assigneeId) {
+          return false;
+        }
+        if (!dueDate || !task.dueDate) {
+          return true;
+        }
+        const compareDate = new Date(task.dueDate);
+        if (Number.isNaN(compareDate.getTime())) {
+          return true;
+        }
+        return compareDate.getTime() === dueDate.getTime();
+      }).length;
+
+      return overlappingProjectTasks + overlappingTeamTasks;
+    },
+    [tasks]
+  );
+
+  const getAssigneeLoadLevel = useCallback(
+    (assigneeId: string, task: TaskListItem) => {
+      const parallelTasks = calculateParallelTasks(assigneeId, task);
+      if (parallelTasks === 0) {
+        return 'free';
+      }
+      if (parallelTasks === 1) {
+        return 'focus';
+      }
+      return 'busy';
+    },
+    [calculateParallelTasks]
+  );
+
+  const handleAssignTask = useCallback((taskId: string, assigneeId: string | null) => {
+    setTasks((prev) =>
+      prev.map((task) =>
+        task.id === taskId
+          ? {
+              ...task,
+              assigneeId
+            }
+          : task
+      )
+    );
+  }, []);
+
+  const handleSubmitTask = useCallback(() => {
+    if (!taskDraft.name.trim() || !taskDraft.dueDate) {
+      setFormError('Укажите наименование задачи и дату реализации.');
+      return;
+    }
+
+    const newTask: TaskListItem = {
+      id: `team-task-${Date.now()}`,
+      name: taskDraft.name.trim(),
+      priority: taskDraft.priority,
+      dueDate: taskDraft.dueDate,
+      status: taskDraft.status,
+      assigneeId: taskDraft.assigneeId,
+      description: taskDraft.description.trim() || 'Описание будет добавлено позже.'
+    };
+
+    setTasks((prev) => [newTask, ...prev]);
+    setTaskDraft({
+      name: '',
+      priority: 'medium',
+      dueDate: '',
+      status: 'new',
+      assigneeId: null,
+      description: ''
+    });
+    setFormError(null);
+    setSelectedTaskId(newTask.id);
+  }, [taskDraft]);
+
   return (
-    <Card className={styles.card} verticalSpace="xl" horizontalSpace="xl">
+    <div className={styles.layout}>
+      <Card
+        className={`${styles.card} ${styles.taskCard}`}
+        verticalSpace="xl"
+        horizontalSpace="xl"
+      >
+        <header className={styles.taskHeader}>
+          <div className={styles.taskHeaderInfo}>
+            <Text size="s" weight="semibold">
+              Постановка задач
+            </Text>
+            <Text size="xs" view="secondary">
+              Создавайте и назначайте задачи для своей команды
+            </Text>
+          </div>
+          <Badge
+            size="xs"
+            view="stroked"
+            status="system"
+            label={`Активных задач: ${tasks.length}`}
+          />
+        </header>
+        <form
+          className={styles.taskForm}
+          onSubmit={(event) => {
+            event.preventDefault();
+            handleSubmitTask();
+          }}
+        >
+          <div className={styles.taskFormFields}>
+            <TextField
+              size="s"
+              label="Наименование"
+              placeholder="Например, подготовить паспорт проекта"
+              value={taskDraft.name}
+              onChange={({ value }) => {
+                setTaskDraft((prev) => ({
+                  ...prev,
+                  name: value ?? ''
+                }));
+              }}
+            />
+            <Select<SelectOption<TaskPriority>>
+              size="s"
+              label="Приоритет"
+              items={priorityOptions}
+              value={priorityOptions.find((item) => item.value === taskDraft.priority) ?? null}
+              getItemLabel={(item) => item.label}
+              getItemKey={(item) => item.value}
+              onChange={(option) => {
+                setTaskDraft((prev) => ({
+                  ...prev,
+                  priority: option?.value ?? prev.priority
+                }));
+              }}
+            />
+            <TextField
+              size="s"
+              type="date"
+              label="Дата реализации"
+              value={taskDraft.dueDate}
+              onChange={({ value }) => {
+                setTaskDraft((prev) => ({
+                  ...prev,
+                  dueDate: value ?? ''
+                }));
+              }}
+            />
+            <Select<SelectOption<TaskStatus>>
+              size="s"
+              label="Статус"
+              items={statusOptions}
+              value={statusOptions.find((item) => item.value === taskDraft.status) ?? null}
+              getItemLabel={(item) => item.label}
+              getItemKey={(item) => item.value}
+              onChange={(option) => {
+                setTaskDraft((prev) => ({
+                  ...prev,
+                  status: option?.value ?? prev.status
+                }));
+              }}
+            />
+            <Select<SelectOption<string>>
+              size="s"
+              label="Исполнитель"
+              placeholder="Назначьте исполнителя"
+              items={assigneeOptions}
+              value={
+                taskDraft.assigneeId
+                  ? assigneeOptions.find((option) => option.value === taskDraft.assigneeId) ?? null
+                  : null
+              }
+              getItemLabel={(item) => item.label}
+              getItemKey={(item) => item.value}
+              onChange={(option) => {
+                setTaskDraft((prev) => ({
+                  ...prev,
+                  assigneeId: option?.value ?? null
+                }));
+              }}
+            />
+          </div>
+          <TextField
+            size="s"
+            label="Описание"
+            type="textarea"
+            rows={3}
+            placeholder="Кратко опишите ожидаемый результат"
+            value={taskDraft.description}
+            onChange={({ value }) => {
+              setTaskDraft((prev) => ({
+                ...prev,
+                description: value ?? ''
+              }));
+            }}
+          />
+          {formError && (
+            <Text size="xs" view="alert">
+              {formError}
+            </Text>
+          )}
+          <div className={styles.taskFormActions}>
+            <Button type="submit" size="s" view="primary" label="Сохранить задачу" />
+          </div>
+        </form>
+        <div className={styles.taskTable}>
+          <div className={`${styles.taskRow} ${styles.taskRowHeader}`} aria-hidden={true}>
+            <Text size="2xs" view="secondary">
+              Наименование
+            </Text>
+            <Text size="2xs" view="secondary">
+              Приоритет
+            </Text>
+            <Text size="2xs" view="secondary">
+              Дата реализации
+            </Text>
+            <Text size="2xs" view="secondary">
+              Статус
+            </Text>
+            <Text size="2xs" view="secondary">
+              Исполнители
+            </Text>
+          </div>
+          {tasks.map((task) => {
+            const priorityBadge = priorityBadges[task.priority];
+            const statusBadge = statusBadges[task.status];
+            const assigneeName = task.assigneeId ? employeeNameMap[task.assigneeId] : null;
+            const loadLevel = task.assigneeId ? getAssigneeLoadLevel(task.assigneeId, task) : null;
+
+            return (
+              <div
+                key={task.id}
+                className={`${styles.taskRow} ${
+                  task.id === selectedTaskId ? styles.taskRowActive : ''
+                }`}
+              >
+                <button
+                  type="button"
+                  className={styles.taskNameButton}
+                  onClick={() => {
+                    setSelectedTaskId(task.id);
+                  }}
+                >
+                  <Text size="xs" weight="semibold">
+                    {task.name}
+                  </Text>
+                </button>
+                <Badge
+                  size="xs"
+                  view="filled"
+                  status={priorityBadge.badgeStatus}
+                  label={priorityBadge.label}
+                />
+                <Text size="xs" view="secondary">
+                  {formatDate(task.dueDate)}
+                </Text>
+                <Badge
+                  size="xs"
+                  view="filled"
+                  status={statusBadge.badgeStatus}
+                  label={statusBadge.label}
+                />
+                {assigneeName ? (
+                  <div className={styles.assigneeInfo}>
+                    <span className={styles.assigneeIndicator} data-level={loadLevel ?? 'free'} />
+                    <Text size="xs" weight="semibold">
+                      {assigneeName}
+                    </Text>
+                  </div>
+                ) : (
+                  <Select<SelectOption<string>>
+                    size="xs"
+                    placeholder="Назначить"
+                    items={assigneeOptions}
+                    value={null}
+                    getItemLabel={(item) => item.label}
+                    getItemKey={(item) => item.value}
+                    onChange={(option) => {
+                      handleAssignTask(task.id, option?.value ?? null);
+                    }}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+        {selectedTask && (
+          <div className={styles.taskDetails}>
+            <Text size="s" weight="semibold">
+              {selectedTask.name}
+            </Text>
+            <div className={styles.taskDetailsMeta}>
+              <Badge
+                size="xs"
+                view="filled"
+                status={priorityBadges[selectedTask.priority].badgeStatus}
+                label={priorityBadges[selectedTask.priority].label}
+              />
+              <Badge
+                size="xs"
+                view="filled"
+                status={statusBadges[selectedTask.status].badgeStatus}
+                label={statusBadges[selectedTask.status].label}
+              />
+              <Text size="xs" view="secondary">
+                Срок: {formatDate(selectedTask.dueDate)}
+              </Text>
+              {selectedTask.assigneeId && (
+                <div className={styles.taskDetailsAssignee}>
+                  <span
+                    className={styles.assigneeIndicator}
+                    data-level={getAssigneeLoadLevel(selectedTask.assigneeId, selectedTask)}
+                  />
+                  <Text size="xs" weight="semibold">
+                    {employeeNameMap[selectedTask.assigneeId]}
+                  </Text>
+                </div>
+              )}
+            </div>
+            <Text size="xs" view="secondary">
+              {selectedTask.description}
+            </Text>
+          </div>
+        )}
+      </Card>
+      <Card
+        className={`${styles.card} ${styles.workloadCard}`}
+        verticalSpace="xl"
+        horizontalSpace="xl"
+      >
       <header className={styles.header}>
         <div className={styles.headerInfo}>
           <Text size="s" weight="semibold">
@@ -283,6 +818,7 @@ const EmployeeWorkloadTrack: React.FC = () => {
       </div>
       <GanttTimeline axisLabel="Сотрудник" scale={scale.value} rows={timelineRows} />
     </Card>
+    </div>
   );
 };
 

--- a/src/components/EmployeeWorkloadTrack.tsx
+++ b/src/components/EmployeeWorkloadTrack.tsx
@@ -313,12 +313,20 @@ const initialTaskList: TaskListItem[] = [
   }
 ];
 
+const viewTabs = [
+  { label: 'Дорожка загрузки', value: 'timeline' },
+  { label: 'Постановка задач', value: 'planner' }
+] as const;
+
+type ViewTab = (typeof viewTabs)[number];
+
 const EmployeeWorkloadTrack: React.FC = () => {
   const [scale, setScale] = useState<TimelineScaleTab>(timelineScaleTabs[1]);
   const [tasks, setTasks] = useState<TaskListItem[]>(initialTaskList);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(
     initialTaskList[0]?.id ?? null
   );
+  const [activeView, setActiveView] = useState<ViewTab>(viewTabs[0]);
   const [taskDraft, setTaskDraft] = useState<{
     name: string;
     priority: TaskPriority;
@@ -523,12 +531,23 @@ const EmployeeWorkloadTrack: React.FC = () => {
   }, [taskDraft]);
 
   return (
-    <div className={styles.layout}>
-      <Card
-        className={`${styles.card} ${styles.taskCard}`}
-        verticalSpace="xl"
-        horizontalSpace="xl"
-      >
+    <div className={styles.wrapper}>
+      <div className={styles.viewTabs}>
+        <Tabs<ViewTab>
+          size="s"
+          items={viewTabs}
+          value={activeView}
+          getItemLabel={(item) => item.label}
+          getItemKey={(item) => item.value}
+          onChange={setActiveView}
+        />
+      </div>
+      {activeView.value === 'planner' ? (
+        <Card
+          className={`${styles.card} ${styles.taskCard}`}
+          verticalSpace="xl"
+          horizontalSpace="xl"
+        >
         <header className={styles.taskHeader}>
           <div className={styles.taskHeaderInfo}>
             <Text size="s" weight="semibold">
@@ -767,12 +786,13 @@ const EmployeeWorkloadTrack: React.FC = () => {
             </Text>
           </div>
         )}
-      </Card>
-      <Card
-        className={`${styles.card} ${styles.workloadCard}`}
-        verticalSpace="xl"
-        horizontalSpace="xl"
-      >
+        </Card>
+      ) : (
+        <Card
+          className={`${styles.card} ${styles.workloadCard}`}
+          verticalSpace="xl"
+          horizontalSpace="xl"
+        >
       <header className={styles.header}>
         <div className={styles.headerInfo}>
           <Text size="s" weight="semibold">
@@ -817,7 +837,8 @@ const EmployeeWorkloadTrack: React.FC = () => {
         </div>
       </div>
       <GanttTimeline axisLabel="Сотрудник" scale={scale.value} rows={timelineRows} />
-    </Card>
+        </Card>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a task planning form and backlog list to the employee tasks tab
- support inline assignee selection with workload indicators and task details
- restyle the layout so the task planner sits alongside the workload timeline

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f777fc1c83329050067bdaff0229)