### PR TITLE
Improve employee workload timeline interactions

### DIFF
--- a/src/components/EmployeeWorkloadTrack.module.css
+++ b/src/components/EmployeeWorkloadTrack.module.css
@@ -238,6 +238,64 @@
   gap: 8px;
 }
 
+.timelineLayout {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(240px, 1fr);
+  gap: 16px;
+  align-items: stretch;
+}
+
+.timelineChart {
+  min-width: 0;
+}
+
+.timelineDetails {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border: 1px solid var(--color-bg-border);
+  border-radius: 12px;
+  background: var(--color-bg-secondary);
+  padding: 16px;
+  min-height: 240px;
+}
+
+.timelineDetailsHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.timelineDetailsMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.timelineDetailsEmployee {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.timelineDetailsStats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+}
+
+.timelineDetailsEmpty {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 12px;
+  color: var(--color-typo-secondary);
+}
+
 .legendMarker {
   width: 14px;
   height: 14px;
@@ -285,6 +343,16 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+}
+
+@media (max-width: 1200px) {
+  .timelineLayout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .timelineDetails {
+    min-height: 200px;
+  }
 }
 
 @media (max-width: 1024px) {

--- a/src/components/EmployeeWorkloadTrack.module.css
+++ b/src/components/EmployeeWorkloadTrack.module.css
@@ -238,9 +238,10 @@
   gap: 8px;
 }
 
+
 .timelineLayout {
   display: grid;
-  grid-template-columns: minmax(0, 3fr) minmax(240px, 1fr);
+  grid-template-columns: minmax(0, 1fr) 320px;
   gap: 16px;
   align-items: stretch;
 }
@@ -258,6 +259,8 @@
   background: var(--color-bg-secondary);
   padding: 16px;
   min-height: 240px;
+  width: 320px;
+  max-width: 320px;
 }
 
 .timelineDetailsHeader {
@@ -352,6 +355,8 @@
 
   .timelineDetails {
     min-height: 200px;
+    width: 100%;
+    max-width: none;
   }
 }
 

--- a/src/components/EmployeeWorkloadTrack.tsx
+++ b/src/components/EmployeeWorkloadTrack.tsx
@@ -10,6 +10,7 @@ import { TextField } from '@consta/uikit/TextField';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import GanttTimeline, {
   type GanttTimelineRow,
+  type GanttTimelineTask,
   type GanttTimelineTaskKind,
   timelineScaleTabs,
   type TimelineScaleTab
@@ -26,6 +27,12 @@ type WorkloadTask = {
   kind: WorkloadKind;
   badge: string;
   description?: string;
+};
+
+const workloadBadgeStatuses: Record<WorkloadKind, 'system' | 'warning' | 'success'> = {
+  project: 'system',
+  'out-of-project': 'warning',
+  training: 'success'
 };
 
 type EmployeeWorkload = {
@@ -234,6 +241,10 @@ const mockEmployees: EmployeeWorkload[] = [
     ]
   }
 ];
