### PR TITLE
feat: add Excel import and export for experts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "react-dom": "18.3.1",
         "react-force-graph": "1.44.2",
         "react-force-graph-2d": "^1.29.0",
-        "sql.js": "1.11.0"
+        "sql.js": "1.11.0",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@eslint/js": "9.15.0",
@@ -2490,6 +2491,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/aframe": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/aframe/-/aframe-1.7.1.tgz",
@@ -3184,6 +3194,19 @@
         "follow-redirects": "^1.15.6"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3232,6 +3255,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -3439,6 +3471,18 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -4809,6 +4853,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fresh": {
@@ -7714,6 +7767,18 @@
       "integrity": "sha512-GsLUDU3vhOo14Pd5ME0y2te49JQyby6HuoCuadevEV+CGgTUjmYRrm7B7lhRyzOgrmcWmspUfyjNb6sOAEqdsA==",
       "license": "MIT"
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -9119,6 +9184,24 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -9202,6 +9285,27 @@
         "is-function": "^1.0.1",
         "parse-headers": "^2.0.0",
         "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml-parse-from-string": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react-dom": "18.3.1",
     "react-force-graph": "1.44.2",
     "react-force-graph-2d": "^1.29.0",
-    "sql.js": "1.11.0"
+    "sql.js": "1.11.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/js": "9.15.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,7 @@ import {
   reuseIndexHistory,
   type ArtifactNode,
   type DomainNode,
+  type ExpertCompetencyRecord,
   type ExpertProfile,
   type ExpertSkill,
   type GraphLink,
@@ -3597,6 +3598,24 @@ function buildExpertFromDraft(
   const domains = deduplicateNonEmpty(draft.domains).filter((id) => options.domainIdSet.has(id));
   const modules = deduplicateNonEmpty(draft.modules).filter((id) => options.moduleIdSet.has(id));
   const competencies = deduplicateNonEmpty(draft.competencies);
+  const competencyRecordLookup = new Map<string, ExpertCompetencyRecord>();
+  (draft.competencyRecords ?? []).forEach((record) => {
+    const name = record.name.trim();
+    if (!name || competencyRecordLookup.has(name)) {
+      return;
+    }
+    const normalized: ExpertCompetencyRecord = { name };
+    if (record.level) {
+      normalized.level = record.level;
+    }
+    if (record.proofStatus) {
+      normalized.proofStatus = record.proofStatus;
+    }
+    competencyRecordLookup.set(name, normalized);
+  });
+  const competencyRecords = competencies.map(
+    (name) => competencyRecordLookup.get(name) ?? { name }
+  );
   const consultingSkills = deduplicateNonEmpty(draft.consultingSkills);
   const softSkills = deduplicateNonEmpty(draft.softSkills ?? []);
   const focusAreas = deduplicateNonEmpty(draft.focusAreas);
@@ -3626,6 +3645,7 @@ function buildExpertFromDraft(
     domains,
     modules,
     competencies,
+    competencyRecords,
     consultingSkills,
     softSkills,
     focusAreas,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1161,7 +1161,7 @@ function App() {
       markGraphDirty();
       showAdminNotice('success', `Сотрудник «${profile.fullName}» создан.`);
     },
-    [domainIdSet, expertProfiles, markGraphDirty, moduleIdSet, showAdminNotice]
+    [domainIdSet, expertProfiles, markGraphDirty, moduleIdSet, moduleNameMap, showAdminNotice]
   );
   const handleUpdateExpert = useCallback(
     (expertId: string, draft: ExpertDraftPayload) => {
@@ -1184,7 +1184,7 @@ function App() {
       markGraphDirty();
       showAdminNotice('success', `Сотрудник «${updated.fullName}» обновлён.`);
     },
-    [domainIdSet, expertProfiles, markGraphDirty, moduleIdSet, showAdminNotice]
+    [domainIdSet, expertProfiles, markGraphDirty, moduleIdSet, moduleNameMap, showAdminNotice]
   );
   const handleDeleteExpert = useCallback(
     (expertId: string) => {

--- a/src/components/AdminPanel.module.css
+++ b/src/components/AdminPanel.module.css
@@ -203,6 +203,66 @@
   align-items: center;
 }
 
+.importToolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.importHint {
+  margin: 0;
+}
+
+.importError {
+  margin: 0;
+  color: var(--color-typo-alert);
+}
+
+.importModal {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 640px;
+}
+
+.importSummary {
+  display: grid;
+  gap: 8px;
+}
+
+.importIssues {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.importWarningList {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.importWarningList li {
+  margin-bottom: 4px;
+}
+
+.importSkillCard {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 16px;
+  border: 1px solid var(--color-bg-border);
+  border-radius: 12px;
+  background-color: var(--color-bg-ghost);
+}
+
+.importSkillActions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .listStack {
   display: flex;
   flex-direction: column;

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -11,6 +11,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   type ArtifactNode,
   type DomainNode,
+  type ExpertCompetencyRecord,
   type ExpertProfile,
   type ExpertSkill,
   type LibraryDependency,
@@ -28,6 +29,7 @@ import {
   type UserStats,
   evidenceStatuses,
   getSkillsByRole,
+  registerRoleCompetency,
   registerSkillDefinition,
   skillLevels
 } from '../data';
@@ -36,6 +38,7 @@ import {
   exportExpertToExcel,
   parseExpertWorkbook,
   type ExpertImportResult,
+  type MissingCompetencyEntry,
   type MissingSkillEntry
 } from '../utils/expertExcel';
 import { useSkillRegistryVersion } from '../utils/useSkillRegistryVersion';
@@ -3042,6 +3045,7 @@ type ExpertImportDialogState = {
   draft: ExpertDraftPayload;
   result: ExpertImportResult;
   pendingSkills: MissingSkillEntry[];
+  pendingCompetencies: MissingCompetencyEntry[];
   fileName: string;
 };
 
@@ -3099,9 +3103,11 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
         ...result,
         errors: [...result.errors],
         warnings: [...result.warnings],
-        missingHardSkills: [...result.missingHardSkills]
+        missingHardSkills: [...result.missingHardSkills],
+        missingCompetencies: [...result.missingCompetencies]
       },
       pendingSkills: [...result.missingHardSkills],
+      pendingCompetencies: [...result.missingCompetencies],
       fileName
     });
     setIsImportModalOpen(true);
@@ -3190,9 +3196,19 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
         (item) => item.requestedId !== entry.requestedId
       );
       const filteredSkills = prev.draft.skills.filter((skill) => skill.id !== entry.requestedId);
+      const nextCompetencies = updateCompetenciesFromSkills(
+        filteredSkills,
+        prev.draft.competencies,
+        prev.draft.competencyRecords ?? []
+      );
       return {
         ...prev,
-        draft: { ...prev.draft, skills: filteredSkills },
+        draft: {
+          ...prev.draft,
+          skills: filteredSkills,
+          competencies: nextCompetencies.names,
+          competencyRecords: nextCompetencies.records
+        },
         pendingSkills,
         result: {
           ...prev.result,
@@ -3200,6 +3216,76 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
           warnings: [
             ...prev.result.warnings,
             `Навык «${entry.definition.name}» будет исключён из профиля.`
+          ]
+        }
+      };
+    });
+  };
+
+  const handleRegisterMissingCompetency = (entry: MissingCompetencyEntry) => {
+    registerRoleCompetency(entry.roleTitle, entry.competencyName);
+    setImportState((prev) => {
+      if (!prev) {
+        return prev;
+      }
+      const pendingCompetencies = prev.pendingCompetencies.filter(
+        (item) =>
+          item.competencyName !== entry.competencyName || item.roleTitle !== entry.roleTitle
+      );
+      const remainingMissing = prev.result.missingCompetencies.filter(
+        (item) =>
+          item.competencyName !== entry.competencyName || item.roleTitle !== entry.roleTitle
+      );
+      return {
+        ...prev,
+        pendingCompetencies,
+        result: {
+          ...prev.result,
+          missingCompetencies: remainingMissing,
+          warnings: [
+            ...prev.result.warnings,
+            `Компетенция «${entry.competencyName}» добавлена в базу роли «${
+              entry.roleTitle || 'роль не указана'
+            }» и будет импортирована.`
+          ]
+        }
+      };
+    });
+  };
+
+  const handleSkipMissingCompetency = (entry: MissingCompetencyEntry) => {
+    setImportState((prev) => {
+      if (!prev) {
+        return prev;
+      }
+      const pendingCompetencies = prev.pendingCompetencies.filter(
+        (item) =>
+          item.competencyName !== entry.competencyName || item.roleTitle !== entry.roleTitle
+      );
+      const remainingMissing = prev.result.missingCompetencies.filter(
+        (item) =>
+          item.competencyName !== entry.competencyName || item.roleTitle !== entry.roleTitle
+      );
+      const filteredCompetencies = prev.draft.competencies.filter(
+        (competency) => competency !== entry.competencyName
+      );
+      const filteredRecords = (prev.draft.competencyRecords ?? []).filter(
+        (record) => record.name !== entry.competencyName
+      );
+      return {
+        ...prev,
+        draft: {
+          ...prev.draft,
+          competencies: filteredCompetencies,
+          competencyRecords: filteredRecords
+        },
+        pendingCompetencies,
+        result: {
+          ...prev.result,
+          missingCompetencies: remainingMissing,
+          warnings: [
+            ...prev.result.warnings,
+            `Компетенция «${entry.competencyName}» будет исключена из профиля.`
           ]
         }
       };
@@ -3316,21 +3402,48 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
   }, [draft.languages, languages]);
 
   const updateCompetenciesFromSkills = useCallback(
-    (skills: ExpertSkill[], currentCompetencies: string[]): string[] => {
-      if (!hardSkillDefinitions.length) {
-        return currentCompetencies;
-      }
+    (
+      skills: ExpertSkill[],
+      currentCompetencies: string[],
+      currentRecords: ExpertCompetencyRecord[]
+    ): { names: string[]; records: ExpertCompetencyRecord[] } => {
       const activeNames = new Set<string>();
+      const derivedRecords = new Map<string, ExpertCompetencyRecord>();
       skills.forEach((skill) => {
         const definition = hardSkillMap.get(skill.id);
-        if (definition) {
-          activeNames.add(definition.name);
+        if (!definition) {
+          return;
+        }
+        activeNames.add(definition.name);
+        derivedRecords.set(definition.name, {
+          name: definition.name,
+          level: skill.level,
+          proofStatus: skill.proofStatus
+        });
+      });
+
+      const preserved = currentCompetencies.filter((competency) => !hardSkillNameSet.has(competency));
+      const names = mergeStringCollections(preserved, Array.from(activeNames));
+
+      const recordMap = new Map<string, ExpertCompetencyRecord>();
+      currentRecords.forEach((record) => {
+        if (!recordMap.has(record.name)) {
+          recordMap.set(record.name, { ...record });
         }
       });
-      const preserved = currentCompetencies.filter((competency) => !hardSkillNameSet.has(competency));
-      return mergeStringCollections(preserved, Array.from(activeNames));
+
+      const records = names.map((name) => {
+        const derived = derivedRecords.get(name);
+        if (derived) {
+          return derived;
+        }
+        const existing = recordMap.get(name);
+        return existing ? { ...existing } : { name };
+      });
+
+      return { names, records };
     },
-    [hardSkillDefinitions.length, hardSkillMap, hardSkillNameSet]
+    [hardSkillMap, hardSkillNameSet]
   );
 
   const areArraysEqual = (first: string[], second: string[]): boolean => {
@@ -3338,6 +3451,23 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
       return false;
     }
     return first.every((value, index) => value === second[index]);
+  };
+
+  const areCompetencyRecordsEqual = (
+    first: ExpertCompetencyRecord[],
+    second: ExpertCompetencyRecord[]
+  ): boolean => {
+    if (first.length !== second.length) {
+      return false;
+    }
+    return first.every((record, index) => {
+      const other = second[index];
+      return (
+        record.name === other.name &&
+        record.level === other.level &&
+        record.proofStatus === other.proofStatus
+      );
+    });
   };
 
   const handleHardSkillToggle = (definition: ReturnType<typeof getSkillsByRole>[number], enabled: boolean) => {
@@ -3357,13 +3487,31 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
               availableFte: 0
             }
           ];
-      const nextCompetencies = updateCompetenciesFromSkills(nextSkills, draft.competencies);
-      onChange({ ...draft, skills: nextSkills, competencies: nextCompetencies });
+      const nextCompetencies = updateCompetenciesFromSkills(
+        nextSkills,
+        draft.competencies,
+        draft.competencyRecords ?? []
+      );
+      onChange({
+        ...draft,
+        skills: nextSkills,
+        competencies: nextCompetencies.names,
+        competencyRecords: nextCompetencies.records
+      });
       return;
     }
     const nextSkills = draft.skills.filter((entry) => entry.id !== definition.id);
