### PR TITLE
Add flexible scheduling controls and timeline period selection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2533,6 +2533,7 @@ function App() {
       const normalizedOwner = request.owner.trim() || 'Ответственный не указан';
       const normalizedImpact = request.expectedImpact.trim() || 'Эффект не оценён';
       const normalizedTarget = request.targetModuleName.trim() || normalizedName;
+      const normalizedStartDate = request.startDate?.trim() || new Date().toISOString().slice(0, 10);
       const domains = request.domains.map((domain) => domain.trim()).filter(Boolean);
       const { potentialModules, plannedModuleIds } = preparePlannerModuleSelections(
         request.potentialModules
@@ -2746,6 +2747,7 @@ function App() {
         requiredSkills,
         workItems,
         approvalStages,
+        startDate: normalizedStartDate,
         status: request.status,
         owner: normalizedOwner,
         expectedImpact: normalizedImpact,
@@ -2789,6 +2791,7 @@ function App() {
       const normalizedOwner = request.owner.trim() || existing.owner;
       const normalizedImpact = request.expectedImpact.trim() || existing.expectedImpact;
       const normalizedTarget = request.targetModuleName.trim() || existing.targetModuleName;
+      const normalizedStartDate = request.startDate?.trim() || existing.startDate || new Date().toISOString().slice(0, 10);
       const domains = request.domains.map((domain) => domain.trim()).filter(Boolean);
       const { potentialModules, plannedModuleIds } = preparePlannerModuleSelections(
         request.potentialModules
@@ -2869,6 +2872,7 @@ function App() {
         owner: normalizedOwner,
         expectedImpact: normalizedImpact,
         targetModuleName: normalizedTarget,
+        startDate: normalizedStartDate,
         lastUpdated: new Date().toISOString(),
         roles,
         potentialModules,

--- a/src/components/GanttTimeline.tsx
+++ b/src/components/GanttTimeline.tsx
@@ -266,9 +266,10 @@ type GanttTimelineProps = {
   axisLabel: string;
   rows: GanttTimelineRow[];
   scale: TimelineScale;
+  viewRange?: { start: Date | string; end: Date | string };
 };
 
-const GanttTimeline: React.FC<GanttTimelineProps> = ({ axisLabel, rows, scale }) => {
+const GanttTimeline: React.FC<GanttTimelineProps> = ({ axisLabel, rows, scale, viewRange }) => {
   const normalizedRows = useMemo<NormalizedRow[]>(() => {
     return rows.map((row) => {
       const normalizedTasks = row.tasks.map((task) => {
@@ -301,7 +302,24 @@ const GanttTimeline: React.FC<GanttTimelineProps> = ({ axisLabel, rows, scale })
     [normalizedRows]
   );
 
-  const { viewStart, viewEnd } = useMemo(() => computeViewRange(allTasks, scale), [allTasks, scale]);
+  const explicitRange = useMemo(() => {
+    if (!viewRange) {
+      return null;
+    }
+    const start = startOfDay(toDate(viewRange.start));
+    const end = startOfDay(toDate(viewRange.end));
+    if (end <= start) {
+      return { viewStart: start, viewEnd: addDays(start, 1) };
+    }
+    return { viewStart: start, viewEnd: end };
+  }, [viewRange]);
+
+  const { viewStart, viewEnd } = useMemo(() => {
+    if (explicitRange) {
+      return explicitRange;
+    }
+    return computeViewRange(allTasks, scale);
+  }, [allTasks, explicitRange, scale]);
   const totalDuration = Math.max(viewEnd.getTime() - viewStart.getTime(), MS_IN_DAY);
   const segments = useMemo(() => buildSegments(viewStart, viewEnd, scale), [viewEnd, viewStart, scale]);
   const gridTemplateColumns = useMemo(() => {

--- a/src/components/InitiativeCreationModal.module.css
+++ b/src/components/InitiativeCreationModal.module.css
@@ -207,6 +207,14 @@
   gap: 12px;
 }
 
+.assignmentTimingPlaceholder {
+  min-height: 1px;
+}
+
+.assignmentTimingHint {
+  margin-top: 4px;
+}
+
 
 .recommendationList {
   display: grid;

--- a/src/components/InitiativeCreationModal.tsx
+++ b/src/components/InitiativeCreationModal.tsx
@@ -997,6 +997,11 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
     });
   };
 
+  const assignmentSchedule = useMemo(
+    () => buildAssignmentSchedule(works, initiativeStartDate?.trim() ? initiativeStartDate : null),
+    [works, initiativeStartDate]
+  );
+
   const ganttTasks = useMemo<InitiativeGanttTask[]>(
     () =>
       works.flatMap((work) => {
@@ -1112,11 +1117,6 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
   const modalTitle = mode === 'edit' ? 'Редактирование инициативы' : 'Новая инициатива';
   const submitButtonLabel = mode === 'edit' ? 'Сохранить изменения' : 'Создать инициативу';
   const teamStepForwardLabel = mode === 'edit' ? 'Обновить команду' : 'Сформировать команду';
-
-  const assignmentSchedule = useMemo(
-    () => buildAssignmentSchedule(works, initiativeStartDate?.trim() ? initiativeStartDate : null),
-    [works, initiativeStartDate]
-  );
 
   const assignmentReferenceOptions = useMemo<SelectOption<string>[]>(() => {
     const options: SelectOption<string>[] = [];
@@ -1300,7 +1300,6 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
     },
     [
       approvalStages,
-      assignmentSchedule,
       customerComment,
       customerContact,
       customerRepresentative,

--- a/src/components/InitiativeCreationModal.tsx
+++ b/src/components/InitiativeCreationModal.tsx
@@ -91,6 +91,8 @@ const collectGraphDomainIds = (domains: DomainNode[]): string[] => {
   return result;
 };
 
+type AssignmentStartMode = 'project-start' | 'after-assignment' | 'fixed-date';
+
 type WorkAssignmentDraft = {
   id: string;
   role: TeamRole;
@@ -99,6 +101,9 @@ type WorkAssignmentDraft = {
   effortDays: number;
   startDay: number;
   durationDays: number;
+  startMode: AssignmentStartMode;
+  startAfterId?: string | null;
+  startDate?: string | null;
   isCustom?: boolean;
   tasks?: string[];
   minUnits?: number;
@@ -124,6 +129,83 @@ type WorkDraft = {
   timeframe: string;
   status: InitiativeWorkItemStatus;
   assignments: WorkAssignmentDraft[];
+};
+
+type AssignmentSchedule = {
+  startDay: number;
+  durationDays: number;
+  startDate: Date | null;
+};
+
+const buildAssignmentSchedule = (
+  works: WorkDraft[],
+  initiativeStartDate: string | null
+): Map<string, AssignmentSchedule> => {
+  const lookup = new Map<string, { assignment: WorkAssignmentDraft }>();
+  works.forEach((work) => {
+    work.assignments.forEach((assignment) => {
+      lookup.set(assignment.id, { assignment });
+    });
+  });
+
+  const baseStart = initiativeStartDate ? startOfDay(new Date(initiativeStartDate)) : null;
+  const memo = new Map<string, number>();
+
+  const computeStart = (assignmentId: string, visited: Set<string>): number => {
+    if (memo.has(assignmentId)) {
+      return memo.get(assignmentId) ?? 0;
+    }
+    const record = lookup.get(assignmentId);
+    if (!record) {
+      memo.set(assignmentId, 0);
+      return 0;
+    }
+    const assignment = record.assignment;
+    const sanitizedStart = Math.max(0, Math.round(assignment.startDay));
+    const mode = assignment.startMode ?? 'project-start';
+    let resolved = sanitizedStart;
+
+    if (mode === 'project-start') {
+      resolved = 0;
+    } else if (mode === 'fixed-date') {
+      if (assignment.startDate && baseStart) {
+        const target = new Date(assignment.startDate);
+        if (!Number.isNaN(target.getTime())) {
+          resolved = Math.max(0, differenceInDays(baseStart, target));
+        }
+      }
+    } else if (mode === 'after-assignment') {
+      const referenceId = assignment.startAfterId;
+      if (
+        referenceId &&
+        referenceId !== assignmentId &&
+        lookup.has(referenceId) &&
+        !visited.has(referenceId)
+      ) {
+        const nextVisited = new Set(visited);
+        nextVisited.add(assignmentId);
+        const referenceStart = computeStart(referenceId, nextVisited);
+        const reference = lookup.get(referenceId);
+        if (reference) {
+          const referenceDuration = Math.max(1, Math.round(reference.assignment.durationDays));
+          resolved = referenceStart + referenceDuration;
+        }
+      }
+    }
+
+    memo.set(assignmentId, resolved);
+    return resolved;
+  };
+
+  const schedule = new Map<string, AssignmentSchedule>();
+  lookup.forEach((record, assignmentId) => {
+    const startDay = computeStart(assignmentId, new Set());
+    const durationDays = Math.max(1, Math.round(record.assignment.durationDays));
+    const startDate = baseStart ? addDays(baseStart, startDay) : null;
+    schedule.set(assignmentId, { startDay, durationDays, startDate });
+  });
+
+  return schedule;
 };
 
 type ApprovalStageDraft = {
@@ -175,6 +257,12 @@ const workItemStatusOptions: SelectOption<InitiativeWorkItemStatus>[] = [
   { label: 'Внедрение', value: 'delivery' }
 ];
 
+const startModeOptions: SelectOption<AssignmentStartMode>[] = [
+  { label: 'С начала проекта', value: 'project-start' },
+  { label: 'После задачи/работы', value: 'after-assignment' },
+  { label: 'С определённой даты', value: 'fixed-date' }
+];
+
 const approvalStatusOptions: SelectOption<InitiativeApprovalStatus>[] = [
   { label: 'Ожидание', value: 'pending' },
   { label: 'В работе', value: 'in-progress' },
@@ -203,6 +291,32 @@ const resolveTaskLabel = (rawValue: string, fallback: string): string => {
   return getSkillNameById(trimmed) ?? trimmed;
 };
 
+const MS_IN_DAY = 24 * 60 * 60 * 1000;
+
+const startOfDay = (input: Date): Date => {
+  const result = new Date(input);
+  result.setHours(0, 0, 0, 0);
+  return result;
+};
+
+const addDays = (input: Date, amount: number): Date => {
+  const result = new Date(input);
+  result.setDate(result.getDate() + amount);
+  return result;
+};
+
+const differenceInDays = (start: Date, end: Date): number => {
+  const startTime = startOfDay(start).getTime();
+  const endTime = startOfDay(end).getTime();
+  return Math.floor((endTime - startTime) / MS_IN_DAY);
+};
+
+const startDateFormatter = new Intl.DateTimeFormat('ru-RU', {
+  day: '2-digit',
+  month: 'short',
+  year: 'numeric'
+});
+
 const createWorkAssignmentDraft = (
   role: TeamRole = roleOptions[0].value,
   startDay = 0,
@@ -214,7 +328,10 @@ const createWorkAssignmentDraft = (
   description: '',
   effortDays: 5,
   startDay,
-  durationDays
+  durationDays,
+  startMode: 'project-start',
+  startAfterId: null,
+  startDate: null
 });
 
 const createWorkDraft = (offset = 0): WorkDraft => ({
@@ -238,6 +355,7 @@ const createApprovalStageDraft = (): ApprovalStageDraft => ({
 
 const buildWorksFromCreationDraft = (draft: InitiativeCreationRequest): WorkDraft[] => {
   const workMap = new Map<string, WorkDraft>();
+  const baseStartDate = draft.startDate ? startOfDay(new Date(draft.startDate)) : null;
   const workItemMetadata = new Map(
     draft.workItems.map((item) => [item.id, item])
   );
@@ -279,14 +397,23 @@ const buildWorksFromCreationDraft = (draft: InitiativeCreationRequest): WorkDraf
       }
 
       const tasks = item.tasks ?? [];
+      const normalizedStart = Math.max(0, Math.round(item.startDay));
+      const normalizedDuration = Math.max(1, Math.round(item.durationDays));
+      const startDateValue =
+        baseStartDate !== null ? addDays(baseStartDate, normalizedStart).toISOString().slice(0, 10) : null;
+      const startMode: AssignmentStartMode =
+        normalizedStart === 0 || !startDateValue ? 'project-start' : 'fixed-date';
       const assignment: WorkAssignmentDraft = {
         id: createId(),
         role: role.role,
         task: tasks[0]?.skill ?? '',
         description: item.description ?? '',
         effortDays: Math.max(1, Math.round(item.effortDays)),
-        startDay: Math.max(0, Math.round(item.startDay)),
-        durationDays: Math.max(1, Math.round(item.durationDays)),
+        startDay: normalizedStart,
+        durationDays: normalizedDuration,
+        startMode,
+        startAfterId: null,
+        startDate: startDateValue,
         isCustom: tasks.some((task) => task.isCustom),
         tasks: tasks.map((task) => task.skill)
       };
@@ -403,6 +530,9 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
   const [expectedImpact, setExpectedImpact] = useState('');
   const [targetModule, setTargetModule] = useState('');
   const [status, setStatus] = useState<InitiativeStatus>('initiated');
+  const [initiativeStartDate, setInitiativeStartDate] = useState<string>(() =>
+    new Date().toISOString().slice(0, 10)
+  );
   const [domainItems, setDomainItems] = useState<OptionItem[]>(() => [...domainBaseItems]);
   const [selectedDomains, setSelectedDomains] = useState<OptionItem[]>([]);
   const [isCreatingDomain, setIsCreatingDomain] = useState(false);
@@ -461,9 +591,10 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
         setDescription('');
         setOwner('');
         setExpectedImpact('');
-        setTargetModule('');
-        setStatus('initiated');
-        setDomainItems([...domainBaseItems]);
+      setTargetModule('');
+      setStatus('initiated');
+      setInitiativeStartDate(new Date().toISOString().slice(0, 10));
+      setDomainItems([...domainBaseItems]);
         setSelectedDomains([]);
         setIsCreatingDomain(false);
         setNewDomainLabel('');
@@ -493,6 +624,7 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
       setExpectedImpact(draft.expectedImpact);
       setTargetModule(draft.targetModuleName);
       setStatus(draft.status);
+      setInitiativeStartDate(draft.startDate ?? new Date().toISOString().slice(0, 10));
 
       const nextDomainItems = [...domainBaseItems];
       const domainSelections = draft.domains
@@ -797,14 +929,83 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
     setIsCreatingUnit(false);
   };
 
+  const handleAssignmentStartModeChange = (
+    workId: string,
+    assignmentId: string,
+    mode: AssignmentStartMode
+  ) => {
+    if (mode === 'after-assignment') {
+      const fallback = assignmentReferenceOptions.find((option) => option.value !== assignmentId);
+      if (!fallback) {
+        handleAssignmentChange(workId, assignmentId, {
+          startMode: 'project-start',
+          startAfterId: null,
+          startDate: null
+        });
+        return;
+      }
+      handleAssignmentChange(workId, assignmentId, {
+        startMode: mode,
+        startAfterId: fallback?.value ?? null
+      });
+      return;
+    }
+
+    if (mode === 'fixed-date') {
+      const currentAssignment = works
+        .find((work) => work.id === workId)
+        ?.assignments.find((assignment) => assignment.id === assignmentId);
+      const fallbackDate =
+        initiativeStartDate?.trim() && initiativeStartDate.length > 0
+          ? initiativeStartDate
+          : new Date().toISOString().slice(0, 10);
+      const defaultDate = currentAssignment?.startDate ?? fallbackDate;
+      handleAssignmentChange(workId, assignmentId, {
+        startMode: mode,
+        startAfterId: null,
+        startDate: defaultDate
+      });
+      return;
+    }
+
+    handleAssignmentChange(workId, assignmentId, {
+      startMode: mode,
+      startAfterId: null,
+      startDate: null
+    });
+  };
+
+  const handleAssignmentStartAfterChange = (
+    workId: string,
+    assignmentId: string,
+    referenceId: string | null
+  ) => {
+    handleAssignmentChange(workId, assignmentId, {
+      startMode: 'after-assignment',
+      startAfterId: referenceId ?? null
+    });
+  };
+
+  const handleAssignmentStartDateChange = (
+    workId: string,
+    assignmentId: string,
+    date: string | null
+  ) => {
+    handleAssignmentChange(workId, assignmentId, {
+      startMode: 'fixed-date',
+      startDate: date ?? null
+    });
+  };
+
   const ganttTasks = useMemo<InitiativeGanttTask[]>(
     () =>
       works.flatMap((work) => {
         const normalizedTitle = work.title.trim() || 'Задача';
         return work.assignments.flatMap((assignment, index) => {
           const normalizedTaskName = resolveTaskLabel(assignment.task, normalizedTitle);
-          const normalizedStart = Math.max(0, Math.round(assignment.startDay));
-          const normalizedDuration = Math.max(1, Math.round(assignment.durationDays));
+          const schedule = assignmentSchedule.get(assignment.id);
+          const normalizedStart = schedule?.startDay ?? Math.max(0, Math.round(assignment.startDay));
+          const normalizedDuration = schedule?.durationDays ?? Math.max(1, Math.round(assignment.durationDays));
           const normalizedEffort = Math.max(1, Math.round(assignment.effortDays));
           const resources: InitiativeGanttResource[] = assignment.assignedExpertId
             ? [
@@ -830,6 +1031,9 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
           if (index > 0) {
             const previous = work.assignments[index - 1];
             dependencies.push({ id: `${work.id}-${previous.id}`, type: 'FS' });
+          }
+          if (assignment.startMode === 'after-assignment' && assignment.startAfterId) {
+            dependencies.push({ id: assignment.startAfterId, type: 'FS' });
           }
 
           const baseTask: InitiativeGanttTask = {
@@ -864,7 +1068,7 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
           return [baseTask];
         });
       }),
-    [works]
+    [assignmentSchedule, works]
   );
 
   const totalEffortDays = works.reduce((acc, work) => {
@@ -909,6 +1113,23 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
   const submitButtonLabel = mode === 'edit' ? 'Сохранить изменения' : 'Создать инициативу';
   const teamStepForwardLabel = mode === 'edit' ? 'Обновить команду' : 'Сформировать команду';
 
+  const assignmentSchedule = useMemo(
+    () => buildAssignmentSchedule(works, initiativeStartDate?.trim() ? initiativeStartDate : null),
+    [works, initiativeStartDate]
+  );
+
+  const assignmentReferenceOptions = useMemo<SelectOption<string>[]>(() => {
+    const options: SelectOption<string>[] = [];
+    works.forEach((work) => {
+      const workTitle = work.title.trim() || 'Работа';
+      work.assignments.forEach((assignment) => {
+        const label = `${workTitle} · ${resolveTaskLabel(assignment.task, workTitle)}`;
+        options.push({ label, value: assignment.id });
+      });
+    });
+    return options;
+  }, [works]);
+
   const { planningRoles, roleAssignmentRefs } = useMemo(() => {
     const accumulator = new Map<
       TeamRole,
@@ -926,8 +1147,9 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
       const normalizedTitle = work.title.trim() || 'Задача';
       const normalizedDescription = work.description.trim();
       work.assignments.forEach((assignment) => {
-        const assignmentStart = Math.max(0, Math.round(assignment.startDay));
-        const assignmentDuration = Math.max(1, Math.round(assignment.durationDays));
+        const schedule = assignmentSchedule.get(assignment.id);
+        const assignmentStart = schedule?.startDay ?? Math.max(0, Math.round(assignment.startDay));
+        const assignmentDuration = schedule?.durationDays ?? Math.max(1, Math.round(assignment.durationDays));
         const entry =
           accumulator.get(assignment.role) ??
           {
@@ -989,7 +1211,7 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
     );
 
     return { planningRoles: planning, roleAssignmentRefs: assignmentRefs };
-  }, [works]);
+  }, [assignmentSchedule, works]);
 
   const draftPayload = useMemo<InitiativeCreationRequest>(
     () => {
@@ -1028,6 +1250,7 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
         status,
         domains: selectedDomains.map((item) => item.value.trim()).filter(Boolean),
         potentialModules: selectedModules.map((item) => item.value.trim()).filter(Boolean),
+        startDate: initiativeStartDate?.trim() || undefined,
         customer: {
           companies: selectedCompanies
             .map((item) => item.value.trim())
@@ -1077,6 +1300,7 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
     },
     [
       approvalStages,
+      assignmentSchedule,
       customerComment,
       customerContact,
       customerRepresentative,
@@ -1092,7 +1316,8 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
       selectedModules,
       status,
       targetModule,
-      works
+      works,
+      initiativeStartDate
     ]
   );
 
@@ -1133,8 +1358,15 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
     assignmentId: string,
     patch: Partial<WorkAssignmentDraft>
   ) => {
-    setWorks((prev) =>
-      prev.map((work) => {
+    setWorks((prev) => {
+      const assignmentLookup = new Map<string, WorkAssignmentDraft>();
+      prev.forEach((candidate) => {
+        candidate.assignments.forEach((item) => {
+          assignmentLookup.set(item.id, item);
+        });
+      });
+
+      return prev.map((work) => {
         if (work.id !== workId) {
           return work;
         }
@@ -1143,8 +1375,8 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
           ...work,
           assignments: work.assignments.map((assignment) => {
             if (assignment.id !== assignmentId) {
-            return assignment;
-          }
+              return assignment;
+            }
 
             let nextEffort =
               patch.effortDays !== undefined
@@ -1170,19 +1402,59 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
               }
             }
 
+            const nextStartMode: AssignmentStartMode = patch.startMode ?? assignment.startMode ?? 'project-start';
+            let nextStartAfterId: string | null =
+              patch.startAfterId !== undefined
+                ? patch.startAfterId ?? null
+                : assignment.startAfterId ?? null;
+            let nextStartDate: string | null =
+              patch.startDate !== undefined
+                ? patch.startDate?.trim() || null
+                : assignment.startDate ?? null;
+            let computedStart = nextStart;
+
+            if (nextStartMode === 'project-start') {
+              nextStartAfterId = null;
+              nextStartDate = null;
+              computedStart = 0;
+            } else if (nextStartMode === 'after-assignment') {
+              nextStartDate = null;
+              const referenceId = nextStartAfterId && nextStartAfterId !== assignment.id ? nextStartAfterId : null;
+              if (referenceId) {
+                const reference = assignmentLookup.get(referenceId);
+                if (reference) {
+                  const referenceStart = Math.max(0, Math.round(reference.startDay));
+                  const referenceDuration = Math.max(1, Math.round(reference.durationDays));
+                  computedStart = referenceStart + referenceDuration;
+                }
+              }
+            } else if (nextStartMode === 'fixed-date') {
+              nextStartAfterId = null;
+              if (nextStartDate) {
+                const base = initiativeStartDate ? startOfDay(new Date(initiativeStartDate)) : null;
+                const target = new Date(nextStartDate);
+                if (base && !Number.isNaN(target.getTime())) {
+                  computedStart = Math.max(0, differenceInDays(base, target));
+                }
+              }
+            }
+
             const nextAssignment: WorkAssignmentDraft = {
               ...assignment,
               ...patch,
               effortDays: nextEffort,
-              startDay: nextStart,
-              durationDays: nextDuration
+              startDay: computedStart,
+              durationDays: nextDuration,
+              startMode: nextStartMode,
+              startAfterId: nextStartAfterId,
+              startDate: nextStartDate
             };
 
             return nextAssignment;
           })
         };
-      })
-    );
+      });
+    });
   };
 
   const handleAssignmentRoleChange = (workId: string, assignmentId: string, role: TeamRole) => {
@@ -1398,6 +1670,13 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
                     onChange={(value) => setOwner(value ?? '')}
                   />
                 </div>
+                <TextField
+                  size="s"
+                  label="Дата старта инициативы"
+                  type="date"
+                  value={initiativeStartDate}
+                  onChange={(value) => setInitiativeStartDate(value ?? '')}
+                />
                 <TextField
                   size="s"
                   label="Краткое описание"
@@ -1715,8 +1994,9 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
                   <div className={styles.workList}>
                     {works.map((work) => {
                       const scheduleBounds = work.assignments.map((assignment) => {
-                        const normalizedStart = Math.max(0, Math.round(assignment.startDay));
-                        const normalizedDuration = Math.max(1, Math.round(assignment.durationDays));
+                        const schedule = assignmentSchedule.get(assignment.id);
+                        const normalizedStart = schedule?.startDay ?? Math.max(0, Math.round(assignment.startDay));
+                        const normalizedDuration = schedule?.durationDays ?? Math.max(1, Math.round(assignment.durationDays));
                         return {
                           start: normalizedStart,
                           end: normalizedStart + normalizedDuration
@@ -1831,11 +2111,11 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
                                 const selectedTask =
                                   skillOptionsForRole.find((option) => option.value === assignment.task) ?? null;
                                 return (
-                                  <div key={assignment.id} className={styles.assignmentCard}>
-                                    <div className={styles.assignmentRow}>
-                                      <Select<SelectOption<TeamRole>>
-                                        size="s"
-                                        label={`Роль сотрудника ${index + 1}`}
+                                <div key={assignment.id} className={styles.assignmentCard}>
+                                  <div className={styles.assignmentRow}>
+                                    <Select<SelectOption<TeamRole>>
+                                      size="s"
+                                      label={`Роль сотрудника ${index + 1}`}
                                         items={roleOptions}
                                         value={roleOption}
                                         getItemLabel={(item) => item.label}
@@ -1889,41 +2169,123 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
                                       type="textarea"
                                       minRows={2}
                                     />
-                                    <div className={styles.assignmentTimingGrid}>
-                                      <TextField
-                                        size="s"
-                                        label="Старт (день)"
-                                        type="number"
-                                        value={String(assignment.startDay)}
-                                        onChange={(value) =>
-                                          handleAssignmentChange(work.id, assignment.id, {
-                                            startDay: Number(value ?? assignment.startDay) || 0
-                                          })
-                                        }
-                                      />
-                                      <TextField
-                                        size="s"
-                                        label="Длительность (дней)"
-                                        type="number"
-                                        value={String(assignment.durationDays)}
-                                        onChange={(value) =>
-                                          handleAssignmentChange(work.id, assignment.id, {
-                                            durationDays: Number(value ?? assignment.durationDays) || 1
-                                          })
-                                        }
-                                      />
-                                      <TextField
-                                        size="s"
-                                        label="Трудозатраты (дней)"
-                                        type="number"
-                                        value={String(assignment.effortDays)}
-                                        onChange={(value) =>
-                                          handleAssignmentChange(work.id, assignment.id, {
-                                            effortDays: Number(value ?? assignment.effortDays) || 1
-                                          })
-                                        }
-                                      />
-                                    </div>
+                                    {(() => {
+                                      const schedule = assignmentSchedule.get(assignment.id);
+                                      const computedStart =
+                                        schedule?.startDay ?? Math.max(0, Math.round(assignment.startDay));
+                                      const computedDuration =
+                                        schedule?.durationDays ?? Math.max(1, Math.round(assignment.durationDays));
+                                      const computedFinish = computedStart + computedDuration;
+                                      const rawStartDate = assignment.startDate
+                                        ? new Date(assignment.startDate)
+                                        : null;
+                                      const startDateDisplay = schedule?.startDate
+                                        ? startDateFormatter.format(schedule.startDate)
+                                        : rawStartDate && !Number.isNaN(rawStartDate.getTime())
+                                          ? startDateFormatter.format(rawStartDate)
+                                          : null;
+                                      const finishDate =
+                                        schedule?.startDate && computedDuration > 0
+                                          ? addDays(schedule.startDate, computedDuration - 1)
+                                          : rawStartDate && !Number.isNaN(rawStartDate.getTime()) && computedDuration > 0
+                                            ? addDays(rawStartDate, computedDuration - 1)
+                                            : null;
+                                      const startModeOption =
+                                        startModeOptions.find((option) => option.value === assignment.startMode) ??
+                                        startModeOptions[0];
+                                      const referenceItems = assignmentReferenceOptions.filter(
+                                        (option) => option.value !== assignment.id
+                                      );
+                                      const referenceValue = referenceItems.find(
+                                        (option) => option.value === assignment.startAfterId
+                                      );
+                                      const fallbackDate =
+                                        initiativeStartDate?.trim() && initiativeStartDate.length > 0
+                                          ? initiativeStartDate
+                                          : new Date().toISOString().slice(0, 10);
+                                      const dateValue = assignment.startDate ?? fallbackDate;
+
+                                      return (
+                                        <>
+                                          <div className={styles.assignmentTimingGrid}>
+                                            <Select<SelectOption<AssignmentStartMode>>
+                                              size="s"
+                                              label="Начало работы"
+                                              items={startModeOptions}
+                                              value={startModeOption}
+                                              getItemLabel={(item) => item.label}
+                                              getItemKey={(item) => item.value}
+                                              onChange={(option) =>
+                                                option &&
+                                                handleAssignmentStartModeChange(work.id, assignment.id, option.value)
+                                              }
+                                            />
+                                            {assignment.startMode === 'after-assignment' ? (
+                                              <Select<SelectOption<string>>
+                                                size="s"
+                                                label="После задачи"
+                                                items={referenceItems}
+                                                value={referenceValue ?? null}
+                                                getItemLabel={(item) => item.label}
+                                                getItemKey={(item) => item.value}
+                                                disabled={referenceItems.length === 0}
+                                                onChange={(option) =>
+                                                  handleAssignmentStartAfterChange(
+                                                    work.id,
+                                                    assignment.id,
+                                                    option?.value ?? null
+                                                  )
+                                                }
+                                              />
+                                            ) : assignment.startMode === 'fixed-date' ? (
+                                              <TextField
+                                                size="s"
+                                                label="Дата начала"
+                                                type="date"
+                                                value={dateValue}
+                                                onChange={(value) =>
+                                                  handleAssignmentStartDateChange(
+                                                    work.id,
+                                                    assignment.id,
+                                                    value ?? null
+                                                  )
+                                                }
+                                              />
+                                            ) : (
+                                              <div className={styles.assignmentTimingPlaceholder} />
+                                            )}
+                                            <TextField
+                                              size="s"
+                                              label="Длительность (дней)"
+                                              type="number"
+                                              value={String(assignment.durationDays)}
+                                              onChange={(value) =>
+                                                handleAssignmentChange(work.id, assignment.id, {
+                                                  durationDays: Number(value ?? assignment.durationDays) || 1
+                                                })
+                                              }
+                                            />
+                                            <TextField
+                                              size="s"
+                                              label="Трудозатраты (дней)"
+                                              type="number"
+                                              value={String(assignment.effortDays)}
+                                              onChange={(value) =>
+                                                handleAssignmentChange(work.id, assignment.id, {
+                                                  effortDays: Number(value ?? assignment.effortDays) || 1
+                                                })
+                                              }
+                                            />
+                                          </div>
+                                          <Text size="2xs" view="secondary" className={styles.assignmentTimingHint}>
+                                            Старт: Д{computedStart + 1}
+                                            {startDateDisplay ? ` · ${startDateDisplay}` : ''}
+                                            {` · Завершение: Д${computedFinish}`}
+                                            {finishDate ? ` (${startDateFormatter.format(finishDate)})` : ''}
+                                          </Text>
+                                        </>
+                                      );
+                                    })()}
                                   </div>
                                 );
                               })}
@@ -1946,7 +2308,10 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
                     </div>
                   </div>
                   <div className={styles.ganttPreview}>
-                    <InitiativeGanttChart tasks={ganttTasks} />
+                    <InitiativeGanttChart
+                      tasks={ganttTasks}
+                      startDate={initiativeStartDate?.trim() ? initiativeStartDate : undefined}
+                    />
                   </div>
                 </div>
               </div>

--- a/src/components/InitiativeGanttChart.module.css
+++ b/src/components/InitiativeGanttChart.module.css
@@ -18,11 +18,22 @@
   gap: 4px;
 }
 
+.headerControls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
 .summary {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
   align-items: center;
+}
+
+.periodSelect {
+  min-width: 200px;
 }
 
 .legend {

--- a/src/components/InitiativeGanttChart.tsx
+++ b/src/components/InitiativeGanttChart.tsx
@@ -1,7 +1,8 @@
 import { Badge } from '@consta/uikit/Badge';
+import { Select } from '@consta/uikit/Select';
 import { Tabs } from '@consta/uikit/Tabs';
 import { Text } from '@consta/uikit/Text';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import type { TeamRole } from '../data';
 import GanttTimeline, {
   type GanttTimelineRow,
@@ -73,6 +74,7 @@ export type InitiativeGanttTask = {
 
 type InitiativeGanttChartProps = {
   tasks: InitiativeGanttTask[];
+  startDate?: string | Date;
 };
 
 type InitiativeTimelineGroup = {
@@ -93,7 +95,190 @@ const addDays = (date: Date, amount: number): Date => {
   return result;
 };
 
-const InitiativeGanttChart: React.FC<InitiativeGanttChartProps> = ({ tasks }) => {
+const startOfDay = (date: Date): Date => {
+  const result = new Date(date);
+  result.setHours(0, 0, 0, 0);
+  return result;
+};
+
+const startOfWeek = (date: Date): Date => {
+  const result = startOfDay(date);
+  const day = result.getDay();
+  const diff = (day + 6) % 7;
+  result.setDate(result.getDate() - diff);
+  return result;
+};
+
+const startOfMonth = (date: Date): Date => new Date(date.getFullYear(), date.getMonth(), 1);
+
+const startOfYear = (date: Date): Date => new Date(date.getFullYear(), 0, 1);
+
+const addMonths = (date: Date, amount: number): Date => {
+  const result = new Date(date);
+  result.setMonth(result.getMonth() + amount, 1);
+  result.setHours(0, 0, 0, 0);
+  return result;
+};
+
+const addYears = (date: Date, amount: number): Date => {
+  const result = new Date(date);
+  result.setFullYear(result.getFullYear() + amount, 1);
+  result.setMonth(0, 1);
+  result.setHours(0, 0, 0, 0);
+  return result;
+};
+
+const weekFormatter = new Intl.DateTimeFormat('ru-RU', {
+  day: '2-digit',
+  month: 'short'
+});
+
+const monthLabelFormatter = new Intl.DateTimeFormat('ru-RU', {
+  month: 'long',
+  year: 'numeric'
+});
+
+const yearLabelFormatter = new Intl.DateTimeFormat('ru-RU', {
+  year: 'numeric'
+});
+
+const capitalize = (value: string): string => {
+  if (!value) {
+    return value;
+  }
+  return value.charAt(0).toUpperCase() + value.slice(1);
+};
+
+const formatWeekLabel = (start: Date, endInclusive: Date): string => {
+  const startLabel = capitalize(weekFormatter.format(start));
+  const endLabel = capitalize(weekFormatter.format(endInclusive));
+  if (startLabel === endLabel) {
+    return startLabel;
+  }
+  return `${startLabel} – ${endLabel}`;
+};
+
+const toDate = (value: Date | string): Date => {
+  if (value instanceof Date) {
+    return value;
+  }
+  return new Date(value);
+};
+
+type PeriodOption = {
+  label: string;
+  value: string;
+  start: Date;
+  end: Date;
+};
+
+type TimelineScale = TimelineScaleTab['value'];
+
+const buildWeekOptions = (baseStart: Date, minDate: Date, maxDate: Date): PeriodOption[] => {
+  const earliest = startOfWeek(addDays(minDate, -7));
+  const latest = startOfWeek(addDays(maxDate, 7));
+  const options: PeriodOption[] = [];
+  let cursor = earliest;
+  let guard = 0;
+  while (cursor <= latest && guard < 104) {
+    const start = cursor;
+    const end = addDays(start, 7);
+    options.push({
+      label: formatWeekLabel(start, addDays(end, -1)),
+      value: start.toISOString(),
+      start,
+      end
+    });
+    cursor = addDays(cursor, 7);
+    guard += 1;
+  }
+  if (options.length === 0) {
+    const start = startOfWeek(baseStart);
+    const end = addDays(start, 7);
+    options.push({
+      label: formatWeekLabel(start, addDays(end, -1)),
+      value: start.toISOString(),
+      start,
+      end
+    });
+  }
+  return options;
+};
+
+const buildMonthOptions = (baseStart: Date, minDate: Date, maxDate: Date): PeriodOption[] => {
+  const earliest = startOfMonth(addMonths(minDate, -1));
+  const latest = startOfMonth(addMonths(maxDate, 1));
+  const options: PeriodOption[] = [];
+  let cursor = earliest;
+  let guard = 0;
+  while (cursor <= latest && guard < 48) {
+    const start = cursor;
+    const end = addMonths(start, 1);
+    options.push({
+      label: capitalize(monthLabelFormatter.format(start)),
+      value: start.toISOString(),
+      start,
+      end
+    });
+    cursor = addMonths(cursor, 1);
+    guard += 1;
+  }
+  if (options.length === 0) {
+    const start = startOfMonth(baseStart);
+    const end = addMonths(start, 1);
+    options.push({
+      label: capitalize(monthLabelFormatter.format(start)),
+      value: start.toISOString(),
+      start,
+      end
+    });
+  }
+  return options;
+};
+
+const buildYearOptions = (baseStart: Date, minDate: Date, maxDate: Date): PeriodOption[] => {
+  const earliest = startOfYear(addYears(minDate, -1));
+  const latest = startOfYear(addYears(maxDate, 1));
+  const options: PeriodOption[] = [];
+  let cursor = earliest;
+  let guard = 0;
+  while (cursor <= latest && guard < 12) {
+    const start = cursor;
+    const end = addYears(start, 1);
+    options.push({
+      label: yearLabelFormatter.format(start),
+      value: start.toISOString(),
+      start,
+      end
+    });
+    cursor = addYears(cursor, 1);
+    guard += 1;
+  }
+  if (options.length === 0) {
+    const start = startOfYear(baseStart);
+    const end = addYears(start, 1);
+    options.push({
+      label: yearLabelFormatter.format(start),
+      value: start.toISOString(),
+      start,
+      end
+    });
+  }
+  return options;
+};
+
+const InitiativeGanttChart: React.FC<InitiativeGanttChartProps> = ({ tasks, startDate }) => {
+  const baseStart = useMemo(() => {
+    if (!startDate) {
+      return startOfDay(new Date(Date.UTC(2024, 0, 1)));
+    }
+    const parsed = new Date(startDate);
+    if (Number.isNaN(parsed.getTime())) {
+      return startOfDay(new Date(Date.UTC(2024, 0, 1)));
+    }
+    return startOfDay(parsed);
+  }, [startDate]);
+
   const [scale, setScale] = useState<TimelineScaleTab>(timelineScaleTabs[1]);
 
   const groups = useMemo(() => {
@@ -101,7 +286,6 @@ const InitiativeGanttChart: React.FC<InitiativeGanttChartProps> = ({ tasks }) =>
       return [] as InitiativeTimelineGroup[];
     }
 
-    const referenceStart = new Date(Date.UTC(2024, 0, 1));
     const map = new Map<string, InitiativeTimelineGroup>();
 
     tasks.forEach((task) => {
@@ -138,8 +322,8 @@ const InitiativeGanttChart: React.FC<InitiativeGanttChartProps> = ({ tasks }) =>
       }
 
       const normalizedDuration = Math.max(1, Math.round(task.durationDays));
-      const startDate = addDays(referenceStart, Math.max(0, Math.round(task.startDay)));
-      const endDate = addDays(startDate, normalizedDuration - 1);
+      const startDateValue = addDays(baseStart, Math.max(0, Math.round(task.startDay)));
+      const endDate = addDays(startDateValue, normalizedDuration - 1);
       const details: string[] = [];
       if (task.role) {
         details.push(`Роль: ${task.role}`);
@@ -157,7 +341,7 @@ const InitiativeGanttChart: React.FC<InitiativeGanttChartProps> = ({ tasks }) =>
       const timelineTask: GanttTimelineTask = {
         id: task.id,
         name: task.name,
-        start: startDate,
+        start: startDateValue,
         end: endDate,
         kind: 'project',
         badge: task.projectName ?? 'Проект',
@@ -184,7 +368,69 @@ const InitiativeGanttChart: React.FC<InitiativeGanttChartProps> = ({ tasks }) =>
       }
       return a.displayName.localeCompare(b.displayName, 'ru');
     });
-  }, [tasks]);
+  }, [baseStart, tasks]);
+
+  const timelineTasks = useMemo(() => groups.flatMap((group) => group.tasks), [groups]);
+
+  const minTaskStart = useMemo(() => {
+    if (timelineTasks.length === 0) {
+      return baseStart;
+    }
+    return timelineTasks.reduce((min, task) => {
+      const startDate = startOfDay(toDate(task.start));
+      return startDate < min ? startDate : min;
+    }, startOfDay(toDate(timelineTasks[0].start)));
+  }, [baseStart, timelineTasks]);
+
+  const maxTaskEnd = useMemo(() => {
+    if (timelineTasks.length === 0) {
+      return baseStart;
+    }
+    return timelineTasks.reduce((max, task) => {
+      const endDate = startOfDay(toDate(task.end));
+      return endDate > max ? endDate : max;
+    }, startOfDay(toDate(timelineTasks[0].end)));
+  }, [baseStart, timelineTasks]);
+
+  const periodOptions = useMemo(
+    () => ({
+      week: buildWeekOptions(baseStart, minTaskStart, maxTaskEnd),
+      month: buildMonthOptions(baseStart, minTaskStart, maxTaskEnd),
+      year: buildYearOptions(baseStart, minTaskStart, maxTaskEnd)
+    }),
+    [baseStart, maxTaskEnd, minTaskStart]
+  );
+
+  const [selectedPeriods, setSelectedPeriods] = useState<Record<TimelineScale, string | null>>(() => ({
+    week: periodOptions.week[0]?.value ?? null,
+    month: periodOptions.month[0]?.value ?? null,
+    year: periodOptions.year[0]?.value ?? null
+  }));
+
+  useEffect(() => {
+    setSelectedPeriods((prev) => ({
+      week:
+        prev.week && periodOptions.week.some((option) => option.value === prev.week)
+          ? prev.week
+          : periodOptions.week[0]?.value ?? null,
+      month:
+        prev.month && periodOptions.month.some((option) => option.value === prev.month)
+          ? prev.month
+          : periodOptions.month[0]?.value ?? null,
+      year:
+        prev.year && periodOptions.year.some((option) => option.value === prev.year)
+          ? prev.year
+          : periodOptions.year[0]?.value ?? null
+    }));
+  }, [periodOptions]);
+
+  const currentPeriodOptions = periodOptions[scale.value];
+  const selectedPeriodValue = selectedPeriods[scale.value];
+  const activePeriod = currentPeriodOptions.find((option) => option.value === selectedPeriodValue) ?? null;
+  const displayedPeriod = activePeriod ?? currentPeriodOptions[0] ?? null;
+  const resolvedViewRange = displayedPeriod
+    ? { start: displayedPeriod.start, end: displayedPeriod.end }
+    : undefined;
 
   const timelineRows = useMemo<GanttTimelineRow[]>(() => {
     return groups.map((group) => {
@@ -280,14 +526,33 @@ const InitiativeGanttChart: React.FC<InitiativeGanttChartProps> = ({ tasks }) =>
             </Text>
           </div>
         </div>
-        <Tabs<TimelineScaleTab>
-          size="s"
-          items={timelineScaleTabs}
-          value={scale}
-          getItemLabel={(item) => item.label}
-          getItemKey={(item) => item.value}
-          onChange={setScale}
-        />
+        <div className={styles.headerControls}>
+          <Tabs<TimelineScaleTab>
+            size="s"
+            items={timelineScaleTabs}
+            value={scale}
+            getItemLabel={(item) => item.label}
+            getItemKey={(item) => item.value}
+            onChange={setScale}
+          />
+          <Select<PeriodOption>
+            size="s"
+            className={styles.periodSelect}
+            label="Период"
+            placeholder="Выберите период"
+            items={currentPeriodOptions}
+            value={displayedPeriod ?? null}
+            getItemLabel={(item) => item.label}
+            getItemKey={(item) => item.value}
+            onChange={(option) =>
+              setSelectedPeriods((prev) => ({
+                ...prev,
+                [scale.value]: option?.value ?? null
+              }))
+            }
+            disabled={currentPeriodOptions.length === 0}
+          />
+        </div>
       </header>
       <div className={styles.legend} aria-hidden={true}>
         <div className={styles.legendItem}>
@@ -309,7 +574,12 @@ const InitiativeGanttChart: React.FC<InitiativeGanttChartProps> = ({ tasks }) =>
           </Text>
         </div>
       </div>
-      <GanttTimeline axisLabel="Исполнитель" scale={scale.value} rows={timelineRows} />
+      <GanttTimeline
+        axisLabel="Исполнитель"
+        scale={scale.value}
+        rows={timelineRows}
+        viewRange={resolvedViewRange}
+      />
     </div>
   );
 };

--- a/src/components/InitiativePlanner.tsx
+++ b/src/components/InitiativePlanner.tsx
@@ -669,7 +669,10 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
               </Text>
             </div>
             <div className={styles.timelineBody}>
-              <InitiativeGanttChart tasks={timelineTasks} />
+              <InitiativeGanttChart
+                tasks={timelineTasks}
+                startDate={selectedInitiative.startDate}
+              />
             </div>
           </Card>
           <aside className={styles.riskSection} aria-label="Риски инициативы">

--- a/src/data.ts
+++ b/src/data.ts
@@ -272,6 +272,7 @@ export type InitiativeNode = {
   name: string;
   description: string;
   domains: string[];
+  startDate?: string;
   plannedModuleIds: string[];
   requiredSkills: string[];
   workItems: InitiativeWorkItem[];
@@ -1299,6 +1300,7 @@ export const initiativeNodes: InitiativeNode[] = [
     description:
       'Создание цифрового контура подготовки площадок и проектирования наземной инфраструктуры для новых кустов скважин.',
     domains: ['layout-optimization', 'surface-readiness'],
+    startDate: '2025-01-06',
     plannedModuleIds: ['module-infraplan-layout', 'module-infraplan-datahub', 'module-infraplan-economics'],
     requiredSkills: [
       'Оптимизация промысловой инфраструктуры',
@@ -1361,6 +1363,7 @@ export const initiativeNodes: InitiativeNode[] = [
     description:
       'Интеграция цифровых двойников и сервисов диспетчеризации для безопасного дистанционного управления фонда скважин.',
     domains: ['real-time-monitoring', 'workover-automation'],
+    startDate: '2024-11-18',
     plannedModuleIds: [
       'module-dtwin-optimizer',
       'module-dtwin-remote-ops',
@@ -1420,6 +1423,7 @@ export const initiativeNodes: InitiativeNode[] = [
     description:
       'Запуск цифрового двойника удалённого промысла с круглосуточным мониторингом телеметрии и сценарным моделированием отклонений.',
     domains: ['real-time-monitoring', 'data-preparation'],
+    startDate: '2024-10-21',
     plannedModuleIds: [
       'module-dtwin-monitoring',
       'module-dtwin-optimizer',
@@ -1479,6 +1483,7 @@ export const initiativeNodes: InitiativeNode[] = [
     description:
       'Расширение экономического блока INFRAPLAN для поддержки сделок M&A и стресс-тестов финансовых сценариев.',
     domains: ['economic-evaluation', 'development-scenarios'],
+    startDate: '2024-08-19',
     plannedModuleIds: ['module-infraplan-economics', 'module-infraplan-datahub'],
     requiredSkills: [
       'Финансовое моделирование M&A',

--- a/src/types/initiativeCreation.ts
+++ b/src/types/initiativeCreation.ts
@@ -69,4 +69,5 @@ export type InitiativeCreationRequest = {
   roles: InitiativeCreationRoleDraft[];
   workItems: InitiativeCreationWorkItemDraft[];
   approvalStages: InitiativeCreationApprovalStageDraft[];
+  startDate?: string;
 };

--- a/src/utils/initiativePlanner.ts
+++ b/src/utils/initiativePlanner.ts
@@ -49,6 +49,7 @@ export function buildCreationRequestFromInitiative(
     status: initiative.status,
     domains: [...initiative.domains],
     potentialModules: moduleSelections,
+    startDate: initiative.startDate,
     customer: {
       companies: [...(initiative.customer?.companies ?? [])],
       units: [...(initiative.customer?.units ?? [])],


### PR DESCRIPTION
## Summary
- add configurable initiative start date and assignment start mode controls in the creation modal
- propagate initiative start dates through planner data and preview gantt data
- extend the initiative gantt chart with explicit period selectors and view ranges

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691253aca738833289cdcddb6b3b7f68)