### PR TITLE
Add employee support to graph creation and import/export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -178,8 +178,8 @@ function App() {
   const [graphNameDraft, setGraphNameDraft] = useState('');
   const [graphSourceIdDraft, setGraphSourceIdDraft] = useState<string | null>(null);
   const [graphCopyOptions, setGraphCopyOptions] = useState<
-    Set<'domains' | 'modules' | 'artifacts' | 'initiatives'>
-  >(() => new Set(['domains', 'modules', 'artifacts', 'initiatives']));
+    Set<'domains' | 'modules' | 'artifacts' | 'experts' | 'initiatives'>
+  >(() => new Set(['domains', 'modules', 'artifacts', 'experts', 'initiatives']));
   const [isGraphActionInProgress, setIsGraphActionInProgress] = useState(false);
   const [graphActionStatus, setGraphActionStatus] = useState<
     { type: 'success' | 'error'; message: string } | null
@@ -1092,6 +1092,7 @@ function App() {
         { id: 'domains' as const, label: 'Домены' },
         { id: 'modules' as const, label: 'Модули' },
         { id: 'artifacts' as const, label: 'Артефакты' },
+        { id: 'experts' as const, label: 'Сотрудники' },
         { id: 'initiatives' as const, label: 'Инициативы' }
       ],
     []
@@ -2913,6 +2914,7 @@ function App() {
       includeDomains: boolean;
       includeModules: boolean;
       includeArtifacts: boolean;
+      includeExperts: boolean;
       includeInitiatives: boolean;
     }) => {
       try {
@@ -2925,6 +2927,7 @@ function App() {
           domains: snapshot.domains.length,
           modules: snapshot.modules.length,
           artifacts: snapshot.artifacts.length,
+          experts: snapshot.experts?.length ?? 0,
           initiatives: snapshot.initiatives?.length ?? 0
         };
       } catch (error) {
@@ -2969,6 +2972,7 @@ function App() {
     const includeDomains = graphCopyOptions.has('domains');
     const includeModules = graphCopyOptions.has('modules');
     const includeArtifacts = graphCopyOptions.has('artifacts');
+    const includeExperts = graphCopyOptions.has('experts');
     const includeInitiatives = graphCopyOptions.has('initiatives');
 
     if (
@@ -2976,6 +2980,7 @@ function App() {
       !includeDomains &&
       !includeModules &&
       !includeArtifacts &&
+      !includeExperts &&
       !includeInitiatives
     ) {
       setGraphActionStatus({
@@ -2993,6 +2998,7 @@ function App() {
         includeDomains,
         includeModules,
         includeArtifacts,
+        includeExperts,
         includeInitiatives
       });
       setGraphActionStatus({
@@ -3001,7 +3007,7 @@ function App() {
       });
       setGraphNameDraft('');
       setGraphSourceIdDraft(null);
-      setGraphCopyOptions(new Set(['domains', 'modules', 'artifacts', 'initiatives']));
+      setGraphCopyOptions(new Set(['domains', 'modules', 'artifacts', 'experts', 'initiatives']));
       setIsCreatePanelOpen(false);
       await refreshGraphs(created.id, { preserveSelection: false });
       showAdminNotice('success', `Граф «${created.name}» создан.`);
@@ -3540,6 +3546,7 @@ function App() {
           modules={moduleData}
           domains={domainData}
           artifacts={artifactData}
+          experts={expertProfiles}
           initiatives={initiativeData}
           onImport={handleImportGraph}
           onImportFromGraph={handleImportFromExistingGraph}

--- a/src/components/GraphPersistenceControls.tsx
+++ b/src/components/GraphPersistenceControls.tsx
@@ -4,7 +4,7 @@ import { CheckboxGroup } from '@consta/uikit/CheckboxGroup';
 import { Select } from '@consta/uikit/Select';
 import { Text } from '@consta/uikit/Text';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { ArtifactNode, DomainNode, Initiative, ModuleNode } from '../data';
+import type { ArtifactNode, DomainNode, ExpertProfile, Initiative, ModuleNode } from '../data';
 import { normalizeLayoutSnapshot } from '../services/graphStorage';
 import {
   GRAPH_SNAPSHOT_VERSION,
@@ -23,6 +23,7 @@ type GraphPersistenceControlsProps = {
   modules: ModuleNode[];
   domains: DomainNode[];
   artifacts: ArtifactNode[];
+  experts: ExpertProfile[];
   initiatives: Initiative[];
   onImport: (snapshot: GraphSnapshotPayload) => void;
   onImportFromGraph?: (request: {
@@ -30,8 +31,9 @@ type GraphPersistenceControlsProps = {
     includeDomains: boolean;
     includeModules: boolean;
     includeArtifacts: boolean;
+    includeExperts: boolean;
     includeInitiatives: boolean;
-  }) => Promise<{ domains: number; modules: number; artifacts: number; initiatives: number }>;
+  }) => Promise<{ domains: number; modules: number; artifacts: number; experts: number; initiatives: number }>;
   graphs?: GraphSummary[];
   activeGraphId?: string | null;
   isGraphListLoading?: boolean;
@@ -43,6 +45,7 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
   modules,
   domains,
   artifacts,
+  experts,
   initiatives,
   onImport,
   onImportFromGraph,
@@ -56,8 +59,8 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
   const [status, setStatus] = useState<StatusMessage | null>(null);
   const [sourceGraphId, setSourceGraphId] = useState<string | null>(null);
   const [copyOptions, setCopyOptions] = useState<
-    Set<'domains' | 'modules' | 'artifacts' | 'initiatives'>
-  >(() => new Set(['domains', 'modules', 'artifacts', 'initiatives']));
+    Set<'domains' | 'modules' | 'artifacts' | 'experts' | 'initiatives'>
+  >(() => new Set(['domains', 'modules', 'artifacts', 'experts', 'initiatives']));
   const [isGraphImporting, setIsGraphImporting] = useState(false);
 
   const buildSnapshot = useCallback((): GraphSnapshotPayload => {
@@ -68,10 +71,11 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
       modules,
       domains,
       artifacts,
+      experts,
       initiatives,
       layout: sanitizedLayout
     };
-  }, [artifacts, domains, initiatives, layout, modules]);
+  }, [artifacts, domains, experts, initiatives, layout, modules]);
 
   const handleExport = () => {
     try {
@@ -123,10 +127,12 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
         const moduleCount = normalized.modules.length;
         const domainCount = normalized.domains.length;
         const artifactCount = normalized.artifacts.length;
+        const expertCount = normalized.experts?.length ?? 0;
         const initiativeCount = normalized.initiatives?.length ?? 0;
         setStatus({
           type: 'success',
-          message: `Импорт завершён. Модулей: ${moduleCount}, доменов: ${domainCount}, артефактов: ${artifactCount}, инициатив: ${initiativeCount}.`
+          message:
+            `Импорт завершён. Модулей: ${moduleCount}, доменов: ${domainCount}, артефактов: ${artifactCount}, сотрудников: ${expertCount}, инициатив: ${initiativeCount}.`
         });
       } catch (error) {
         setStatus({
@@ -175,6 +181,7 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
         { id: 'domains' as const, label: 'Домены' },
         { id: 'modules' as const, label: 'Модули' },
         { id: 'artifacts' as const, label: 'Артефакты' },
+        { id: 'experts' as const, label: 'Сотрудники' },
         { id: 'initiatives' as const, label: 'Инициативы' }
       ],
     []
@@ -211,12 +218,14 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
         includeDomains: copyOptions.has('domains'),
         includeModules: copyOptions.has('modules'),
         includeArtifacts: copyOptions.has('artifacts'),
+        includeExperts: copyOptions.has('experts'),
         includeInitiatives: copyOptions.has('initiatives')
       });
       const graphName = graphs?.find((graph) => graph.id === sourceGraphId)?.name ?? 'выбранного графа';
       setStatus({
         type: 'success',
-        message: `Импорт завершён из графа «${graphName}». Модулей: ${result.modules}, доменов: ${result.domains}, артефактов: ${result.artifacts}, инициатив: ${result.initiatives}.`
+        message:
+          `Импорт завершён из графа «${graphName}». Модулей: ${result.modules}, доменов: ${result.domains}, артефактов: ${result.artifacts}, сотрудников: ${result.experts}, инициатив: ${result.initiatives}.`
       });
     } catch (error) {
       setStatus({
@@ -368,6 +377,7 @@ type GraphSnapshotLike = {
   modules: ModuleNode[];
   domains: DomainNode[];
   artifacts: ArtifactNode[];
+  experts?: ExpertProfile[];
   initiatives?: Initiative[];
   layout?: GraphSnapshotPayload['layout'];
 };
@@ -382,8 +392,13 @@ function isGraphSnapshotLike(value: unknown): value is GraphSnapshotLike {
     !Array.isArray(candidate.modules) ||
     !Array.isArray(candidate.domains) ||
     !Array.isArray(candidate.artifacts) ||
+    (candidate.experts !== undefined && !Array.isArray(candidate.experts)) ||
     (candidate.initiatives !== undefined && !Array.isArray(candidate.initiatives))
   ) {
+    return false;
+  }
+
+  if (candidate.experts !== undefined && !Array.isArray(candidate.experts)) {
     return false;
   }
 
@@ -408,6 +423,7 @@ function normalizeImportedSnapshot(snapshot: GraphSnapshotLike): GraphSnapshotPa
     modules: snapshot.modules,
     domains: snapshot.domains,
     artifacts: snapshot.artifacts,
+    experts: snapshot.experts ?? undefined,
     initiatives: snapshot.initiatives ?? [],
     layout: normalizeLayoutSnapshot(snapshot.layout) ?? undefined
   };

--- a/src/services/graphStorage.ts
+++ b/src/services/graphStorage.ts
@@ -32,6 +32,7 @@ export async function createGraph(
     includeDomains: boolean;
     includeModules: boolean;
     includeArtifacts: boolean;
+    includeExperts: boolean;
     includeInitiatives: boolean;
   },
   signal?: AbortSignal
@@ -163,7 +164,7 @@ export async function importGraphFromSource(
     domains: request.includeDomains ? snapshot.domains : [],
     modules: request.includeModules ? snapshot.modules : [],
     artifacts: request.includeArtifacts ? snapshot.artifacts : [],
-    experts: snapshot.experts ?? [],
+    experts: request.includeExperts ? snapshot.experts ?? [] : [],
     initiatives: request.includeInitiatives ? snapshot.initiatives ?? [] : [],
     layout:
       request.includeModules && snapshot.layout

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -48,5 +48,6 @@ export type GraphCopyRequest = {
   includeDomains: boolean;
   includeModules: boolean;
   includeArtifacts: boolean;
+  includeExperts: boolean;
   includeInitiatives: boolean;
 };


### PR DESCRIPTION
## Summary
- include employees in graph export/import snapshots and graph-to-graph copy flows
- extend graph creation copy options and API requests to handle employees

## Testing
- npm run lint (fails: InitiativeCreationModal useMemo dependency warning; expertExcel unused variable error)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a54c0f1e88332bccbe47452ce908e)