### PR TITLE
Fix Gantt task width scaling

### DIFF
--- a/src/components/GanttTimeline.module.css
+++ b/src/components/GanttTimeline.module.css
@@ -77,8 +77,8 @@
   border-radius: 10px;
   border: 1px solid transparent;
   box-shadow: 0 8px 18px rgba(17, 43, 96, 0.12);
-  min-width: 92px;
-  max-width: 280px;
+  min-width: 0;
+  max-width: none;
 }
 
 .task[data-kind='project'] {


### PR DESCRIPTION
## Summary
- remove fixed min/max width from Gantt timeline tasks so their rendered length follows the computed duration

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912607b4cf8833299a8814649ea7cdd)