-    const nextCompetencies = updateCompetenciesFromSkills(nextSkills, draft.competencies);
-    onChange({ ...draft, skills: nextSkills, competencies: nextCompetencies });
+    const nextCompetencies = updateCompetenciesFromSkills(
+      nextSkills,
+      draft.competencies,
+      draft.competencyRecords ?? []
+    );
+    onChange({
+      ...draft,
+      skills: nextSkills,
+      competencies: nextCompetencies.names,
+      competencyRecords: nextCompetencies.records
+    });
   };
 
   const handleHardSkillLevelChange = (skillId: string, level: SkillLevel) => {
@@ -3375,7 +3523,17 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
           }
         : skill
     );
-    onChange({ ...draft, skills: nextSkills });
+    const nextCompetencies = updateCompetenciesFromSkills(
+      nextSkills,
+      draft.competencies,
+      draft.competencyRecords ?? []
+    );
+    onChange({
+      ...draft,
+      skills: nextSkills,
+      competencies: nextCompetencies.names,
+      competencyRecords: nextCompetencies.records
+    });
   };
 
   const handleHardSkillEvidenceChange = (skillId: string, status: SkillEvidenceStatus) => {
@@ -3387,7 +3545,17 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
           }
         : skill
     );
-    onChange({ ...draft, skills: nextSkills });
+    const nextCompetencies = updateCompetenciesFromSkills(
+      nextSkills,
+      draft.competencies,
+      draft.competencyRecords ?? []
+    );
+    onChange({
+      ...draft,
+      skills: nextSkills,
+      competencies: nextCompetencies.names,
+      competencyRecords: nextCompetencies.records
+    });
   };
 
   const handleSoftSkillToggle = (skillName: string, enabled: boolean) => {
@@ -3404,9 +3572,20 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
     if (!hardSkillDefinitions.length) {
       return;
     }
-    const recalculated = updateCompetenciesFromSkills(draft.skills, draft.competencies);
-    if (!areArraysEqual(recalculated, draft.competencies)) {
-      onChange({ ...draft, competencies: recalculated });
+    const recalculated = updateCompetenciesFromSkills(
+      draft.skills,
+      draft.competencies,
+      draft.competencyRecords ?? []
+    );
+    if (
+      !areArraysEqual(recalculated.names, draft.competencies) ||
+      !areCompetencyRecordsEqual(recalculated.records, draft.competencyRecords ?? [])
+    ) {
+      onChange({
+        ...draft,
+        competencies: recalculated.names,
+        competencyRecords: recalculated.records
+      });
     }
   }, [draft, hardSkillDefinitions.length, onChange, updateCompetenciesFromSkills]);
 
@@ -4026,6 +4205,54 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
                 ))}
               </div>
             )}
