### PR TITLE
Support dynamic roles in initiatives and skill freshness

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3634,7 +3634,8 @@ function buildExpertFromDraft(
   const skills = draft.skills.map((skill) => ({
     ...skill,
     artifacts: [...skill.artifacts],
-    usage: skill.usage ? { ...skill.usage } : undefined
+    usage: skill.usage ? { ...skill.usage } : undefined,
+    createdAt: skill.createdAt ?? new Date().toISOString()
   }));
 
   return {

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -3530,6 +3530,7 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
               level: definition.recommendedLevel as SkillLevel,
               proofStatus: 'claimed' as SkillEvidenceStatus,
               evidence: [],
+              createdAt: new Date().toISOString(),
               artifacts: [],
               interest: 'medium',
               availableFte: 0

--- a/src/components/InitiativeCreationModal.tsx
+++ b/src/components/InitiativeCreationModal.tsx
@@ -16,7 +16,7 @@ import type {
   InitiativeWorkItemStatus,
   TeamRole
 } from '../data';
-import { getSkillNameById, getSkillsByRole } from '../data/skills';
+import { getKnownRoles, getSkillNameById, getSkillsByRole } from '../data/skills';
 import InitiativeGanttChart, {
   type InitiativeGanttBlocker,
   type InitiativeGanttDependency,
@@ -239,17 +239,32 @@ const statusOptions: SelectOption<InitiativeStatus>[] = [
   { label: 'Конвертирована', value: 'converted' }
 ];
 
-const roleOptions: SelectOption<TeamRole>[] = [
-  { label: 'Владелец продукта', value: 'Владелец продукта' },
-  { label: 'Эксперт R&D', value: 'Эксперт R&D' },
-  { label: 'Аналитик', value: 'Аналитик' },
-  { label: 'Backend', value: 'Backend' },
-  { label: 'Frontend', value: 'Frontend' },
-  { label: 'Архитектор', value: 'Архитектор' },
-  { label: 'Тестировщик', value: 'Тестировщик' },
-  { label: 'Руководитель проекта', value: 'Руководитель проекта' },
-  { label: 'UX', value: 'UX' }
+const defaultRoles: TeamRole[] = [
+  'Владелец продукта',
+  'Эксперт R&D',
+  'Аналитик',
+  'Backend',
+  'Frontend',
+  'Архитектор',
+  'Тестировщик',
+  'Руководитель проекта',
+  'UX'
 ];
+
+const mergeRoles = (base: TeamRole[], extra: TeamRole[]): TeamRole[] => {
+  const set = new Set<TeamRole>();
+  base.forEach((role) => set.add(role));
+  extra.forEach((role) => {
+    const normalized = role.trim();
+    if (normalized) {
+      set.add(normalized as TeamRole);
+    }
+  });
+  return Array.from(set);
+};
+
+const buildRoleOptions = (roles: TeamRole[]): SelectOption<TeamRole>[] =>
+  roles.map((role) => ({ label: role, value: role }));
 
 const workItemStatusOptions: SelectOption<InitiativeWorkItemStatus>[] = [
   { label: 'Исследование', value: 'discovery' },
@@ -318,8 +333,10 @@ const startDateFormatter = new Intl.DateTimeFormat('ru-RU', {
   year: 'numeric'
 });
 
+const DEFAULT_ROLE: TeamRole = 'Аналитик';
+
 const createWorkAssignmentDraft = (
-  role: TeamRole = roleOptions[0].value,
+  role: TeamRole = DEFAULT_ROLE,
   startDay = 0,
   durationDays = 5
 ): WorkAssignmentDraft => ({
@@ -335,7 +352,7 @@ const createWorkAssignmentDraft = (
   startDate: null
 });
 
-const createWorkDraft = (offset = 0): WorkDraft => ({
+const createWorkDraft = (role: TeamRole = DEFAULT_ROLE, offset = 0): WorkDraft => ({
   id: createId(),
   title: '',
   description: '',
@@ -343,7 +360,7 @@ const createWorkDraft = (offset = 0): WorkDraft => ({
   owner: '',
   timeframe: '',
   status: 'discovery',
-  assignments: [createWorkAssignmentDraft(roleOptions[0].value, offset)]
+  assignments: [createWorkAssignmentDraft(role, offset)]
 });
 
 const createApprovalStageDraft = (): ApprovalStageDraft => ({
@@ -354,7 +371,10 @@ const createApprovalStageDraft = (): ApprovalStageDraft => ({
   comment: ''
 });
 
-const buildWorksFromCreationDraft = (draft: InitiativeCreationRequest): WorkDraft[] => {
+const buildWorksFromCreationDraft = (
+  draft: InitiativeCreationRequest,
+  defaultRole: TeamRole
+): WorkDraft[] => {
   const workMap = new Map<string, WorkDraft>();
   const baseStartDate = draft.startDate ? startOfDay(new Date(draft.startDate)) : null;
   const workItemMetadata = new Map(
@@ -456,7 +476,7 @@ const buildWorksFromCreationDraft = (draft: InitiativeCreationRequest): WorkDraf
       owner: metadata.owner ?? '',
       timeframe: metadata.timeframe ?? '',
       status: metadata.status ?? 'discovery',
-      assignments: [createWorkAssignmentDraft()]
+      assignments: [createWorkAssignmentDraft(defaultRole)]
     });
   });
 
@@ -467,7 +487,7 @@ const buildWorksFromCreationDraft = (draft: InitiativeCreationRequest): WorkDraf
       work.assignments.length > 0 ? work.assignments : [createWorkAssignmentDraft()]
   }));
 
-  return works.length > 0 ? works : [createWorkDraft()];
+  return works.length > 0 ? works : [createWorkDraft(defaultRole)];
 };
 
 const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
@@ -553,12 +573,21 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
   const [customerRepresentative, setCustomerRepresentative] = useState('');
   const [customerContact, setCustomerContact] = useState('');
   const [customerComment, setCustomerComment] = useState('');
-  const [works, setWorks] = useState<WorkDraft[]>([createWorkDraft()]);
+  const [works, setWorks] = useState<WorkDraft[]>([createWorkDraft(DEFAULT_ROLE)]);
   const [approvalStages, setApprovalStages] = useState<ApprovalStageDraft[]>([
     createApprovalStageDraft()
   ]);
   const [activeStep, setActiveStep] = useState<CreationStep>('details');
   const skillRegistryVersion = useSkillRegistryVersion();
+  const roleOptions = useMemo<SelectOption<TeamRole>[]>(() => {
+    const registryRoles = getKnownRoles();
+    const mergedRoles = mergeRoles(defaultRoles, registryRoles);
+    return buildRoleOptions(mergedRoles);
+  }, [skillRegistryVersion]);
+  const primaryRole = useMemo<TeamRole>(
+    () => roleOptions[0]?.value ?? DEFAULT_ROLE,
+    [roleOptions]
+  );
   const baseRoleSkillOptions = useMemo<Record<TeamRole, OptionItem[]>>(
     () =>
       roleOptions.reduce((acc, option) => {
@@ -573,7 +602,7 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
         acc[option.value] = skillOptions;
         return acc;
       }, {} as Record<TeamRole, OptionItem[]>),
-    [skillRegistryVersion]
+    [roleOptions, skillRegistryVersion]
   );
   const createRoleSkillState = useCallback(
     () =>
@@ -581,11 +610,33 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
         acc[option.value] = [...(baseRoleSkillOptions[option.value] ?? [])];
         return acc;
       }, {} as Record<TeamRole, OptionItem[]>),
-    [baseRoleSkillOptions]
+    [baseRoleSkillOptions, roleOptions]
   );
   const [roleSkillOptions, setRoleSkillOptions] = useState<Record<TeamRole, OptionItem[]>>(
     () => createRoleSkillState()
   );
+
+  useEffect(() => {
+    setRoleSkillOptions((prev) => {
+      const next = createRoleSkillState();
+
+      Object.entries(prev).forEach(([role, options]) => {
+        const roleKey = role as TeamRole;
+        const existing = next[roleKey] ?? [];
+        const merged = [...existing];
+
+        options.forEach((option) => {
+          if (!merged.some((item) => item.value === option.value)) {
+            merged.push(option);
+          }
+        });
+
+        next[roleKey] = merged.sort((a, b) => a.label.localeCompare(b.label, 'ru'));
+      });
+
+      return next;
+    });
+  }, [createRoleSkillState]);
 
   const hydrateFromDraft = useCallback(
     (draft: InitiativeCreationRequest | null) => {
@@ -614,7 +665,7 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
         setCustomerRepresentative('');
         setCustomerContact('');
         setCustomerComment('');
-        setWorks([createWorkDraft()]);
+        setWorks([createWorkDraft(primaryRole)]);
         setApprovalStages([createApprovalStageDraft()]);
         setRoleSkillOptions(createRoleSkillState());
         setActiveStep('details');
@@ -728,7 +779,7 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
       setCustomerContact(draft.customer?.contact ?? '');
       setCustomerComment(draft.customer?.comment ?? '');
 
-      const worksFromDraft = buildWorksFromCreationDraft(draft);
+      const worksFromDraft = buildWorksFromCreationDraft(draft, primaryRole);
       setWorks(worksFromDraft);
 
       const nextRoleSkills = createRoleSkillState();
@@ -771,6 +822,7 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
       companyBaseItems,
       createRoleSkillState,
       domainBaseItems,
+      primaryRole,
       moduleBaseItems,
       unitBaseItems
     ]
@@ -1529,7 +1581,7 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
   };
 
   const handleAddWork = () => {
-    setWorks((prev) => [...prev, createWorkDraft(prev.length * 5)]);
+    setWorks((prev) => [...prev, createWorkDraft(primaryRole, prev.length * 5)]);
   };
 
   const handleApprovalStageChange = (
@@ -1572,7 +1624,7 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
                 Math.round(lastAssignment?.durationDays ?? 5)
               );
               const nextAssignment = createWorkAssignmentDraft(
-                lastAssignment?.role ?? roleOptions[0].value,
+                lastAssignment?.role ?? primaryRole,
                 nextStart,
                 defaultDuration
               );
@@ -2108,7 +2160,10 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
                             <div className={styles.assignmentGrid}>
                               {work.assignments.map((assignment, index) => {
                                 const roleOption =
-                                  roleOptions.find((option) => option.value === assignment.role) ?? roleOptions[0];
+                                  roleOptions.find((option) => option.value === assignment.role) ?? {
+                                    label: primaryRole,
+                                    value: primaryRole
+                                  };
                                 const skillOptionsForRole = roleSkillOptions[assignment.role] ?? [];
                                 const selectedTask =
                                   skillOptionsForRole.find((option) => option.value === assignment.task) ?? null;

--- a/src/data.ts
+++ b/src/data.ts
@@ -85,6 +85,7 @@ export type ExpertSkill = {
   proofStatus: SkillEvidenceStatus;
   evidence: SkillEvidenceRecord[];
   usage?: SkillUsage;
+  createdAt?: string;
   artifacts: string[];
   interest: SkillInterestLevel;
   availableFte: number;

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -617,6 +617,14 @@ export const skills = skillRegistry;
 
 export { roleToSkillsMap };
 
+export const getKnownRoles = (): TeamRole[] => {
+  const roles = new Set<TeamRole>();
+  Object.keys(roleToSkillsMap).forEach((role) => {
+    roles.add(role as TeamRole);
+  });
+  return Array.from(roles).sort((a, b) => a.localeCompare(b, 'ru'));
+};
+
 export const getSkillRegistryVersion = (): number => registryVersion;
 
 export const subscribeToSkillRegistry = (listener: SkillListener): (() => void) => {

--- a/src/services/expertSkills.ts
+++ b/src/services/expertSkills.ts
@@ -15,10 +15,10 @@ const collectSkillStatuses = (skill: ExpertSkill): SkillEvidenceStatus[] => {
  */
 export const getSkillLastUsedDate = (skill: ExpertSkill): string | undefined => {
   if (!skill.usage) {
-    return undefined;
+    return skill.createdAt;
   }
 
-  const candidates = [skill.usage.to, skill.usage.from].filter(
+  const candidates = [skill.usage.to, skill.usage.from, skill.createdAt].filter(
     (value): value is string => Boolean(value)
   );
 

--- a/src/utils/expertExcel.ts
+++ b/src/utils/expertExcel.ts
@@ -545,10 +545,20 @@ const parseRoles = (raw: string): TeamRole[] => {
   if (!raw) {
     return [];
   }
-  const knownRoles = new Set(Object.keys(roleToSkillsMap) as TeamRole[]);
+  const seen = new Set<string>();
   return splitMultiline(raw)
     .map((value) => value.trim())
-    .filter((value): value is TeamRole => knownRoles.has(value as TeamRole));
+    .filter((value): value is TeamRole => {
+      if (!value) {
+        return false;
+      }
+      const normalized = value.toLowerCase();
+      if (seen.has(normalized)) {
+        return false;
+      }
+      seen.add(normalized);
+      return true;
+    });
 };
 
 const coerceNumber = (value: string | number): number => {
@@ -579,6 +589,7 @@ export const parseExpertWorkbook = ({
 
   const profileValues = new Map<string, string>();
   const competencyRows: Array<{ name: string; level: string; proof: string; rowNumber: number }> = [];
+  const skillCreationTimestamp = new Date().toISOString();
   if (profileSheet) {
     const rows = utils.sheet_to_json<(string | number)[]>(profileSheet, {
       header: 1,
@@ -955,6 +966,7 @@ export const parseExpertWorkbook = ({
       level,
       proofStatus,
       evidence: [],
+      createdAt: skillCreationTimestamp,
       artifacts,
       interest,
       availableFte,
@@ -977,6 +989,7 @@ export const parseExpertWorkbook = ({
       level: override.level,
       proofStatus: override.proofStatus,
       evidence: [],
+      createdAt: skillCreationTimestamp,
       artifacts: [],
       interest: 'medium',
       availableFte: 0


### PR DESCRIPTION
## Summary
- surface roles from the skill registry in initiative planning so newly added skills and roles appear in work assignments
- capture skill creation timestamps when adding experts manually or via Excel import and use them when deriving freshness
- expose known roles from the skill registry for downstream consumers

## Testing
- npm run build *(fails: Rollup cannot resolve optional dependency `xlsx` during Vite build)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a4a0b7d4c8332972e9dc45b9c31df)