+
+const employeeById = new Map<string, EmployeeWorkload>(
+  mockEmployees.map((employee) => [employee.id, employee] as const)
+);
 
 const priorityOptions: SelectOption<TaskPriority>[] = [
   { label: 'Низкий', value: 'low' },
@@ -639,6 +650,24 @@ const startOfMonth = (date: Date): Date => new Date(date.getFullYear(), date.get
 
 const startOfYear = (date: Date): Date => new Date(date.getFullYear(), 0, 1);
 
+const detailDateFormatter = new Intl.DateTimeFormat('ru-RU', {
+  day: '2-digit',
+  month: 'long',
+  year: 'numeric'
+});
+
+const formatTimelineTaskPeriod = (start: string, end: string): string => {
+  const startDate = parseDateValue(start);
+  const endDate = parseDateValue(end);
+  if (!startDate || !endDate) {
+    return 'Период не задан';
+  }
+  if (startDate.getTime() === endDate.getTime()) {
+    return detailDateFormatter.format(startDate);
+  }
+  return `${detailDateFormatter.format(startDate)} — ${detailDateFormatter.format(endDate)}`;
+};
+
 const toDate = (value: Date | string): Date => {
   if (value instanceof Date) {
     return value;
@@ -774,6 +803,10 @@ const buildYearOptions = (baseStart: Date, minDate: Date, maxDate: Date): Period
     });
   }
   return options;
+};
+
+const findPeriodContainingDate = (options: PeriodOption[], target: Date): PeriodOption | null => {
+  return options.find((option) => target >= option.start && target < option.end) ?? null;
 };
 
 const getScheduleDueDate = (schedule: TaskSchedule): Date | null => {
@@ -1131,26 +1164,32 @@ const EmployeeWorkloadTrack: React.FC = () => {
     [baseStart, maxTaskEnd, minTaskStart]
   );
 
-  const [selectedPeriods, setSelectedPeriods] = useState<Record<TimelineScale, string | null>>(() => ({
-    week: periodOptions.week[0]?.value ?? null,
-    month: periodOptions.month[0]?.value ?? null,
-    year: periodOptions.year[0]?.value ?? null
-  }));
+  const [selectedPeriods, setSelectedPeriods] = useState<Record<TimelineScale, string | null>>(() => {
+    const now = new Date();
+    return {
+      week: findPeriodContainingDate(periodOptions.week, now)?.value ?? periodOptions.week[0]?.value ?? null,
+      month:
+        findPeriodContainingDate(periodOptions.month, now)?.value ?? periodOptions.month[0]?.value ?? null,
+      year: findPeriodContainingDate(periodOptions.year, now)?.value ?? periodOptions.year[0]?.value ?? null
+    };
+  });
+  const [activeTimelineTaskId, setActiveTimelineTaskId] = useState<string | null>(null);
 
   useEffect(() => {
+    const now = new Date();
     setSelectedPeriods((prev) => ({
       week:
         prev.week && periodOptions.week.some((option) => option.value === prev.week)
           ? prev.week
-          : periodOptions.week[0]?.value ?? null,
+          : findPeriodContainingDate(periodOptions.week, now)?.value ?? periodOptions.week[0]?.value ?? null,
       month:
         prev.month && periodOptions.month.some((option) => option.value === prev.month)
           ? prev.month
-          : periodOptions.month[0]?.value ?? null,
+          : findPeriodContainingDate(periodOptions.month, now)?.value ?? periodOptions.month[0]?.value ?? null,
       year:
         prev.year && periodOptions.year.some((option) => option.value === prev.year)
           ? prev.year
-          : periodOptions.year[0]?.value ?? null
+          : findPeriodContainingDate(periodOptions.year, now)?.value ?? periodOptions.year[0]?.value ?? null
     }));
   }, [periodOptions]);
 
@@ -1161,6 +1200,38 @@ const EmployeeWorkloadTrack: React.FC = () => {
   const resolvedViewRange = displayedPeriod
     ? { start: displayedPeriod.start, end: displayedPeriod.end }
     : undefined;
+
+  const timelineTaskLookup = useMemo(() => {
+    const map = new Map<string, { task: WorkloadTask; employee: EmployeeWorkload }>();
+
+    mockEmployees.forEach((employee) => {
+      employee.tasks.forEach((task) => {
+        map.set(task.id, { task, employee });
+      });
+    });
+
+    teamTimelineTasksByEmployee.forEach((employeeTasks, employeeId) => {
+      const employee = employeeById.get(employeeId);
+      if (!employee) {
+        return;
+      }
+      employeeTasks.forEach((task) => {
+        map.set(task.id, { task, employee });
+      });
+    });
+
+    return map;
+  }, [teamTimelineTasksByEmployee]);
+
+  useEffect(() => {
+    if (activeTimelineTaskId && !timelineTaskLookup.has(activeTimelineTaskId)) {
+      setActiveTimelineTaskId(null);
+    }
+  }, [activeTimelineTaskId, timelineTaskLookup]);
+
+  const activeTimelineTask = activeTimelineTaskId
+    ? timelineTaskLookup.get(activeTimelineTaskId) ?? null
+    : null;
 
   const timelineRows = useMemo<GanttTimelineRow[]>(() => {
     return mockEmployees.map((employee) => {
@@ -1222,6 +1293,17 @@ const EmployeeWorkloadTrack: React.FC = () => {
       return { id: employee.id, sidebar, tasks };
     });
   }, [teamTimelineTasksByEmployee]);
+
+  const handleTimelineTaskClick = useCallback(
+    ({ task }: { rowId: string; task: GanttTimelineTask }) => {
+      setActiveTimelineTaskId(task.id);
+    },
+    []
+  );
+
+  const handleClearTimelineTask = useCallback(() => {
+    setActiveTimelineTaskId(null);
+  }, []);
 
   const assigneeOptions = useMemo<SelectOption<string>[]>(() => {
     return mockEmployees.map((employee) => ({
@@ -2024,12 +2106,76 @@ const EmployeeWorkloadTrack: React.FC = () => {
           </Text>
         </div>
       </div>
-      <GanttTimeline
-        axisLabel="Сотрудник"
-        scale={scale.value}
-        rows={timelineRows}
-        viewRange={resolvedViewRange}
-      />
+      <div className={styles.timelineLayout}>
+        <div className={styles.timelineChart}>
+          <GanttTimeline
+            axisLabel="Сотрудник"
+            scale={scale.value}
+            rows={timelineRows}
+            viewRange={resolvedViewRange}
+            onTaskClick={handleTimelineTaskClick}
+            selectedTaskId={activeTimelineTaskId}
+          />
+        </div>
+        <aside className={styles.timelineDetails}>
+          {activeTimelineTask ? (
+            <>
+              <div className={styles.timelineDetailsHeader}>
+                <Text size="s" weight="semibold">
+                  {activeTimelineTask.task.name}
+                </Text>
+                <Button
+                  size="xs"
+                  view="ghost"
+                  label="Очистить"
+                  onClick={handleClearTimelineTask}
+                />
+              </div>
+              <div className={styles.timelineDetailsMeta}>
+                <Badge
+                  size="xs"
+                  status={workloadBadgeStatuses[activeTimelineTask.task.kind]}
+                  label={activeTimelineTask.task.badge}
+                />
+                <Text size="xs" view="secondary">
+                  {formatTimelineTaskPeriod(activeTimelineTask.task.start, activeTimelineTask.task.end)}
+                </Text>
+              </div>
+              <div className={styles.timelineDetailsEmployee}>
+                <Text size="2xs" view="secondary">
+                  Сотрудник
+                </Text>
+                <Text size="s" weight="semibold">
+                  {activeTimelineTask.employee.fullName}
+                </Text>
+                <Text size="xs" view="secondary">
+                  {activeTimelineTask.employee.position}
+                </Text>
+              </div>
+              <div className={styles.timelineDetailsStats}>
+                <Text size="2xs" view="secondary">
+                  Загруженность: {Math.round(activeTimelineTask.employee.workload * 100)}%
+                </Text>
+                <Text size="2xs" view="secondary">
+                  {activeTimelineTask.employee.availability}
+                </Text>
+              </div>
+              <Text size="xs" view="secondary">
+                {activeTimelineTask.employee.focus}
+              </Text>
+              <Text size="xs">
+                {activeTimelineTask.task.description ?? 'Описание не добавлено'}
+              </Text>
+            </>
+          ) : (
+            <div className={styles.timelineDetailsEmpty}>
+              <Text size="s" view="secondary">
+                Выберите задачу на дорожной карте, чтобы увидеть подробности
+              </Text>
+            </div>
+          )}
+        </aside>
+      </div>
         </Card>
       )}
     </div>

--- a/src/components/GanttTimeline.module.css
+++ b/src/components/GanttTimeline.module.css
@@ -17,6 +17,7 @@
 }
 
 .axis {
+  position: relative;
   display: grid;
   width: 100%;
   border-radius: 12px;
@@ -66,6 +67,27 @@
   border-radius: 8px;
   background: var(--color-bg-default);
   pointer-events: none;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.laneSection {
+  flex: 0 0 auto;
+  border-bottom: 1px solid var(--color-bg-border);
+  background: rgba(37, 110, 255, 0.04);
+}
+
+.laneSection[data-kind='out-of-project'] {
+  background: rgba(255, 166, 0, 0.05);
+}
+
+.laneSection[data-kind='training'] {
+  background: rgba(47, 209, 150, 0.05);
+}
+
+.laneSection:last-child {
+  border-bottom: none;
 }
 
 .task {
@@ -79,6 +101,34 @@
   box-shadow: 0 8px 18px rgba(17, 43, 96, 0.12);
   min-width: 0;
   max-width: none;
+}
+
+.task[data-clickable='true'] {
+  cursor: pointer;
+}
+
+.task[data-selected='true'] {
+  box-shadow: 0 0 0 2px var(--color-bg-link), 0 12px 24px rgba(17, 43, 96, 0.18);
+  border-color: var(--color-bg-link);
+}
+
+.todayIndicator {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(37, 110, 255, 0.1) 0%, rgba(37, 110, 255, 0.6) 48%, rgba(37, 110, 255, 0.1) 100%);
+  pointer-events: none;
+}
+
+.timelineTodayIndicator {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: rgba(37, 110, 255, 0.4);
+  pointer-events: none;
+  transform: translateX(-1px);
 }
 
 .task[data-kind='project'] {

--- a/src/components/GanttTimeline.tsx
+++ b/src/components/GanttTimeline.tsx
@@ -345,27 +345,37 @@ const GanttTimeline: React.FC<GanttTimelineProps> = ({
     }
     return computeViewRange(allTasks, scale);
   }, [allTasks, explicitRange, scale]);
-  const totalDuration = Math.max(viewEnd.getTime() - viewStart.getTime(), MS_IN_DAY);
+  const viewStartTime = viewStart.getTime();
+  const viewEndTime = viewEnd.getTime();
+  const totalDurationMs = Math.max(viewEndTime - viewStartTime, MS_IN_DAY);
+  const totalDurationDays = totalDurationMs / MS_IN_DAY;
   const segments = useMemo(() => buildSegments(viewStart, viewEnd, scale), [viewEnd, viewStart, scale]);
+  const targetTotalUnits = scale === 'year' ? segments.length : 12;
+  const timelineUnitScale = totalDurationDays > 0 ? targetTotalUnits / totalDurationDays : 1;
+  const scaledTimelineDuration = Math.max(totalDurationDays * timelineUnitScale, 1);
   const gridTemplateColumns = useMemo(() => {
     if (segments.length === 0) {
       return undefined;
     }
-    const durations = segments.map((segment) => {
-      const durationInDays = (segment.end.getTime() - segment.start.getTime()) / MS_IN_DAY;
-      return Math.max(1, durationInDays);
-    });
-    const totalDuration = durations.reduce((sum, value) => sum + value, 0);
-    const targetTotalUnits = scale === 'year' ? segments.length : 12;
-    const unitScale = totalDuration > 0 ? targetTotalUnits / totalDuration : 1;
-    return durations
-      .map((duration) => `${duration * unitScale}fr`)
+    return segments
+      .map((segment) => {
+        const durationInDays = Math.max(
+          1 / 24,
+          (segment.end.getTime() - segment.start.getTime()) / MS_IN_DAY
+        );
+        return `${durationInDays * timelineUnitScale}fr`;
+      })
       .join(' ');
-  }, [scale, segments]);
+  }, [segments, timelineUnitScale]);
 
   const today = startOfDay(new Date());
-  const todayOffset = today.getTime() >= viewStart.getTime() && today.getTime() <= viewEnd.getTime()
-    ? ((Math.min(today.getTime(), viewEnd.getTime()) - viewStart.getTime()) / totalDuration) * 100
+  const todayOffset = today.getTime() >= viewStartTime && today.getTime() <= viewEndTime
+    ? ((
+        (Math.min(today.getTime(), viewEndTime) - viewStartTime) / MS_IN_DAY
+      ) * timelineUnitScale)
+        /
+        scaledTimelineDuration *
+        100
     : null;
 
   return (
@@ -429,13 +439,16 @@ const GanttTimeline: React.FC<GanttTimelineProps> = ({
                 )}
                 {row.tasks.map((task) => {
                   const laneIndex = laneLayout.assignments.get(task.id) ?? 0;
-                  const clampedStart = Math.max(task.startTime, viewStart.getTime());
-                  const clampedEnd = Math.min(task.endTime, viewEnd.getTime());
-                  if (clampedEnd <= viewStart.getTime() || clampedStart >= viewEnd.getTime()) {
+                  const clampedStart = Math.max(task.startTime, viewStartTime);
+                  const clampedEnd = Math.min(task.endTime, viewEndTime);
+                  if (clampedEnd <= viewStartTime || clampedStart >= viewEndTime) {
                     return null;
                   }
-                  const offset = ((clampedStart - viewStart.getTime()) / totalDuration) * 100;
-                  const width = Math.max(((clampedEnd - clampedStart) / totalDuration) * 100, 2);
+                  const offsetUnits = ((clampedStart - viewStartTime) / MS_IN_DAY) * timelineUnitScale;
+                  const endUnits = ((clampedEnd - viewStartTime) / MS_IN_DAY) * timelineUnitScale;
+                  const segmentUnits = Math.max(endUnits - offsetUnits, 0);
+                  const offset = (offsetUnits / scaledTimelineDuration) * 100;
+                  const width = Math.max((segmentUnits / scaledTimelineDuration) * 100, 2);
                   const top = TIMELINE_INSET + TASK_VERTICAL_OFFSET + laneIndex * LANE_HEIGHT;
                   const startDate = new Date(task.startTime);
                   const endDate = new Date(task.endTime - MS_IN_DAY);

--- a/src/components/GanttTimeline.tsx
+++ b/src/components/GanttTimeline.tsx
@@ -351,12 +351,17 @@ const GanttTimeline: React.FC<GanttTimelineProps> = ({
     if (segments.length === 0) {
       return undefined;
     }
-    const template = segments
-      .map((segment) => Math.max(1, Math.round((segment.end.getTime() - segment.start.getTime()) / MS_IN_DAY)))
-      .map((size) => `${size}fr`)
+    const durations = segments.map((segment) => {
+      const durationInDays = (segment.end.getTime() - segment.start.getTime()) / MS_IN_DAY;
+      return Math.max(1, durationInDays);
+    });
+    const totalDuration = durations.reduce((sum, value) => sum + value, 0);
+    const targetTotalUnits = scale === 'year' ? segments.length : 12;
+    const unitScale = totalDuration > 0 ? targetTotalUnits / totalDuration : 1;
+    return durations
+      .map((duration) => `${duration * unitScale}fr`)
       .join(' ');
-    return template;
-  }, [segments]);
+  }, [scale, segments]);
 
   const today = startOfDay(new Date());
   const todayOffset = today.getTime() >= viewStart.getTime() && today.getTime() <= viewEnd.getTime()

--- a/src/components/GanttTimeline.tsx
+++ b/src/components/GanttTimeline.tsx
@@ -50,6 +50,10 @@ const monthFormatter = new Intl.DateTimeFormat('ru-RU', {
 
 const kindPriority: GanttTimelineTaskKind[] = ['project', 'out-of-project', 'training'];
 
+const TIMELINE_INSET = 12;
+const LANE_HEIGHT = 72;
+const TASK_VERTICAL_OFFSET = 8;
+
 const capitalize = (value: string): string => {
   if (!value) {
     return value;
@@ -104,9 +108,15 @@ type NormalizedRow = {
   tasks: (NormalizedTask & { original: GanttTimelineTask })[];
 };
 
+type LaneGroupLayout = {
+  offset: number;
+  lanes: number;
+};
+
 type LaneLayout = {
   assignments: Map<string, number>;
   laneCount: number;
+  groups: Record<GanttTimelineTaskKind, LaneGroupLayout>;
 };
 
 const formatPeriod = (start: Date, end: Date): string => {
@@ -150,22 +160,28 @@ const assignLanesWithinGroup = (tasks: NormalizedTask[]): LaneLayout => {
 
 const buildLaneLayout = (tasks: NormalizedTask[]): LaneLayout => {
   const assignments = new Map<string, number>();
+  const groups = Object.fromEntries(
+    kindPriority.map((kind) => [kind, { offset: 0, lanes: 1 } satisfies LaneGroupLayout])
+  ) as Record<GanttTimelineTaskKind, LaneGroupLayout>;
   let laneOffset = 0;
 
   kindPriority.forEach((kind) => {
     const kindTasks = tasks.filter((task) => task.kind === kind);
-    if (kindTasks.length === 0) {
-      return;
-    }
     const { assignments: kindAssignments, laneCount } = assignLanesWithinGroup(kindTasks);
+    const lanes = Math.max(1, laneCount);
+    groups[kind] = { offset: laneOffset, lanes };
+
     kindTasks.forEach((task) => {
       const laneIndex = kindAssignments.get(task.id) ?? 0;
-      assignments.set(task.id, laneIndex + laneOffset);
+      assignments.set(task.id, laneOffset + laneIndex);
     });
-    laneOffset += laneCount;
+
+    laneOffset += lanes;
   });
 
-  return { assignments, laneCount: Math.max(laneOffset, tasks.length > 0 ? 1 : 0) };
+  const laneCount = Math.max(laneOffset, kindPriority.length);
+
+  return { assignments, laneCount, groups };
 };
 
 const computeViewRange = (allTasks: NormalizedTask[], scale: TimelineScale): { viewStart: Date; viewEnd: Date } => {
@@ -267,9 +283,18 @@ type GanttTimelineProps = {
   rows: GanttTimelineRow[];
   scale: TimelineScale;
   viewRange?: { start: Date | string; end: Date | string };
+  onTaskClick?: (payload: { rowId: string; task: GanttTimelineTask }) => void;
+  selectedTaskId?: string | null;
 };
 
-const GanttTimeline: React.FC<GanttTimelineProps> = ({ axisLabel, rows, scale, viewRange }) => {
+const GanttTimeline: React.FC<GanttTimelineProps> = ({
+  axisLabel,
+  rows,
+  scale,
+  viewRange,
+  onTaskClick,
+  selectedTaskId
+}) => {
   const normalizedRows = useMemo<NormalizedRow[]>(() => {
     return rows.map((row) => {
       const normalizedTasks = row.tasks.map((task) => {
@@ -333,6 +358,11 @@ const GanttTimeline: React.FC<GanttTimelineProps> = ({ axisLabel, rows, scale, v
     return template;
   }, [segments]);
 
+  const today = startOfDay(new Date());
+  const todayOffset = today.getTime() >= viewStart.getTime() && today.getTime() <= viewEnd.getTime()
+    ? ((Math.min(today.getTime(), viewEnd.getTime()) - viewStart.getTime()) / totalDuration) * 100
+    : null;
+
   return (
     <div className={timelineStyles.timeline}>
       <div className={timelineStyles.axisRow}>
@@ -345,6 +375,13 @@ const GanttTimeline: React.FC<GanttTimelineProps> = ({ axisLabel, rows, scale, v
           className={timelineStyles.axis}
           style={gridTemplateColumns ? { gridTemplateColumns } : undefined}
         >
+          {todayOffset !== null && (
+            <div
+              className={timelineStyles.todayIndicator}
+              style={{ left: `${todayOffset}%` }}
+              aria-hidden={true}
+            />
+          )}
           {segments.map((segment) => (
             <div key={`${segment.label}-${segment.start.getTime()}`} className={timelineStyles.axisCell}>
               <Text size="2xs" view="secondary">
@@ -359,13 +396,32 @@ const GanttTimeline: React.FC<GanttTimelineProps> = ({ axisLabel, rows, scale, v
           const laneLayout = buildLaneLayout(
             row.tasks.map((task) => ({ id: task.id, kind: task.kind, startTime: task.startTime, endTime: task.endTime }))
           );
-          const minHeight = Math.max(112, laneLayout.laneCount * 68 + 28);
+          const minHeight = TIMELINE_INSET * 2 + laneLayout.laneCount * LANE_HEIGHT;
 
           return (
             <div key={row.id} className={timelineStyles.row}>
               {row.sidebar}
               <div className={timelineStyles.timelineCell} style={{ minHeight }}>
-                <div className={timelineStyles.timelineLane} />
+                <div className={timelineStyles.timelineLane}>
+                  {kindPriority.map((kind) => {
+                    const group = laneLayout.groups[kind];
+                    return (
+                      <div
+                        key={`${row.id}-${kind}`}
+                        className={timelineStyles.laneSection}
+                        data-kind={kind}
+                        style={{ height: `${group.lanes * LANE_HEIGHT}px` }}
+                      />
+                    );
+                  })}
+                </div>
+                {todayOffset !== null && (
+                  <div
+                    className={timelineStyles.timelineTodayIndicator}
+                    style={{ left: `${todayOffset}%` }}
+                    aria-hidden={true}
+                  />
+                )}
                 {row.tasks.map((task) => {
                   const laneIndex = laneLayout.assignments.get(task.id) ?? 0;
                   const clampedStart = Math.max(task.startTime, viewStart.getTime());
@@ -375,17 +431,40 @@ const GanttTimeline: React.FC<GanttTimelineProps> = ({ axisLabel, rows, scale, v
                   }
                   const offset = ((clampedStart - viewStart.getTime()) / totalDuration) * 100;
                   const width = Math.max(((clampedEnd - clampedStart) / totalDuration) * 100, 2);
-                  const top = 8 + laneIndex * 68;
+                  const top = TIMELINE_INSET + TASK_VERTICAL_OFFSET + laneIndex * LANE_HEIGHT;
                   const startDate = new Date(task.startTime);
                   const endDate = new Date(task.endTime - MS_IN_DAY);
                   const periodLabel = formatPeriod(startDate, endDate);
+                  const isSelected = selectedTaskId === task.id;
+                  const isInteractive = typeof onTaskClick === 'function';
 
                   return (
                     <div
                       key={task.id}
                       className={timelineStyles.task}
                       data-kind={task.kind}
+                      data-selected={isSelected ? 'true' : 'false'}
+                      data-clickable={isInteractive ? 'true' : 'false'}
                       style={{ left: `${offset}%`, width: `${width}%`, top }}
+                      role={isInteractive ? 'button' : undefined}
+                      tabIndex={isInteractive ? 0 : undefined}
+                      onClick={
+                        isInteractive
+                          ? () => {
+                              onTaskClick?.({ rowId: row.id, task: task.original });
+                            }
+                          : undefined
+                      }
+                      onKeyDown={
+                        isInteractive
+                          ? (event) => {
+                              if (event.key === 'Enter' || event.key === ' ') {
+                                event.preventDefault();
+                                onTaskClick?.({ rowId: row.id, task: task.original });
+                              }
+                            }
+                          : undefined
+                      }
                     >
                       <Text size="xs" weight="semibold" className={timelineStyles.taskName} truncate>
                         {task.original.name}


### PR DESCRIPTION
## Summary
- default the employee workload period selectors to the server date and keep selections valid when timeline options change
- add an interactive task details panel beside the roadmap so that small cards can be opened for full descriptions
- rework the timeline lane layout to fixed thirds, prevent overlap per workload type, and draw a global today indicator

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691558a0582c833287f19fbbb4824a57)