+            {importState.pendingCompetencies.length > 0 && (
+              <div className={styles.importIssues}>
+                <Text size="s" weight="semibold">
+                  Новые компетенции
+                </Text>
+                <Text size="xs" view="secondary">
+                  Эти компетенции отсутствуют в базе для указанной роли. Добавьте их или исключите из импорта.
+                </Text>
+                {importState.pendingCompetencies.map((entry, index) => (
+                  <div
+                    key={`${entry.competencyName}-${entry.roleTitle}-${entry.rowNumber}-${index}`}
+                    className={styles.importSkillCard}
+                  >
+                    <Text size="s" weight="semibold">
+                      {entry.competencyName}
+                    </Text>
+                    <Text size="xs" view="secondary">
+                      Роль: {entry.roleTitle || 'не указана'}
+                    </Text>
+                    {entry.levelLabel && (
+                      <Text size="xs" view="secondary">
+                        Уровень: {entry.levelLabel}
+                      </Text>
+                    )}
+                    {entry.proofLabel && (
+                      <Text size="xs" view="secondary">
+                        Подтверждение: {entry.proofLabel}
+                      </Text>
+                    )}
+                    <Text size="xs" view="secondary">Строка в файле: {entry.rowNumber}</Text>
+                    <div className={styles.importSkillActions}>
+                      <Button
+                        size="xs"
+                        view="primary"
+                        label="Добавить в базу"
+                        onClick={() => handleRegisterMissingCompetency(entry)}
+                      />
+                      <Button
+                        size="xs"
+                        view="ghost"
+                        label="Не импортировать"
+                        onClick={() => handleSkipMissingCompetency(entry)}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
             <div className={styles.submitButtons}>
               <Button size="s" view="ghost" label="Отмена" onClick={handleImportClose} />
               <Button
@@ -4033,7 +4260,9 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
                 view="primary"
                 label="Импортировать"
                 disabled={
-                  importState.result.errors.length > 0 || importState.pendingSkills.length > 0
+                  importState.result.errors.length > 0 ||
+                  importState.pendingSkills.length > 0 ||
+                  importState.pendingCompetencies.length > 0
                 }
                 onClick={handleImportApply}
               />
@@ -4051,6 +4280,7 @@ function cloneExpertDraft(draft: ExpertDraftPayload): ExpertDraftPayload {
     domains: [...draft.domains],
     modules: [...draft.modules],
     competencies: [...draft.competencies],
+    competencyRecords: (draft.competencyRecords ?? []).map((record) => ({ ...record })),
     consultingSkills: [...draft.consultingSkills],
     softSkills: [...draft.softSkills],
     focusAreas: [...draft.focusAreas],
@@ -4076,6 +4306,7 @@ function createDefaultExpertDraft(): ExpertDraftPayload {
     domains: [],
     modules: [],
     competencies: [],
+    competencyRecords: [],
     consultingSkills: [],
     softSkills: [],
     focusAreas: [],
@@ -4098,6 +4329,7 @@ function expertToDraft(expert: ExpertProfile): ExpertDraftPayload {
     domains: [...expert.domains],
     modules: [...expert.modules],
     competencies: [...expert.competencies],
+    competencyRecords: (expert.competencyRecords ?? []).map((record) => ({ ...record })),
     consultingSkills: [...expert.consultingSkills],
     softSkills: Array.isArray(expert.softSkills) ? [...expert.softSkills] : [],
     focusAreas: [...expert.focusAreas],

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -1,12 +1,13 @@
 import { Button } from '@consta/uikit/Button';
 import { Combobox } from '@consta/uikit/Combobox';
 import { Collapse } from '@consta/uikit/Collapse';
+import { Modal } from '@consta/uikit/Modal';
 import { Select } from '@consta/uikit/Select';
 import { Switch } from '@consta/uikit/Switch';
 import { Tabs } from '@consta/uikit/Tabs';
 import { Text } from '@consta/uikit/Text';
 import { TextField } from '@consta/uikit/TextField';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   type ArtifactNode,
   type DomainNode,
@@ -27,8 +28,17 @@ import {
   type UserStats,
   evidenceStatuses,
   getSkillsByRole,
+  registerSkillDefinition,
   skillLevels
 } from '../data';
+import type { ExpertDraftPayload } from '../types/expert';
+import {
+  exportExpertToExcel,
+  parseExpertWorkbook,
+  type ExpertImportResult,
+  type MissingSkillEntry
+} from '../utils/expertExcel';
+import { useSkillRegistryVersion } from '../utils/useSkillRegistryVersion';
 import styles from './AdminPanel.module.css';
 
 export type ModuleDraftPayload = {
@@ -89,7 +99,7 @@ export type ArtifactDraftPayload = {
   sampleUrl: string;
 };
 
-export type ExpertDraftPayload = Omit<ExpertProfile, 'id'>;
+export type { ExpertDraftPayload } from '../types/expert';
 
 type AdminPanelProps = {
   modules: ModuleNode[];
@@ -850,6 +860,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
           <ExpertForm
             mode={selectedExpertId === '__new__' ? 'create' : 'edit'}
             draft={expertDraft}
+            expertId={selectedExpertId === '__new__' ? null : selectedExpertId}
             domainItems={parentDomainIds}
             domainLabelMap={domainLabelMap}
             moduleLabelMap={moduleLabelMap}
@@ -3014,6 +3025,7 @@ const ArtifactForm: React.FC<ArtifactFormProps> = ({
 type ExpertFormProps = {
   mode: 'create' | 'edit';
   draft: ExpertDraftPayload;
+  expertId: string | null;
   domainItems: string[];
   domainLabelMap: Record<string, string>;
   moduleLabelMap: Record<string, string>;
@@ -3026,9 +3038,17 @@ type ExpertFormProps = {
   onDelete?: () => void;
 };
 
+type ExpertImportDialogState = {
+  draft: ExpertDraftPayload;
+  result: ExpertImportResult;
+  pendingSkills: MissingSkillEntry[];
+  fileName: string;
+};
+
 const ExpertForm: React.FC<ExpertFormProps> = ({
   mode,
   draft,
+  expertId,
   domainItems,
   domainLabelMap,
   moduleLabelMap,
@@ -3040,6 +3060,13 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
   onSubmit,
   onDelete
 }) => {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [importState, setImportState] = useState<ExpertImportDialogState | null>(null);
+  const [isImportModalOpen, setIsImportModalOpen] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+  const skillRegistryVersion = useSkillRegistryVersion();
+
   const handleDraftChange = <Key extends keyof ExpertDraftPayload>(
     key: Key,
     value: ExpertDraftPayload[Key]
@@ -3054,6 +3081,154 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
       .filter((item) => item.length > 0);
 
   const formatList = (values: string[]): string => values.join('\n');
+
+  const buildExportFileName = () => {
+    const baseName = draft.fullName.trim() || 'expert-profile';
+    const normalized = baseName
+      .replace(/[^0-9A-Za-zА-Яа-яЁё\s-]+/g, '')
+      .trim()
+      .replace(/\s+/g, '_');
+    return `${normalized || 'expert-profile'}.xlsx`;
+  };
+
+  const openImportPreview = (result: ExpertImportResult, fileName: string) => {
+    const normalizedDraft = cloneExpertDraft(result.draft);
+    setImportState({
+      draft: normalizedDraft,
+      result: {
+        ...result,
+        errors: [...result.errors],
+        warnings: [...result.warnings],
+        missingHardSkills: [...result.missingHardSkills]
+      },
+      pendingSkills: [...result.missingHardSkills],
+      fileName
+    });
+    setIsImportModalOpen(true);
+  };
+
+  const handleExpertExport = () => {
+    try {
+      const buffer = exportExpertToExcel({
+        draft,
+        expertId,
+        domainLabelMap,
+        moduleLabelMap
+      });
+      const blob = new Blob([buffer], {
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = buildExportFileName();
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      setImportError('Не удалось экспортировать профиль. Попробуйте ещё раз.');
+      console.error('Failed to export expert profile', error);
+    }
+  };
+
+  const handleImportClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleImportClose = () => {
+    setIsImportModalOpen(false);
+    setImportState(null);
+  };
+
+  const handleImportApply = () => {
+    if (!importState) {
+      return;
+    }
+    onChange(importState.draft);
+    setImportState(null);
+    setIsImportModalOpen(false);
+    setImportError(null);
+  };
+
+  const handleRegisterMissingSkill = (entry: MissingSkillEntry) => {
+    registerSkillDefinition(entry.definition);
+    setImportState((prev) => {
+      if (!prev) {
+        return prev;
+      }
+      const pendingSkills = prev.pendingSkills.filter(
+        (item) => item.requestedId !== entry.requestedId
+      );
+      const remainingMissing = prev.result.missingHardSkills.filter(
+        (item) => item.requestedId !== entry.requestedId
+      );
+      return {
+        ...prev,
+        pendingSkills,
+        result: {
+          ...prev.result,
+          missingHardSkills: remainingMissing,
+          warnings: [
+            ...prev.result.warnings,
+            `Навык «${entry.definition.name}» добавлен в базу и будет импортирован.`
+          ]
+        }
+      };
+    });
+  };
+
+  const handleSkipMissingSkill = (entry: MissingSkillEntry) => {
+    setImportState((prev) => {
+      if (!prev) {
+        return prev;
+      }
+      const pendingSkills = prev.pendingSkills.filter(
+        (item) => item.requestedId !== entry.requestedId
+      );
+      const remainingMissing = prev.result.missingHardSkills.filter(
+        (item) => item.requestedId !== entry.requestedId
+      );
+      const filteredSkills = prev.draft.skills.filter((skill) => skill.id !== entry.requestedId);
+      return {
+        ...prev,
+        draft: { ...prev.draft, skills: filteredSkills },
+        pendingSkills,
+        result: {
+          ...prev.result,
+          missingHardSkills: remainingMissing,
+          warnings: [
+            ...prev.result.warnings,
+            `Навык «${entry.definition.name}» будет исключён из профиля.`
+          ]
+        }
+      };
+    });
+  };
+
+  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const [file] = event.target.files ?? [];
+    if (!file) {
+      return;
+    }
+    event.target.value = '';
+    setImportError(null);
+    setIsImporting(true);
+    try {
+      const buffer = await file.arrayBuffer();
+      const result = parseExpertWorkbook({
+        buffer,
+        domainLabelMap,
+        moduleLabelMap
+      });
+      openImportPreview(result, file.name);
+    } catch (error) {
+      setImportError('Не удалось обработать файл. Проверьте формат и попробуйте снова.');
+      console.error('Failed to import expert profile', error);
+    } finally {
+      setIsImporting(false);
+    }
+  };
 
   const handleExperienceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const numeric = Number(event.target.value);
@@ -3078,18 +3253,20 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
   );
 
   const hardSkillDefinitions = useMemo(() => {
+    void skillRegistryVersion;
     if (!selectedRole) {
       return [] as ReturnType<typeof getSkillsByRole>;
     }
     return getSkillsByRole(selectedRole).filter((definition) => definition.category === 'hard');
-  }, [selectedRole]);
+  }, [selectedRole, skillRegistryVersion]);
 
   const softSkillDefinitions = useMemo(() => {
+    void skillRegistryVersion;
     if (!selectedRole) {
       return [] as ReturnType<typeof getSkillsByRole>;
     }
     return getSkillsByRole(selectedRole).filter((definition) => definition.category === 'soft');
-  }, [selectedRole]);
+  }, [selectedRole, skillRegistryVersion]);
 
   const hardSkillMap = useMemo(() => {
     const map = new Map<string, ReturnType<typeof getSkillsByRole>[number]>();
@@ -3138,23 +3315,23 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
     return [...base, CREATE_LANGUAGE_OPTION];
   }, [draft.languages, languages]);
 
-  const updateCompetenciesFromSkills = (
-    skills: ExpertSkill[],
-    currentCompetencies: string[]
-  ): string[] => {
-    if (!hardSkillDefinitions.length) {
-      return currentCompetencies;
-    }
-    const activeNames = new Set<string>();
-    skills.forEach((skill) => {
-      const definition = hardSkillMap.get(skill.id);
-      if (definition) {
-        activeNames.add(definition.name);
+  const updateCompetenciesFromSkills = useCallback(
+    (skills: ExpertSkill[], currentCompetencies: string[]): string[] => {
+      if (!hardSkillDefinitions.length) {
+        return currentCompetencies;
       }
-    });
-    const preserved = currentCompetencies.filter((competency) => !hardSkillNameSet.has(competency));
-    return mergeStringCollections(preserved, Array.from(activeNames));
-  };
+      const activeNames = new Set<string>();
+      skills.forEach((skill) => {
+        const definition = hardSkillMap.get(skill.id);
+        if (definition) {
+          activeNames.add(definition.name);
+        }
+      });
+      const preserved = currentCompetencies.filter((competency) => !hardSkillNameSet.has(competency));
+      return mergeStringCollections(preserved, Array.from(activeNames));
+    },
+    [hardSkillDefinitions.length, hardSkillMap, hardSkillNameSet]
+  );
 
   const areArraysEqual = (first: string[], second: string[]): boolean => {
     if (first.length !== second.length) {
@@ -3231,10 +3408,36 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
     if (!areArraysEqual(recalculated, draft.competencies)) {
       onChange({ ...draft, competencies: recalculated });
     }
-  }, [draft.skills, draft.competencies, hardSkillDefinitions, onChange]);
+  }, [draft, hardSkillDefinitions.length, onChange, updateCompetenciesFromSkills]);
 
   return (
     <div className={styles.formBody}>
+      <div className={styles.importToolbar}>
+        <Button
+          size="s"
+          view="ghost"
+          label="Импорт из Excel"
+          disabled={isImporting}
+          onClick={handleImportClick}
+        />
+        <Button size="s" view="ghost" label="Экспорт в Excel" onClick={handleExpertExport} />
+        <Text size="xs" view="secondary" className={styles.importHint}>
+          Используйте Excel-шаблон для обмена профилями сотрудников.
+        </Text>
+      </div>
+      {importError && (
+        <Text size="xs" view="alert" className={styles.importError}>
+          {importError}
+        </Text>
+      )}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".xlsx"
+        hidden
+        onChange={handleFileChange}
+      />
+
       <div className={styles.formHeader}>
         <div>
           <Text size="l" weight="semibold" className={styles.formTitle}>
@@ -3703,9 +3906,167 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
           />
         </div>
       </div>
+
+      <Modal isOpen={isImportModalOpen && Boolean(importState)} hasOverlay onClose={handleImportClose}>
+        {importState && (
+          <div className={styles.importModal}>
+            <Text size="l" weight="semibold">
+              Импорт профиля сотрудника
+            </Text>
+            <div className={styles.importSummary}>
+              <div>
+                <Text size="xs" view="secondary">
+                  Файл
+                </Text>
+                <Text size="s">{importState.fileName}</Text>
+              </div>
+              <div>
+                <Text size="xs" view="secondary">
+                  Имя сотрудника
+                </Text>
+                <Text size="s">{importState.draft.fullName || 'Не указано'}</Text>
+              </div>
+              <div>
+                <Text size="xs" view="secondary">
+                  Количество навыков
+                </Text>
+                <Text size="s">{importState.draft.skills.length}</Text>
+              </div>
+              <div>
+                <Text size="xs" view="secondary">
+                  Домены
+                </Text>
+                <Text size="s">{importState.draft.domains.length}</Text>
+              </div>
+            </div>
+            {importState.result.requestedExpertId && (
+              <Text size="xs" view="secondary">
+                Идентификатор из файла: {importState.result.requestedExpertId}
+              </Text>
+            )}
+            {importState.result.errors.length > 0 && (
+              <div className={styles.importIssues}>
+                <Text size="s" weight="semibold" view="alert">
+                  Обнаружены ошибки
+                </Text>
+                <ul className={styles.importWarningList}>
+                  {importState.result.errors.map((message, index) => (
+                    <li key={`import-error-${index}`}>
+                      <Text size="s" view="alert">
+                        {message}
+                      </Text>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {importState.result.warnings.length > 0 && (
+              <div className={styles.importIssues}>
+                <Text size="s" weight="semibold" view="warning">
+                  Предупреждения
+                </Text>
+                <ul className={styles.importWarningList}>
+                  {importState.result.warnings.map((message, index) => (
+                    <li key={`import-warning-${index}`}>
+                      <Text size="s" view="warning">
+                        {message}
+                      </Text>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {importState.pendingSkills.length > 0 && (
+              <div className={styles.importIssues}>
+                <Text size="s" weight="semibold">
+                  Новые hard skills
+                </Text>
+                <Text size="xs" view="secondary">
+                  Эти навыки отсутствуют в базе. Добавьте их или исключите из импорта.
+                </Text>
+                {importState.pendingSkills.map((entry) => (
+                  <div key={entry.requestedId} className={styles.importSkillCard}>
+                    <Text size="s" weight="semibold">
+                      {entry.definition.name}
+                    </Text>
+                    <Text size="xs" view="secondary">
+                      Категория: {entry.definition.category}, рекомендуемый уровень: {entry.definition.recommendedLevel}
+                    </Text>
+                    {entry.definition.description && (
+                      <Text size="xs" view="secondary">{entry.definition.description}</Text>
+                    )}
+                    <Text size="xs" view="secondary">
+                      Источники:{' '}
+                      {entry.definition.sources.length > 0
+                        ? entry.definition.sources.join(', ')
+                        : 'не указаны'}
+                    </Text>
+                    <Text size="xs" view="secondary">
+                      Роли:{' '}
+                      {entry.definition.roles.length > 0
+                        ? entry.definition.roles.join(', ')
+                        : 'не указаны'}
+                    </Text>
+                    <Text size="xs" view="secondary">Строка в файле: {entry.rowNumber}</Text>
+                    <div className={styles.importSkillActions}>
+                      <Button
+                        size="xs"
+                        view="primary"
+                        label="Добавить в базу"
+                        onClick={() => handleRegisterMissingSkill(entry)}
+                      />
+                      <Button
+                        size="xs"
+                        view="ghost"
+                        label="Не импортировать"
+                        onClick={() => handleSkipMissingSkill(entry)}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+            <div className={styles.submitButtons}>
+              <Button size="s" view="ghost" label="Отмена" onClick={handleImportClose} />
+              <Button
+                size="s"
+                view="primary"
+                label="Импортировать"
+                disabled={
+                  importState.result.errors.length > 0 || importState.pendingSkills.length > 0
+                }
+                onClick={handleImportApply}
+              />
+            </div>
+          </div>
+        )}
+      </Modal>
     </div>
   );
 };
+
+function cloneExpertDraft(draft: ExpertDraftPayload): ExpertDraftPayload {
+  return {
+    ...draft,
+    domains: [...draft.domains],
+    modules: [...draft.modules],
+    competencies: [...draft.competencies],
+    consultingSkills: [...draft.consultingSkills],
+    softSkills: [...draft.softSkills],
+    focusAreas: [...draft.focusAreas],
+    languages: [...draft.languages],
+    notableProjects: [...draft.notableProjects],
+    skills: draft.skills.map((skill) => ({
+      ...skill,
+      artifacts: [...skill.artifacts],
+      evidence: (skill.evidence ?? []).map((entry) => ({
+        ...entry,
+        artifactIds: entry.artifactIds ? [...entry.artifactIds] : undefined
+      })),
+      usage: skill.usage ? { ...skill.usage } : undefined
+    }))
+  };
+}
 
 function createDefaultExpertDraft(): ExpertDraftPayload {
   return {

--- a/src/components/InitiativeCreationModal.tsx
+++ b/src/components/InitiativeCreationModal.tsx
@@ -29,6 +29,7 @@ import {
   buildRoleMatchReports,
   type RolePlanningDraft
 } from '../utils/initiativeMatching';
+import { useSkillRegistryVersion } from '../utils/useSkillRegistryVersion';
 import styles from './InitiativeCreationModal.module.css';
 
 type SelectOption<Value extends string> = {
@@ -557,9 +558,11 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
     createApprovalStageDraft()
   ]);
   const [activeStep, setActiveStep] = useState<CreationStep>('details');
+  const skillRegistryVersion = useSkillRegistryVersion();
   const baseRoleSkillOptions = useMemo<Record<TeamRole, OptionItem[]>>(
     () =>
       roleOptions.reduce((acc, option) => {
+        void skillRegistryVersion;
         const skillOptions = getSkillsByRole(option.value)
           .map((skill) => ({
             id: skill.id,
@@ -570,7 +573,7 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
         acc[option.value] = skillOptions;
         return acc;
       }, {} as Record<TeamRole, OptionItem[]>),
-    []
+    [skillRegistryVersion]
   );
   const createRoleSkillState = useCallback(
     () =>

--- a/src/data.ts
+++ b/src/data.ts
@@ -73,6 +73,12 @@ export type SkillUsage = {
   description?: string;
 };
 
+export type ExpertCompetencyRecord = {
+  name: string;
+  level?: SkillLevel;
+  proofStatus?: SkillEvidenceStatus;
+};
+
 export type ExpertSkill = {
   id: string;
   level: SkillLevel;
@@ -92,6 +98,7 @@ export type ExpertProfile = {
   domains: string[];
   modules: string[];
   competencies: string[];
+  competencyRecords?: ExpertCompetencyRecord[];
   consultingSkills: string[];
   softSkills: string[];
   focusAreas: string[];
@@ -103,6 +110,49 @@ export type ExpertProfile = {
   availability: ExpertAvailability;
   availabilityComment: string;
   skills: ExpertSkill[];
+};
+
+const normalizeRoleTitle = (role: string): string => role.trim().toLowerCase();
+
+const roleCompetencyIndex = new Map<string, Set<string>>();
+
+const addCompetencyToRoleIndex = (roleTitle: string, competency: string) => {
+  const normalizedRole = normalizeRoleTitle(roleTitle);
+  if (!normalizedRole) {
+    return;
+  }
+  const normalizedCompetency = competency.trim();
+  if (!normalizedCompetency) {
+    return;
+  }
+  const current = roleCompetencyIndex.get(normalizedRole) ?? new Set<string>();
+  current.add(normalizedCompetency);
+  roleCompetencyIndex.set(normalizedRole, current);
+};
+
+export const getRoleCompetencies = (roleTitle: string): string[] => {
+  const normalizedRole = normalizeRoleTitle(roleTitle);
+  const values = roleCompetencyIndex.get(normalizedRole);
+  if (!values) {
+    return [];
+  }
+  return Array.from(values).sort((a, b) => a.localeCompare(b, 'ru'));
+};
+
+export const isRoleCompetencyKnown = (roleTitle: string, competency: string): boolean => {
+  const normalizedRole = normalizeRoleTitle(roleTitle);
+  if (!normalizedRole) {
+    return false;
+  }
+  const normalizedCompetency = competency.trim();
+  if (!normalizedCompetency) {
+    return false;
+  }
+  return roleCompetencyIndex.get(normalizedRole)?.has(normalizedCompetency) ?? false;
+};
+
+export const registerRoleCompetency = (roleTitle: string, competency: string): void => {
+  addCompetencyToRoleIndex(roleTitle, competency);
 };
 
 export type InitiativeStatus = 'initiated' | 'in-progress' | 'converted';
@@ -1535,7 +1585,7 @@ export const initiativeNodes: InitiativeNode[] = [
 ];
 
 
- export const experts: ExpertProfile[] = [
+export const experts: ExpertProfile[] = [
   {
     id: 'expert-viktoria-berezhnaya',
     fullName: 'Виктория Бережная',
@@ -2906,6 +2956,11 @@ export const initiatives: Initiative[] = initiativeNodes.map((node, index) => {
     works,
     requirements
   };
+});
+
+experts.forEach((expert) => {
+  expert.competencies.forEach((competency) => addCompetencyToRoleIndex(expert.title, competency));
+  (expert.competencyRecords ?? []).forEach((record) => addCompetencyToRoleIndex(expert.title, record.name));
 });
 
 export { moduleById };

--- a/src/data.ts
+++ b/src/data.ts
@@ -2936,6 +2936,7 @@ export {
   getSkillsByRole,
   getSkillIdsByRole,
   getRolesForSkill,
+  getSkillNameById,
   skillLevels,
   evidenceStatuses,
   registerSkillDefinition,

--- a/src/data.ts
+++ b/src/data.ts
@@ -2937,7 +2937,12 @@ export {
   getSkillIdsByRole,
   getRolesForSkill,
   skillLevels,
-  evidenceStatuses
+  evidenceStatuses,
+  registerSkillDefinition,
+  ensureSkillDefinition,
+  subscribeToSkillRegistry,
+  getSkillRegistryVersion,
+  findSkillByName
 } from './data/skills';
 
 export type {

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -117,7 +117,7 @@ export const evidenceStatuses: EvidenceStatusDescriptor[] = [
   }
 ];
 
-export const skills: Record<string, SkillDefinition> = {
+const initialSkills: Record<string, SkillDefinition> = {
   'requirements-elicitation': {
     id: 'requirements-elicitation',
     name: 'Сбор и анализ требований',
@@ -526,26 +526,129 @@ export const skills: Record<string, SkillDefinition> = {
   }
 };
 
-export const roleToSkillsMap: Record<TeamRole, string[]> = Object.values(skills).reduce(
-  (acc, skill) => {
-    skill.roles.forEach((role) => {
-      if (!acc[role]) {
-        acc[role] = [];
+type SkillListener = () => void;
+
+const skillRegistry: Record<string, SkillDefinition> = {};
+const roleSkillIndex = new Map<TeamRole, Set<string>>();
+
+let roleToSkillsMap: Record<TeamRole, string[]> = {} as Record<TeamRole, string[]>;
+let registryVersion = 0;
+const registryListeners = new Set<SkillListener>();
+
+const rebuildRoleIndex = () => {
+  const next: Record<TeamRole, string[]> = {} as Record<TeamRole, string[]>;
+  roleSkillIndex.forEach((set, role) => {
+    next[role] = Array.from(set).sort((a, b) => a.localeCompare(b, 'ru'));
+  });
+  roleToSkillsMap = next;
+};
+
+const notifyRegistryChange = () => {
+  registryVersion += 1;
+  registryListeners.forEach((listener) => {
+    try {
+      listener();
+    } catch (error) {
+      console.error('Skill registry listener failed', error);
+    }
+  });
+};
+
+const normalizeSkillDefinition = (definition: SkillDefinition): SkillDefinition => {
+  const id = definition.id.trim();
+  const name = definition.name.trim();
+  const description = definition.description.trim();
+  const sources = Array.from(new Set(definition.sources.map((source) => source.trim()))).filter(
+    (source) => source.length > 0
+  ) as SkillSource[];
+  const roles = Array.from(new Set(definition.roles));
+
+  return {
+    ...definition,
+    id,
+    name,
+    description,
+    sources,
+    roles
+  };
+};
+
+const upsertSkillDefinition = (
+  definition: SkillDefinition,
+  options: { silent?: boolean } = {}
+): SkillDefinition => {
+  const normalized = normalizeSkillDefinition(definition);
+  const previous = skillRegistry[normalized.id];
+
+  if (previous) {
+    previous.roles.forEach((role) => {
+      const set = roleSkillIndex.get(role);
+      if (!set) {
+        return;
       }
-      acc[role].push(skill.id);
+      set.delete(previous.id);
+      if (set.size === 0) {
+        roleSkillIndex.delete(role);
+      }
     });
-    return acc;
-  },
-  {} as Record<TeamRole, string[]>
-);
+  }
+
+  skillRegistry[normalized.id] = normalized;
+  normalized.roles.forEach((role) => {
+    const set = roleSkillIndex.get(role) ?? new Set<string>();
+    set.add(normalized.id);
+    roleSkillIndex.set(role, set);
+  });
+
+  rebuildRoleIndex();
+
+  if (!options.silent) {
+    notifyRegistryChange();
+  }
+
+  return normalized;
+};
+
+Object.values(initialSkills).forEach((definition) => {
+  upsertSkillDefinition(definition, { silent: true });
+});
+
+export const skills = skillRegistry;
+
+export { roleToSkillsMap };
+
+export const getSkillRegistryVersion = (): number => registryVersion;
+
+export const subscribeToSkillRegistry = (listener: SkillListener): (() => void) => {
+  registryListeners.add(listener);
+  return () => {
+    registryListeners.delete(listener);
+  };
+};
+
+export const registerSkillDefinition = (definition: SkillDefinition): SkillDefinition =>
+  upsertSkillDefinition(definition);
+
+export const ensureSkillDefinition = (definition: SkillDefinition): SkillDefinition => {
+  const existing = skillRegistry[definition.id];
+  if (existing) {
+    return existing;
+  }
+  return upsertSkillDefinition(definition);
+};
 
 export const getSkillsByRole = (role: TeamRole): SkillDefinition[] => {
   const skillIds = roleToSkillsMap[role] ?? [];
-  return skillIds.map((id) => skills[id]).filter(Boolean);
+  return skillIds.map((id) => skillRegistry[id]).filter((skill): skill is SkillDefinition => Boolean(skill));
 };
 
 export const getSkillIdsByRole = (role: TeamRole): string[] => roleToSkillsMap[role] ?? [];
 
-export const getRolesForSkill = (skillId: string): TeamRole[] => skills[skillId]?.roles ?? [];
+export const getRolesForSkill = (skillId: string): TeamRole[] => skillRegistry[skillId]?.roles ?? [];
 
-export const getSkillNameById = (skillId: string): string | undefined => skills[skillId]?.name;
+export const getSkillNameById = (skillId: string): string | undefined => skillRegistry[skillId]?.name;
+
+export const findSkillByName = (name: string): SkillDefinition | undefined => {
+  const normalized = name.trim().toLowerCase();
+  return Object.values(skillRegistry).find((skill) => skill.name.toLowerCase() === normalized);
+};

--- a/src/types/expert.ts
+++ b/src/types/expert.ts
@@ -1,0 +1,4 @@
+import type { ExpertProfile } from '../data';
+
+export type ExpertDraftPayload = Omit<ExpertProfile, 'id'>;
+

--- a/src/utils/expertExcel.ts
+++ b/src/utils/expertExcel.ts
@@ -1,6 +1,7 @@
 import { read, utils, write } from 'xlsx';
 import {
   type ExpertAvailability,
+  type ExpertCompetencyRecord,
   type ExpertSkill,
   type SkillDefinition,
   type SkillEvidenceStatus,
@@ -10,6 +11,7 @@ import {
   evidenceStatuses,
   findSkillByName,
   getSkillNameById,
+  isRoleCompetencyKnown,
   roleToSkillsMap,
   skills,
   skillLevels
@@ -22,6 +24,10 @@ const PROFILE_SHEET = 'Profile';
 const SKILLS_SHEET = 'Skills';
 const HARD_SKILLS_SHEET = 'Hard навыки';
 const EVIDENCE_SHEET = 'Evidence';
+
+const PROFILE_HEADERS = ['Атрибут', 'Значение', 'Уровень', 'Подтверждение'] as const;
+const COMPETENCY_FIELD_REGEX = /^компетенция\s*\d+$/i;
+const COMPETENCY_FIELD_EN_REGEX = /^competency\s*\d+$/i;
 
 const PROFILE_FIELDS = {
   id: 'ID эксперта',
@@ -197,12 +203,21 @@ export type MissingSkillEntry = {
   requestedName: string;
 };
 
+export type MissingCompetencyEntry = {
+  competencyName: string;
+  roleTitle: string;
+  rowNumber: number;
+  levelLabel?: string;
+  proofLabel?: string;
+};
+
 export type ExpertImportResult = {
   draft: ExpertDraftPayload;
   requestedExpertId?: string;
   errors: string[];
   warnings: string[];
   missingHardSkills: MissingSkillEntry[];
+  missingCompetencies: MissingCompetencyEntry[];
 };
 
 export type ExpertExcelImportParams = {
@@ -219,9 +234,15 @@ export const createExpertWorkbook = ({
 }: ExpertExcelExportParams): Workbook => {
   const workbook = utils.book_new();
 
-  const profileRows: Array<{ Field: string; Value: string }> = (Object.keys(
-    PROFILE_FIELDS
-  ) as ProfileFieldKey[]).map((key) => {
+  const profileMatrix: string[][] = [
+    [...PROFILE_HEADERS]
+  ];
+
+  const profileKeys = (Object.keys(PROFILE_FIELDS) as ProfileFieldKey[]).filter(
+    (key) => key !== 'competencies'
+  );
+
+  profileKeys.forEach((key) => {
     const field = PROFILE_FIELDS[key];
     let value = '';
 
@@ -268,9 +289,6 @@ export const createExpertWorkbook = ({
       case 'moduleIds':
         value = joinMultivalue(draft.modules);
         break;
-      case 'competencies':
-        value = joinMultivalue(draft.competencies);
-        break;
       case 'consultingSkills':
         value = joinMultivalue(draft.consultingSkills);
         break;
@@ -288,12 +306,44 @@ export const createExpertWorkbook = ({
         break;
     }
 
-    return { Field: field, Value: value };
+    profileMatrix.push([field, value, '', '']);
   });
 
-  const profileSheet = utils.json_to_sheet(profileRows, {
-    header: ['Атрибут', 'Значение']
+  const competencyOrder: string[] = [];
+  const seenCompetencies = new Set<string>();
+  draft.competencies.forEach((name) => {
+    const trimmed = name.trim();
+    if (trimmed && !seenCompetencies.has(trimmed)) {
+      seenCompetencies.add(trimmed);
+      competencyOrder.push(trimmed);
+    }
   });
+  (draft.competencyRecords ?? []).forEach((record) => {
+    const trimmed = record.name.trim();
+    if (trimmed && !seenCompetencies.has(trimmed)) {
+      seenCompetencies.add(trimmed);
+      competencyOrder.push(trimmed);
+    }
+  });
+
+  const competencyRecordMap = new Map<string, ExpertCompetencyRecord>();
+  (draft.competencyRecords ?? []).forEach((record) => {
+    const trimmed = record.name.trim();
+    if (trimmed && !competencyRecordMap.has(trimmed)) {
+      competencyRecordMap.set(trimmed, record);
+    }
+  });
+
+  competencyOrder.forEach((name, index) => {
+    const record = competencyRecordMap.get(name);
+    const levelLabel = record?.level ? skillLevelLabelMap[record.level] ?? record.level : '';
+    const proofLabel = record?.proofStatus
+      ? proofStatusLabelMap[record.proofStatus] ?? record.proofStatus
+      : '';
+    profileMatrix.push([`Компетенция ${index + 1}`, name, levelLabel, proofLabel]);
+  });
+
+  const profileSheet = utils.aoa_to_sheet(profileMatrix);
   utils.book_append_sheet(workbook, profileSheet, PROFILE_SHEET);
 
   const skillRows = draft.skills.map((skill) => {
@@ -496,19 +546,30 @@ export const parseExpertWorkbook = ({
   const moduleNameMap = buildNameMap(moduleLabelMap);
 
   const profileValues = new Map<string, string>();
+  const competencyRows: Array<{ name: string; level: string; proof: string; rowNumber: number }> = [];
   if (profileSheet) {
-    const rows = utils.sheet_to_json<[string, string]>(profileSheet, { header: 1, blankrows: false });
+    const rows = utils.sheet_to_json<(string | number)[]>(profileSheet, {
+      header: 1,
+      blankrows: false
+    });
     rows.forEach((row, index) => {
-      const header = String(row[0] ?? '').trim();
-      if (index === 0 && (header === 'Field' || header === 'Атрибут')) {
+      const fieldLabel = String(row[0] ?? '').trim();
+      if (index === 0 && (fieldLabel === 'Field' || fieldLabel === 'Атрибут')) {
         return;
       }
-      const field = row[0];
-      const value = row[1];
-      if (!field) {
+      if (!fieldLabel) {
         return;
       }
-      profileValues.set(String(field).trim(), String(value ?? ''));
+      const value = row[1] !== undefined ? String(row[1]).trim() : '';
+      const level = row[2] !== undefined ? String(row[2]).trim() : '';
+      const proof = row[3] !== undefined ? String(row[3]).trim() : '';
+
+      if (COMPETENCY_FIELD_REGEX.test(fieldLabel) || COMPETENCY_FIELD_EN_REGEX.test(fieldLabel)) {
+        competencyRows.push({ name: value, level, proof, rowNumber: index + 1 });
+        return;
+      }
+
+      profileValues.set(fieldLabel, value);
     });
   }
 
@@ -532,6 +593,90 @@ export const parseExpertWorkbook = ({
   if (!availabilityValue) {
     errors.push('Некорректное значение доступности сотрудника.');
   }
+
+  type CompetencyCandidate = {
+    record: ExpertCompetencyRecord;
+    rowNumber: number;
+    levelLabel?: string;
+    proofLabel?: string;
+  };
+
+  const competencyCandidateMap = new Map<string, CompetencyCandidate>();
+
+  competencyRows.forEach((row) => {
+    const name = row.name.trim();
+    if (!name) {
+      errors.push(
+        `Лист «${PROFILE_SHEET}», строка ${row.rowNumber}: не указано название компетенции.`
+      );
+      return;
+    }
+
+    let level: SkillLevel | undefined;
+    if (row.level) {
+      const parsedLevel = parseSkillLevel(row.level);
+      if (!parsedLevel) {
+        errors.push(
+          `Лист «${PROFILE_SHEET}», строка ${row.rowNumber}: некорректный уровень компетенции «${name}».`
+        );
+      } else {
+        level = parsedLevel;
+      }
+    }
+
+    let proofStatus: SkillEvidenceStatus | undefined;
+    if (row.proof) {
+      const parsedProof = parseProofStatus(row.proof);
+      if (!parsedProof) {
+        errors.push(
+          `Лист «${PROFILE_SHEET}», строка ${row.rowNumber}: некорректный статус подтверждения для компетенции «${name}».`
+        );
+      } else {
+        proofStatus = parsedProof;
+      }
+    }
+
+    if (competencyCandidateMap.has(name)) {
+      return;
+    }
+
+    const record: ExpertCompetencyRecord = { name };
+    if (level) {
+      record.level = level;
+    }
+    if (proofStatus) {
+      record.proofStatus = proofStatus;
+    }
+
+    competencyCandidateMap.set(name, {
+      record,
+      rowNumber: row.rowNumber,
+      levelLabel: level ? skillLevelLabelMap[level] ?? level : undefined,
+      proofLabel: proofStatus ? proofStatusLabelMap[proofStatus] ?? proofStatus : undefined
+    });
+  });
+
+  const competencyCandidates = Array.from(competencyCandidateMap.values());
+  const fallbackCompetencies = splitMultiline(getProfileValue('competencies'));
+
+  const competencyRecordMap = new Map<string, ExpertCompetencyRecord>();
+  const competencyOrder: string[] = [];
+
+  competencyCandidates.forEach((candidate) => {
+    const name = candidate.record.name;
+    if (!competencyRecordMap.has(name)) {
+      competencyOrder.push(name);
+      competencyRecordMap.set(name, candidate.record);
+    }
+  });
+
+  fallbackCompetencies.forEach((name) => {
+    const trimmed = name.trim();
+    if (trimmed && !competencyRecordMap.has(trimmed)) {
+      competencyOrder.push(trimmed);
+      competencyRecordMap.set(trimmed, { name: trimmed });
+    }
+  });
 
   const domainIds = splitMultiline(getProfileValue('domainIds'));
   const domainNames = splitMultiline(getProfileValue('domains'));
@@ -580,7 +725,8 @@ export const parseExpertWorkbook = ({
     notableProjects: splitMultiline(getProfileValue('notableProjects')),
     availability: availabilityValue ?? 'available',
     availabilityComment: getProfileValue('availabilityComment'),
-    competencies: splitMultiline(getProfileValue('competencies')),
+    competencies: competencyOrder,
+    competencyRecords: competencyOrder.map((name) => competencyRecordMap.get(name) ?? { name }),
     consultingSkills: splitMultiline(getProfileValue('consultingSkills')),
     softSkills: splitMultiline(getProfileValue('softSkills')),
     focusAreas: splitMultiline(getProfileValue('focusAreas')),
@@ -592,6 +738,7 @@ export const parseExpertWorkbook = ({
   const requestedExpertId = getProfileValue('id') || undefined;
 
   const missingHardSkills: MissingSkillEntry[] = [];
+  const missingCompetencies: MissingCompetencyEntry[] = [];
   const hardSkillOverrides = new Map<
     string,
     {
@@ -831,12 +978,28 @@ export const parseExpertWorkbook = ({
 
   draft.skills = Array.from(skillMap.values());
 
+  if (competencyCandidates.length > 0) {
+    const roleTitle = draft.title.trim();
+    competencyCandidates.forEach((candidate) => {
+      if (!isRoleCompetencyKnown(roleTitle, candidate.record.name)) {
+        missingCompetencies.push({
+          competencyName: candidate.record.name,
+          roleTitle,
+          rowNumber: candidate.rowNumber,
+          levelLabel: candidate.levelLabel,
+          proofLabel: candidate.proofLabel
+        });
+      }
+    });
+  }
+
   return {
     draft,
     requestedExpertId,
     errors,
     warnings,
-    missingHardSkills
+    missingHardSkills,
+    missingCompetencies
   };
 };
 

--- a/src/utils/expertExcel.ts
+++ b/src/utils/expertExcel.ts
@@ -20,6 +20,7 @@ type Workbook = ReturnType<typeof utils.book_new>;
 
 const PROFILE_SHEET = 'Profile';
 const SKILLS_SHEET = 'Skills';
+const HARD_SKILLS_SHEET = 'Hard навыки';
 const EVIDENCE_SHEET = 'Evidence';
 
 const PROFILE_FIELDS = {
@@ -89,6 +90,10 @@ const SKILL_HEADERS = [
 
 type SkillHeader = (typeof SKILL_HEADERS)[number];
 
+const HARD_SKILL_HEADERS = ['ID навыка', 'Навык', 'Уровень', 'Подтверждение'] as const;
+
+type HardSkillHeader = (typeof HARD_SKILL_HEADERS)[number];
+
 const EVIDENCE_HEADERS = ['Skill ID', 'Status', 'Initiative ID', 'Artifacts', 'Comment'] as const;
 
 type EvidenceHeader = (typeof EVIDENCE_HEADERS)[number];
@@ -108,11 +113,21 @@ const proofStatusMap = evidenceStatuses.reduce<Record<string, SkillEvidenceStatu
   return acc;
 }, {});
 
+const proofStatusLabelMap = evidenceStatuses.reduce<Record<SkillEvidenceStatus, string>>((acc, status) => {
+  acc[status.id as SkillEvidenceStatus] = status.label;
+  return acc;
+}, {} as Record<SkillEvidenceStatus, string>);
+
 const skillLevelMap = skillLevels.reduce<Record<string, SkillLevel>>((acc, descriptor) => {
   acc[descriptor.id] = descriptor.id as SkillLevel;
   acc[descriptor.label.toLowerCase()] = descriptor.id as SkillLevel;
   return acc;
 }, {});
+
+const skillLevelLabelMap = skillLevels.reduce<Record<SkillLevel, string>>((acc, descriptor) => {
+  acc[descriptor.id as SkillLevel] = descriptor.label;
+  return acc;
+}, {} as Record<SkillLevel, string>);
 
 const interestMap: Record<string, ExpertSkill['interest']> = {
   high: 'high',
@@ -310,6 +325,31 @@ export const createExpertWorkbook = ({
   });
   utils.book_append_sheet(workbook, skillsSheet, SKILLS_SHEET);
 
+  const hardSkillRows = draft.skills
+    .map((skill) => {
+      const definition = skills[skill.id];
+      if (definition && definition.category !== 'hard') {
+        return null;
+      }
+
+      const skillName = definition?.name ?? getSkillNameById(skill.id) ?? skill.id;
+
+      return {
+        'ID навыка': skill.id,
+        Навык: skillName,
+        Уровень: skillLevelLabelMap[skill.level] ?? skill.level,
+        Подтверждение: proofStatusLabelMap[skill.proofStatus] ?? skill.proofStatus
+      } as Record<HardSkillHeader, string>;
+    })
+    .filter((row): row is Record<HardSkillHeader, string> => Boolean(row));
+
+  if (hardSkillRows.length > 0) {
+    const hardSkillsSheet = utils.json_to_sheet(hardSkillRows, {
+      header: [...HARD_SKILL_HEADERS]
+    });
+    utils.book_append_sheet(workbook, hardSkillsSheet, HARD_SKILLS_SHEET);
+  }
+
   const evidenceRows: Array<Record<EvidenceHeader, string>> = [];
   draft.skills.forEach((skill) => {
     (skill.evidence ?? []).forEach((entry) => {
@@ -337,6 +377,8 @@ export const exportExpertToExcel = (params: ExpertExcelExportParams): ArrayBuffe
 type SkillSheetRow = Record<SkillHeader, string | number>;
 
 type EvidenceSheetRow = Record<EvidenceHeader, string | number>;
+
+type HardSkillSheetRow = Partial<Record<HardSkillHeader, string | number>>;
 
 const parseSkillCategory = (raw: string): SkillDefinition['category'] | null => {
   const normalized = raw.trim().toLowerCase();
@@ -444,6 +486,7 @@ export const parseExpertWorkbook = ({
 
   const profileSheet = workbook.Sheets[PROFILE_SHEET];
   const skillsSheet = workbook.Sheets[SKILLS_SHEET];
+  const hardSkillsSheet = workbook.Sheets[HARD_SKILLS_SHEET];
   const evidenceSheet = workbook.Sheets[EVIDENCE_SHEET];
 
   const errors: string[] = [];
@@ -549,6 +592,97 @@ export const parseExpertWorkbook = ({
   const requestedExpertId = getProfileValue('id') || undefined;
 
   const missingHardSkills: MissingSkillEntry[] = [];
+  const hardSkillOverrides = new Map<
+    string,
+    {
+      id: string;
+      name: string;
+      level: SkillLevel;
+      proofStatus: SkillEvidenceStatus;
+      definition?: SkillDefinition;
+      rowNumber: number;
+    }
+  >();
+
+  if (hardSkillsSheet) {
+    const rows = utils.sheet_to_json<HardSkillSheetRow>(hardSkillsSheet, { defval: '' });
+    rows.forEach((row, index) => {
+      const rawId = String(row['ID навыка'] ?? '').trim();
+      const rawName = String(row['Навык'] ?? '').trim();
+      if (!rawId && !rawName) {
+        return;
+      }
+
+      let skillId = rawId;
+      let definition = skillId ? skills[skillId] : undefined;
+
+      if (!definition && rawName) {
+        const existing = findSkillByName(rawName);
+        if (existing) {
+          skillId = existing.id;
+          definition = existing;
+        }
+      }
+
+      if (!skillId && rawName) {
+        skillId = slugifySkillId(rawName);
+      }
+
+      if (!skillId) {
+        errors.push(`Лист «${HARD_SKILLS_SHEET}», строка ${index + 2}: не указан идентификатор или название навыка.`);
+        return;
+      }
+
+      const level = parseSkillLevel(String(row['Уровень'] ?? ''));
+      if (!level) {
+        errors.push(
+          `Лист «${HARD_SKILLS_SHEET}», строка ${index + 2}: некорректное значение уровня для «${rawName || skillId}».`
+        );
+        return;
+      }
+
+      const proofStatus = parseProofStatus(String(row['Подтверждение'] ?? ''));
+      if (!proofStatus) {
+        errors.push(
+          `Лист «${HARD_SKILLS_SHEET}», строка ${index + 2}: некорректный статус подтверждения для «${rawName || skillId}».`
+        );
+        return;
+      }
+
+      const resolvedName = rawName || definition?.name || skillId;
+
+      if (!definition) {
+        const existingMissing = missingHardSkills.find((entry) => entry.requestedId === skillId);
+        if (!existingMissing) {
+          missingHardSkills.push({
+            definition: {
+              id: skillId,
+              name: resolvedName,
+              description: resolvedName,
+              category: 'hard',
+              sources: [],
+              recommendedLevel: 'P',
+              evidenceStatus: 'screened',
+              roles: []
+            },
+            requestedId: skillId,
+            requestedName: resolvedName,
+            rowNumber: index + 2
+          });
+        }
+      }
+
+      hardSkillOverrides.set(skillId, {
+        id: skillId,
+        name: resolvedName,
+        level,
+        proofStatus,
+        definition,
+        rowNumber: index + 2
+      });
+    });
+  }
+
   const skillRows = skillsSheet ? utils.sheet_to_json<SkillSheetRow>(skillsSheet, { defval: '' }) : [];
 
   const skillMap = new Map<string, ExpertSkill>();
@@ -613,21 +747,24 @@ export const parseExpertWorkbook = ({
         parseEvidenceStatus(String(row['Definition Evidence Status'] ?? '')) ?? 'screened';
       const roles = parseRoles(String(row['Definition Roles'] ?? ''));
 
-      missingHardSkills.push({
-        definition: {
-          id: skillId,
-          name: resolvedSkillName,
-          description: definitionDescription || resolvedSkillName,
-          category,
-          sources: definitionSources,
-          recommendedLevel,
-          evidenceStatus,
-          roles
-        },
-        requestedId: skillId,
-        requestedName: resolvedSkillName,
-        rowNumber: index + 2
-      });
+      const alreadyMissing = missingHardSkills.find((entry) => entry.requestedId === skillId);
+      if (!alreadyMissing) {
+        missingHardSkills.push({
+          definition: {
+            id: skillId,
+            name: resolvedSkillName,
+            description: definitionDescription || resolvedSkillName,
+            category,
+            sources: definitionSources,
+            recommendedLevel,
+            evidenceStatus,
+            roles
+          },
+          requestedId: skillId,
+          requestedName: resolvedSkillName,
+          rowNumber: index + 2
+        });
+      }
     }
 
     const usage = usageFrom || usageTo || usageDescription ? { from: usageFrom, to: usageTo, description: usageDescription } : undefined;
@@ -644,6 +781,25 @@ export const parseExpertWorkbook = ({
     };
 
     skillMap.set(skillId, expertSkill);
+  });
+
+  hardSkillOverrides.forEach((override) => {
+    const skill = skillMap.get(override.id);
+    if (skill) {
+      skill.level = override.level;
+      skill.proofStatus = override.proofStatus;
+      return;
+    }
+
+    skillMap.set(override.id, {
+      id: override.id,
+      level: override.level,
+      proofStatus: override.proofStatus,
+      evidence: [],
+      artifacts: [],
+      interest: 'medium',
+      availableFte: 0
+    });
   });
 
   if (evidenceSheet) {

--- a/src/utils/expertExcel.ts
+++ b/src/utils/expertExcel.ts
@@ -1,0 +1,653 @@
+import { read, utils, write } from 'xlsx';
+import {
+  type ExpertAvailability,
+  type ExpertSkill,
+  type SkillDefinition,
+  type SkillEvidenceStatus,
+  type SkillLevel,
+  type SkillSource,
+  type TeamRole,
+  evidenceStatuses,
+  findSkillByName,
+  getSkillNameById,
+  roleToSkillsMap,
+  skills,
+  skillLevels
+} from '../data';
+import type { ExpertDraftPayload } from '../types/expert';
+
+type Workbook = ReturnType<typeof utils.book_new>;
+
+const PROFILE_SHEET = 'Profile';
+const SKILLS_SHEET = 'Skills';
+const EVIDENCE_SHEET = 'Evidence';
+
+const PROFILE_FIELDS = {
+  id: 'Expert ID',
+  fullName: 'Full Name',
+  title: 'Title',
+  summary: 'Summary',
+  experienceYears: 'Experience Years',
+  availability: 'Availability',
+  availabilityComment: 'Availability Comment',
+  location: 'Location',
+  contact: 'Contact',
+  languages: 'Languages',
+  domains: 'Domains',
+  domainIds: 'Domain IDs',
+  modules: 'Modules',
+  moduleIds: 'Module IDs',
+  competencies: 'Competencies',
+  consultingSkills: 'Consulting Skills',
+  softSkills: 'Soft Skills',
+  focusAreas: 'Focus Areas',
+  notableProjects: 'Notable Projects'
+} as const;
+
+type ProfileFieldKey = keyof typeof PROFILE_FIELDS;
+
+const SKILL_HEADERS = [
+  'Skill ID',
+  'Skill Name',
+  'Category',
+  'Level',
+  'Proof Status',
+  'Interest',
+  'Available FTE',
+  'Artifacts',
+  'Usage From',
+  'Usage To',
+  'Usage Description',
+  'Definition Description',
+  'Definition Sources',
+  'Definition Recommended Level',
+  'Definition Evidence Status',
+  'Definition Roles'
+] as const;
+
+type SkillHeader = (typeof SKILL_HEADERS)[number];
+
+const EVIDENCE_HEADERS = ['Skill ID', 'Status', 'Initiative ID', 'Artifacts', 'Comment'] as const;
+
+type EvidenceHeader = (typeof EVIDENCE_HEADERS)[number];
+
+const availabilityMap: Record<string, ExpertAvailability> = {
+  available: 'available',
+  'доступен': 'available',
+  partial: 'partial',
+  'частично доступен': 'partial',
+  busy: 'busy',
+  'занят': 'busy'
+};
+
+const proofStatusMap = evidenceStatuses.reduce<Record<string, SkillEvidenceStatus>>((acc, status) => {
+  acc[status.id] = status.id as SkillEvidenceStatus;
+  acc[status.label.toLowerCase()] = status.id as SkillEvidenceStatus;
+  return acc;
+}, {});
+
+const skillLevelMap = skillLevels.reduce<Record<string, SkillLevel>>((acc, descriptor) => {
+  acc[descriptor.id] = descriptor.id as SkillLevel;
+  acc[descriptor.label.toLowerCase()] = descriptor.id as SkillLevel;
+  return acc;
+}, {});
+
+const interestMap: Record<string, ExpertSkill['interest']> = {
+  high: 'high',
+  средний: 'medium',
+  medium: 'medium',
+  low: 'low',
+  высокий: 'high',
+  низкий: 'low'
+};
+
+const skillSourceMap: Record<string, SkillSource> = {
+  sfia: 'SFIA',
+  iiba: 'IIBA',
+  incose: 'INCOSE'
+};
+
+const evidenceStatusMap = evidenceStatuses.reduce<Record<string, SkillEvidenceStatus>>((acc, status) => {
+  acc[status.id] = status.id as SkillEvidenceStatus;
+  acc[status.label.toLowerCase()] = status.id as SkillEvidenceStatus;
+  return acc;
+}, {});
+
+const recommendedLevelMap = skillLevels.reduce<Record<string, SkillLevel>>((acc, descriptor) => {
+  acc[descriptor.id] = descriptor.id as SkillLevel;
+  acc[descriptor.label.toLowerCase()] = descriptor.id as SkillLevel;
+  return acc;
+}, {});
+
+const splitMultiline = (value: string): string[] =>
+  value
+    .split(/\r?\n|,/)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+
+const buildNameMap = (record: Record<string, string>): Map<string, string> => {
+  const map = new Map<string, string>();
+  Object.entries(record).forEach(([id, label]) => {
+    if (!label) {
+      return;
+    }
+    map.set(label.trim().toLowerCase(), id);
+  });
+  return map;
+};
+
+const slugifySkillId = (name: string): string =>
+  name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\u0400-\u04ff]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+
+export type ExpertExcelExportParams = {
+  draft: ExpertDraftPayload;
+  expertId?: string | null;
+  domainLabelMap: Record<string, string>;
+  moduleLabelMap: Record<string, string>;
+};
+
+export type MissingSkillEntry = {
+  definition: SkillDefinition;
+  rowNumber: number;
+  requestedId: string;
+  requestedName: string;
+};
+
+export type ExpertImportResult = {
+  draft: ExpertDraftPayload;
+  requestedExpertId?: string;
+  errors: string[];
+  warnings: string[];
+  missingHardSkills: MissingSkillEntry[];
+};
+
+export type ExpertExcelImportParams = {
+  buffer: ArrayBuffer;
+  domainLabelMap: Record<string, string>;
+  moduleLabelMap: Record<string, string>;
+};
+
+export const createExpertWorkbook = ({
+  draft,
+  expertId,
+  domainLabelMap,
+  moduleLabelMap
+}: ExpertExcelExportParams): Workbook => {
+  const workbook = utils.book_new();
+
+  const profileRows: Array<{ Field: string; Value: string }> = (Object.keys(
+    PROFILE_FIELDS
+  ) as ProfileFieldKey[]).map((key) => {
+    const field = PROFILE_FIELDS[key];
+    let value = '';
+
+    switch (key) {
+      case 'id':
+        value = expertId ? String(expertId) : '';
+        break;
+      case 'fullName':
+        value = draft.fullName;
+        break;
+      case 'title':
+        value = draft.title;
+        break;
+      case 'summary':
+        value = draft.summary;
+        break;
+      case 'experienceYears':
+        value = String(draft.experienceYears ?? 0);
+        break;
+      case 'availability':
+        value = draft.availability;
+        break;
+      case 'availabilityComment':
+        value = draft.availabilityComment;
+        break;
+      case 'location':
+        value = draft.location;
+        break;
+      case 'contact':
+        value = draft.contact;
+        break;
+      case 'languages':
+        value = draft.languages.join('\n');
+        break;
+      case 'domains':
+        value = draft.domains.map((id) => domainLabelMap[id] ?? id).join('\n');
+        break;
+      case 'domainIds':
+        value = draft.domains.join('\n');
+        break;
+      case 'modules':
+        value = draft.modules.map((id) => moduleLabelMap[id] ?? id).join('\n');
+        break;
+      case 'moduleIds':
+        value = draft.modules.join('\n');
+        break;
+      case 'competencies':
+        value = draft.competencies.join('\n');
+        break;
+      case 'consultingSkills':
+        value = draft.consultingSkills.join('\n');
+        break;
+      case 'softSkills':
+        value = (draft.softSkills ?? []).join('\n');
+        break;
+      case 'focusAreas':
+        value = draft.focusAreas.join('\n');
+        break;
+      case 'notableProjects':
+        value = draft.notableProjects.join('\n');
+        break;
+      default:
+        value = '';
+        break;
+    }
+
+    return { Field: field, Value: value };
+  });
+
+  const profileSheet = utils.json_to_sheet(profileRows, {
+    header: ['Field', 'Value']
+  });
+  utils.book_append_sheet(workbook, profileSheet, PROFILE_SHEET);
+
+  const skillRows = draft.skills.map((skill) => {
+    const definition = skills[skill.id];
+    const usage = skill.usage ?? {};
+
+    return {
+      'Skill ID': skill.id,
+      'Skill Name': definition?.name ?? getSkillNameById(skill.id) ?? skill.id,
+      Category: definition?.category ?? 'hard',
+      Level: skill.level,
+      'Proof Status': skill.proofStatus,
+      Interest: skill.interest,
+      'Available FTE': skill.availableFte ?? 0,
+      Artifacts: skill.artifacts.join('\n'),
+      'Usage From': usage.from ?? '',
+      'Usage To': usage.to ?? '',
+      'Usage Description': usage.description ?? '',
+      'Definition Description': definition?.description ?? '',
+      'Definition Sources': definition?.sources.join(', ') ?? '',
+      'Definition Recommended Level': definition?.recommendedLevel ?? '',
+      'Definition Evidence Status': definition?.evidenceStatus ?? '',
+      'Definition Roles': definition?.roles.join(', ') ?? ''
+    };
+  });
+
+  const skillsSheet = utils.json_to_sheet(skillRows, {
+    header: [...SKILL_HEADERS]
+  });
+  utils.book_append_sheet(workbook, skillsSheet, SKILLS_SHEET);
+
+  const evidenceRows: Array<Record<EvidenceHeader, string>> = [];
+  draft.skills.forEach((skill) => {
+    (skill.evidence ?? []).forEach((entry) => {
+      evidenceRows.push({
+        'Skill ID': skill.id,
+        Status: entry.status,
+        'Initiative ID': entry.initiativeId ?? '',
+        Artifacts: (entry.artifactIds ?? []).join('\n'),
+        Comment: entry.comment ?? ''
+      });
+    });
+  });
+
+  const evidenceSheet = utils.json_to_sheet(evidenceRows, {
+    header: [...EVIDENCE_HEADERS]
+  });
+  utils.book_append_sheet(workbook, evidenceSheet, EVIDENCE_SHEET);
+
+  return workbook;
+};
+
+export const exportExpertToExcel = (params: ExpertExcelExportParams): ArrayBuffer =>
+  write(createExpertWorkbook(params), { type: 'array', bookType: 'xlsx' });
+
+type SkillSheetRow = Record<SkillHeader, string | number>;
+
+type EvidenceSheetRow = Record<EvidenceHeader, string | number>;
+
+const parseSkillCategory = (raw: string): SkillDefinition['category'] | null => {
+  const normalized = raw.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  if (normalized.startsWith('hard')) {
+    return 'hard';
+  }
+  if (normalized.startsWith('soft')) {
+    return 'soft';
+  }
+  if (normalized.startsWith('domain')) {
+    return 'domain';
+  }
+  return null;
+};
+
+const parseSkillLevel = (raw: string): SkillLevel | null => {
+  if (!raw) {
+    return null;
+  }
+  const normalized = raw.trim().toLowerCase();
+  return skillLevelMap[normalized] ?? null;
+};
+
+const parseProofStatus = (raw: string): SkillEvidenceStatus | null => {
+  if (!raw) {
+    return null;
+  }
+  const normalized = raw.trim().toLowerCase();
+  return proofStatusMap[normalized] ?? null;
+};
+
+const parseInterest = (raw: string): ExpertSkill['interest'] | null => {
+  if (!raw) {
+    return null;
+  }
+  const normalized = raw.trim().toLowerCase();
+  return interestMap[normalized] ?? null;
+};
+
+const parseAvailability = (raw: string): ExpertAvailability | null => {
+  if (!raw) {
+    return null;
+  }
+  const normalized = raw.trim().toLowerCase();
+  return availabilityMap[normalized] ?? null;
+};
+
+const parseSources = (raw: string): SkillSource[] => {
+  if (!raw) {
+    return [];
+  }
+  const values = splitMultiline(raw);
+  return Array.from(
+    new Set(
+      values
+        .map((value) => skillSourceMap[value.trim().toLowerCase()])
+        .filter((value): value is SkillSource => Boolean(value))
+    )
+  );
+};
+
+const parseEvidenceStatus = (raw: string): SkillEvidenceStatus | null => {
+  if (!raw) {
+    return null;
+  }
+  const normalized = raw.trim().toLowerCase();
+  return evidenceStatusMap[normalized] ?? null;
+};
+
+const parseRecommendedLevel = (raw: string): SkillLevel | null => {
+  if (!raw) {
+    return null;
+  }
+  const normalized = raw.trim().toLowerCase();
+  return recommendedLevelMap[normalized] ?? null;
+};
+
+const parseRoles = (raw: string): TeamRole[] => {
+  if (!raw) {
+    return [];
+  }
+  const knownRoles = new Set(Object.keys(roleToSkillsMap) as TeamRole[]);
+  return splitMultiline(raw)
+    .map((value) => value.trim())
+    .filter((value): value is TeamRole => knownRoles.has(value as TeamRole));
+};
+
+const coerceNumber = (value: string | number): number => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : 0;
+  }
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
+};
+
+export const parseExpertWorkbook = ({
+  buffer,
+  domainLabelMap,
+  moduleLabelMap
+}: ExpertExcelImportParams): ExpertImportResult => {
+  const workbook = read(buffer, { type: 'array' });
+
+  const profileSheet = workbook.Sheets[PROFILE_SHEET];
+  const skillsSheet = workbook.Sheets[SKILLS_SHEET];
+  const evidenceSheet = workbook.Sheets[EVIDENCE_SHEET];
+
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const domainNameMap = buildNameMap(domainLabelMap);
+  const moduleNameMap = buildNameMap(moduleLabelMap);
+
+  const profileValues = new Map<string, string>();
+  if (profileSheet) {
+    const rows = utils.sheet_to_json<[string, string]>(profileSheet, { header: 1, blankrows: false });
+    rows.forEach((row, index) => {
+      if (index === 0 && row[0] === 'Field') {
+        return;
+      }
+      const field = row[0];
+      const value = row[1];
+      if (!field) {
+        return;
+      }
+      profileValues.set(String(field).trim(), String(value ?? ''));
+    });
+  }
+
+  const getProfileValue = (key: ProfileFieldKey): string =>
+    profileValues.get(PROFILE_FIELDS[key]) ?? '';
+
+  const fullName = getProfileValue('fullName').trim();
+  if (!fullName) {
+    errors.push('В файле не указано полное имя сотрудника.');
+  }
+
+  const availabilityValue = parseAvailability(getProfileValue('availability'));
+  if (!availabilityValue) {
+    errors.push('Некорректное значение доступности сотрудника.');
+  }
+
+  const domainIds = splitMultiline(getProfileValue('domainIds'));
+  const domainNames = splitMultiline(getProfileValue('domains'));
+  const normalizedDomains = new Set<string>();
+  domainIds.forEach((id) => {
+    if (domainLabelMap[id]) {
+      normalizedDomains.add(id);
+    } else if (id) {
+      warnings.push(`Домен «${id}» отсутствует в системе и будет пропущен.`);
+    }
+  });
+  domainNames.forEach((name) => {
+    const id = domainNameMap.get(name.toLowerCase());
+    if (id) {
+      normalizedDomains.add(id);
+    }
+  });
+
+  const moduleIds = splitMultiline(getProfileValue('moduleIds'));
+  const moduleNames = splitMultiline(getProfileValue('modules'));
+  const normalizedModules = new Set<string>();
+  moduleIds.forEach((id) => {
+    if (moduleLabelMap[id]) {
+      normalizedModules.add(id);
+    } else if (id) {
+      warnings.push(`Модуль «${id}» отсутствует в системе и будет пропущен.`);
+    }
+  });
+  moduleNames.forEach((name) => {
+    const id = moduleNameMap.get(name.toLowerCase());
+    if (id) {
+      normalizedModules.add(id);
+    }
+  });
+
+  const draft: ExpertDraftPayload = {
+    fullName,
+    title: getProfileValue('title'),
+    summary: getProfileValue('summary'),
+    domains: Array.from(normalizedDomains),
+    modules: Array.from(normalizedModules),
+    experienceYears: Math.max(0, Math.round(coerceNumber(getProfileValue('experienceYears')))),
+    location: getProfileValue('location'),
+    contact: getProfileValue('contact'),
+    languages: splitMultiline(getProfileValue('languages')),
+    notableProjects: splitMultiline(getProfileValue('notableProjects')),
+    availability: availabilityValue ?? 'available',
+    availabilityComment: getProfileValue('availabilityComment'),
+    competencies: splitMultiline(getProfileValue('competencies')),
+    consultingSkills: splitMultiline(getProfileValue('consultingSkills')),
+    softSkills: splitMultiline(getProfileValue('softSkills')),
+    focusAreas: splitMultiline(getProfileValue('focusAreas')),
+    skills: []
+  };
+
+  draft.skills = [];
+
+  const requestedExpertId = getProfileValue('id') || undefined;
+
+  const missingHardSkills: MissingSkillEntry[] = [];
+  const skillRows = skillsSheet ? utils.sheet_to_json<SkillSheetRow>(skillsSheet, { defval: '' }) : [];
+
+  const skillMap = new Map<string, ExpertSkill>();
+
+  skillRows.forEach((row, index) => {
+    const rawCategory = String(row.Category ?? '');
+    const skillName = String(row['Skill Name'] ?? '').trim();
+    const rawSkillId = String(row['Skill ID'] ?? '').trim();
+
+    if (!skillName && !rawSkillId) {
+      return;
+    }
+
+    const level = parseSkillLevel(String(row.Level ?? ''));
+    if (!level) {
+      errors.push(`Строка ${index + 2}: некорректный уровень навыка для «${skillName || rawSkillId}».`);
+      return;
+    }
+
+    const proofStatus = parseProofStatus(String(row['Proof Status'] ?? ''));
+    if (!proofStatus) {
+      errors.push(`Строка ${index + 2}: некорректный статус подтверждения для «${skillName || rawSkillId}».`);
+      return;
+    }
+
+    const interest = parseInterest(String(row.Interest ?? '')) ?? 'medium';
+    const availableFte = coerceNumber(row['Available FTE'] ?? 0);
+    const artifacts = splitMultiline(String(row.Artifacts ?? ''));
+    const usageFrom = String(row['Usage From'] ?? '').trim();
+    const usageTo = String(row['Usage To'] ?? '').trim();
+    const usageDescription = String(row['Usage Description'] ?? '').trim();
+
+    let skillId = rawSkillId || slugifySkillId(skillName || `skill-${index}`);
+    let definition = skills[skillId];
+
+    if (!definition && skillName) {
+      const existing = findSkillByName(skillName);
+      if (existing) {
+        skillId = existing.id;
+        definition = existing;
+      }
+    }
+
+    let category = parseSkillCategory(rawCategory);
+    if (!category) {
+      category = definition?.category ?? null;
+    }
+
+    const resolvedSkillName = skillName || definition?.name || skillId;
+
+    if (!category) {
+      errors.push(`Строка ${index + 2}: не удалось определить категорию навыка «${resolvedSkillName}».`);
+      return;
+    }
+
+    if (!definition && category === 'hard') {
+      const definitionDescription = String(row['Definition Description'] ?? '').trim();
+      const definitionSources = parseSources(String(row['Definition Sources'] ?? ''));
+      const recommendedLevel =
+        parseRecommendedLevel(String(row['Definition Recommended Level'] ?? '')) ?? 'P';
+      const evidenceStatus =
+        parseEvidenceStatus(String(row['Definition Evidence Status'] ?? '')) ?? 'screened';
+      const roles = parseRoles(String(row['Definition Roles'] ?? ''));
+
+      missingHardSkills.push({
+        definition: {
+          id: skillId,
+          name: resolvedSkillName,
+          description: definitionDescription || resolvedSkillName,
+          category,
+          sources: definitionSources,
+          recommendedLevel,
+          evidenceStatus,
+          roles
+        },
+        requestedId: skillId,
+        requestedName: resolvedSkillName,
+        rowNumber: index + 2
+      });
+    }
+
+    const usage = usageFrom || usageTo || usageDescription ? { from: usageFrom, to: usageTo, description: usageDescription } : undefined;
+
+    const expertSkill: ExpertSkill = {
+      id: skillId,
+      level,
+      proofStatus,
+      evidence: [],
+      artifacts,
+      interest,
+      availableFte,
+      usage
+    };
+
+    skillMap.set(skillId, expertSkill);
+  });
+
+  if (evidenceSheet) {
+    const evidenceRows = utils.sheet_to_json<EvidenceSheetRow>(evidenceSheet, { defval: '' });
+    evidenceRows.forEach((row, index) => {
+      const skillId = String(row['Skill ID'] ?? '').trim();
+      const status = parseEvidenceStatus(String(row.Status ?? ''));
+      if (!skillId || !status) {
+        return;
+      }
+      const initiativeId = String(row['Initiative ID'] ?? '').trim();
+      const artifacts = splitMultiline(String(row.Artifacts ?? ''));
+      const comment = String(row.Comment ?? '').trim();
+
+      const skill = skillMap.get(skillId);
+      if (!skill) {
+        warnings.push(`Лист Evidence, строка ${index + 2}: навык «${skillId}» не найден в профиле и будет пропущен.`);
+        return;
+      }
+
+      skill.evidence.push({
+        status,
+        ...(initiativeId ? { initiativeId } : {}),
+        ...(artifacts.length > 0 ? { artifactIds: artifacts } : {}),
+        ...(comment ? { comment } : {})
+      });
+    });
+  }
+
+  draft.skills = Array.from(skillMap.values());
+
+  return {
+    draft,
+    requestedExpertId,
+    errors,
+    warnings,
+    missingHardSkills
+  };
+};
+

--- a/src/utils/expertExcel.ts
+++ b/src/utils/expertExcel.ts
@@ -23,26 +23,48 @@ const SKILLS_SHEET = 'Skills';
 const EVIDENCE_SHEET = 'Evidence';
 
 const PROFILE_FIELDS = {
-  id: 'Expert ID',
-  fullName: 'Full Name',
-  title: 'Title',
-  summary: 'Summary',
-  experienceYears: 'Experience Years',
-  availability: 'Availability',
-  availabilityComment: 'Availability Comment',
-  location: 'Location',
-  contact: 'Contact',
-  languages: 'Languages',
-  domains: 'Domains',
-  domainIds: 'Domain IDs',
-  modules: 'Modules',
-  moduleIds: 'Module IDs',
-  competencies: 'Competencies',
-  consultingSkills: 'Consulting Skills',
-  softSkills: 'Soft Skills',
-  focusAreas: 'Focus Areas',
-  notableProjects: 'Notable Projects'
+  id: 'ID эксперта',
+  fullName: 'ФИО',
+  title: 'Роль / должность',
+  summary: 'Краткое описание',
+  experienceYears: 'Опыт (лет)',
+  availability: 'Доступность',
+  availabilityComment: 'Комментарий по доступности',
+  location: 'Локация',
+  contact: 'Контакты',
+  languages: 'Языки',
+  domains: 'Доменные области',
+  domainIds: 'ID доменов',
+  modules: 'Модули',
+  moduleIds: 'ID модулей',
+  competencies: 'Компетенции',
+  consultingSkills: 'Консалтинговые навыки',
+  softSkills: 'Soft skills',
+  focusAreas: 'Фокусы и задачи',
+  notableProjects: 'Значимые проекты'
 } as const;
+
+const PROFILE_FIELD_ALIASES: Partial<Record<ProfileFieldKey, string[]>> = {
+  id: ['Expert ID'],
+  fullName: ['Full Name'],
+  title: ['Title'],
+  summary: ['Summary'],
+  experienceYears: ['Experience Years'],
+  availability: ['Availability'],
+  availabilityComment: ['Availability Comment'],
+  location: ['Location'],
+  contact: ['Contact'],
+  languages: ['Languages'],
+  domains: ['Domains'],
+  domainIds: ['Domain IDs'],
+  modules: ['Modules'],
+  moduleIds: ['Module IDs'],
+  competencies: ['Competencies'],
+  consultingSkills: ['Consulting Skills'],
+  softSkills: ['Soft Skills'],
+  focusAreas: ['Focus Areas'],
+  notableProjects: ['Notable Projects']
+};
 
 type ProfileFieldKey = keyof typeof PROFILE_FIELDS;
 
@@ -121,9 +143,11 @@ const recommendedLevelMap = skillLevels.reduce<Record<string, SkillLevel>>((acc,
 
 const splitMultiline = (value: string): string[] =>
   value
-    .split(/\r?\n|,/)
+    .split(/[\r\n,;]+/)
     .map((item) => item.trim())
     .filter((item) => item.length > 0);
+
+const joinMultivalue = (values: string[]): string => values.join('; ');
 
 const buildNameMap = (record: Record<string, string>): Map<string, string> => {
   const map = new Map<string, string>();
@@ -215,34 +239,34 @@ export const createExpertWorkbook = ({
         value = draft.contact;
         break;
       case 'languages':
-        value = draft.languages.join('\n');
+        value = joinMultivalue(draft.languages);
         break;
       case 'domains':
-        value = draft.domains.map((id) => domainLabelMap[id] ?? id).join('\n');
+        value = joinMultivalue(draft.domains.map((id) => domainLabelMap[id] ?? id));
         break;
       case 'domainIds':
-        value = draft.domains.join('\n');
+        value = joinMultivalue(draft.domains);
         break;
       case 'modules':
-        value = draft.modules.map((id) => moduleLabelMap[id] ?? id).join('\n');
+        value = joinMultivalue(draft.modules.map((id) => moduleLabelMap[id] ?? id));
         break;
       case 'moduleIds':
-        value = draft.modules.join('\n');
+        value = joinMultivalue(draft.modules);
         break;
       case 'competencies':
-        value = draft.competencies.join('\n');
+        value = joinMultivalue(draft.competencies);
         break;
       case 'consultingSkills':
-        value = draft.consultingSkills.join('\n');
+        value = joinMultivalue(draft.consultingSkills);
         break;
       case 'softSkills':
-        value = (draft.softSkills ?? []).join('\n');
+        value = joinMultivalue(draft.softSkills ?? []);
         break;
       case 'focusAreas':
-        value = draft.focusAreas.join('\n');
+        value = joinMultivalue(draft.focusAreas);
         break;
       case 'notableProjects':
-        value = draft.notableProjects.join('\n');
+        value = joinMultivalue(draft.notableProjects);
         break;
       default:
         value = '';
@@ -253,7 +277,7 @@ export const createExpertWorkbook = ({
   });
 
   const profileSheet = utils.json_to_sheet(profileRows, {
-    header: ['Field', 'Value']
+    header: ['Атрибут', 'Значение']
   });
   utils.book_append_sheet(workbook, profileSheet, PROFILE_SHEET);
 
@@ -269,15 +293,15 @@ export const createExpertWorkbook = ({
       'Proof Status': skill.proofStatus,
       Interest: skill.interest,
       'Available FTE': skill.availableFte ?? 0,
-      Artifacts: skill.artifacts.join('\n'),
+      Artifacts: joinMultivalue(skill.artifacts),
       'Usage From': usage.from ?? '',
       'Usage To': usage.to ?? '',
       'Usage Description': usage.description ?? '',
       'Definition Description': definition?.description ?? '',
-      'Definition Sources': definition?.sources.join(', ') ?? '',
+      'Definition Sources': joinMultivalue(definition?.sources ?? []),
       'Definition Recommended Level': definition?.recommendedLevel ?? '',
       'Definition Evidence Status': definition?.evidenceStatus ?? '',
-      'Definition Roles': definition?.roles.join(', ') ?? ''
+      'Definition Roles': joinMultivalue(definition?.roles ?? [])
     };
   });
 
@@ -293,7 +317,7 @@ export const createExpertWorkbook = ({
         'Skill ID': skill.id,
         Status: entry.status,
         'Initiative ID': entry.initiativeId ?? '',
-        Artifacts: (entry.artifactIds ?? []).join('\n'),
+        Artifacts: joinMultivalue(entry.artifactIds ?? []),
         Comment: entry.comment ?? ''
       });
     });
@@ -432,7 +456,8 @@ export const parseExpertWorkbook = ({
   if (profileSheet) {
     const rows = utils.sheet_to_json<[string, string]>(profileSheet, { header: 1, blankrows: false });
     rows.forEach((row, index) => {
-      if (index === 0 && row[0] === 'Field') {
+      const header = String(row[0] ?? '').trim();
+      if (index === 0 && (header === 'Field' || header === 'Атрибут')) {
         return;
       }
       const field = row[0];
@@ -444,8 +469,16 @@ export const parseExpertWorkbook = ({
     });
   }
 
-  const getProfileValue = (key: ProfileFieldKey): string =>
-    profileValues.get(PROFILE_FIELDS[key]) ?? '';
+  const getProfileValue = (key: ProfileFieldKey): string => {
+    const labels = [PROFILE_FIELDS[key], ...(PROFILE_FIELD_ALIASES[key] ?? [])];
+    for (const label of labels) {
+      const value = profileValues.get(label);
+      if (value !== undefined) {
+        return value;
+      }
+    }
+    return '';
+  };
 
   const fullName = getProfileValue('fullName').trim();
   if (!fullName) {

--- a/src/utils/useSkillRegistryVersion.ts
+++ b/src/utils/useSkillRegistryVersion.ts
@@ -1,0 +1,9 @@
+import { useSyncExternalStore } from 'react';
+import {
+  getSkillRegistryVersion,
+  subscribeToSkillRegistry
+} from '../data/skills';
+
+export const useSkillRegistryVersion = (): number =>
+  useSyncExternalStore(subscribeToSkillRegistry, getSkillRegistryVersion, getSkillRegistryVersion);
+


### PR DESCRIPTION
## Summary
- add single-profile Excel import/export flows with validation and missing skill handling in the admin expert form
- add expert Excel serialization/parsing utilities and a skill registry subscription hook
- allow runtime skill registry updates and refresh dependent UIs

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691264f8bdcc8332af936e6b901f1a27)