### PR TITLE
Ensure employee tasks reflect admin data and register imported skills

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3534,7 +3534,7 @@ function App() {
         aria-hidden={!isEmployeeTasksActive}
         style={{ display: isEmployeeTasksActive ? undefined : 'none' }}
       >
-        <EmployeeWorkloadTrack />
+        <EmployeeWorkloadTrack experts={expertProfiles} initiatives={initiativeData} />
       </main>
       <main
         className={styles.creationMain}

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -29,6 +29,7 @@ import {
   type UserStats,
   evidenceStatuses,
   getSkillNameById,
+  getRolesForSkill,
   getSkillsByRole,
   registerRoleCompetency,
   registerSkillDefinition,
@@ -3163,10 +3164,39 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
     setImportState(null);
   };
 
+  const ensureImportedSkillsRegistered = useCallback(() => {
+    if (!importState) {
+      return;
+    }
+    const importRole = importState.draft.title.trim();
+
+    importState.draft.skills.forEach((skill) => {
+      const existingName = getSkillNameById(skill.id);
+      const currentRoles = getRolesForSkill(skill.id);
+      const shouldAttachRole = importRole
+        ? !currentRoles.includes(importRole as TeamRole)
+        : false;
+
+      if (!existingName || shouldAttachRole) {
+        registerSkillDefinition({
+          id: skill.id,
+          name: existingName ?? skill.id,
+          description: existingName ?? skill.id,
+          category: 'hard',
+          sources: [],
+          recommendedLevel: 'P',
+          evidenceStatus: 'screened',
+          roles: shouldAttachRole ? [...currentRoles, importRole as TeamRole] : currentRoles
+        });
+      }
+    });
+  }, [importState]);
+
   const handleImportApply = () => {
     if (!importState) {
       return;
     }
+    ensureImportedSkillsRegistered();
     onChange(importState.draft);
     setImportState(null);
     setIsImportModalOpen(false);

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -28,6 +28,7 @@ import {
   type TeamRole,
   type UserStats,
   evidenceStatuses,
+  findSkillByName,
   getSkillNameById,
   getRolesForSkill,
   getSkillsByRole,
@@ -3102,6 +3103,14 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
 
   const formatList = (values: string[]): string => values.join('\n');
 
+  const slugifySkillId = (name: string): string =>
+    name
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9\u0400-\u04ff]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .replace(/-{2,}/g, '-');
+
   const buildExportFileName = () => {
     const baseName = draft.fullName.trim() || 'expert-profile';
     const normalized = baseName
@@ -3305,6 +3314,57 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
       if (!prev) {
         return prev;
       }
+
+      const normalizedRole = entry.roleTitle.trim();
+      const existingDefinition = findSkillByName(entry.competencyName);
+      const competencyRecord = prev.draft.competencyRecords?.find(
+        (record) => record.name === entry.competencyName
+      );
+      const level = competencyRecord?.level ?? 'P';
+      const proofStatus = competencyRecord?.proofStatus ?? 'screened';
+      const skillId = existingDefinition?.id ?? slugifySkillId(entry.competencyName);
+      const mergedRoles = existingDefinition?.roles ?? [];
+      const shouldAttachRole =
+        normalizedRole && !mergedRoles.includes(normalizedRole as TeamRole)
+          ? [...mergedRoles, normalizedRole as TeamRole]
+          : mergedRoles;
+
+      registerSkillDefinition({
+        id: skillId,
+        name: existingDefinition?.name ?? entry.competencyName,
+        description: existingDefinition?.description ?? entry.competencyName,
+        category: 'hard',
+        sources: existingDefinition?.sources ?? [],
+        recommendedLevel: existingDefinition?.recommendedLevel ?? level,
+        evidenceStatus: existingDefinition?.evidenceStatus ?? proofStatus,
+        roles: shouldAttachRole
+      });
+
+      const existingSkill = prev.draft.skills.find((skill) => skill.id === skillId);
+      const nextSkills = existingSkill
+        ? prev.draft.skills.map((skill) =>
+            skill.id === skillId ? { ...skill, level, proofStatus } : skill
+          )
+        : [
+            ...prev.draft.skills,
+            {
+              id: skillId,
+              level,
+              proofStatus,
+              evidence: [],
+              artifacts: [],
+              createdAt: new Date().toISOString(),
+              interest: 'medium',
+              availableFte: 0
+            }
+          ];
+
+      const nextCompetencies = updateCompetenciesFromSkills(
+        nextSkills,
+        prev.draft.competencies,
+        prev.draft.competencyRecords ?? []
+      );
+
       const pendingCompetencies = prev.pendingCompetencies.filter(
         (item) =>
           item.competencyName !== entry.competencyName || item.roleTitle !== entry.roleTitle
@@ -3315,15 +3375,21 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
       );
       return {
         ...prev,
+        draft: {
+          ...prev.draft,
+          skills: nextSkills,
+          competencies: nextCompetencies.names,
+          competencyRecords: nextCompetencies.records
+        },
         pendingCompetencies,
         result: {
           ...prev.result,
           missingCompetencies: remainingMissing,
           warnings: [
             ...prev.result.warnings,
-            `Компетенция «${entry.competencyName}» добавлена в базу роли «${
+            `Компетенция «${entry.competencyName}» добавлена как hard skill и связана с ролью «${
               entry.roleTitle || 'роль не указана'
-            }» и будет импортирована.`
+            }».`
           ]
         }
       };

--- a/src/components/EmployeeWorkloadTrack.tsx
+++ b/src/components/EmployeeWorkloadTrack.tsx
@@ -8,6 +8,7 @@ import { Tabs } from '@consta/uikit/Tabs';
 import { Text } from '@consta/uikit/Text';
 import { TextField } from '@consta/uikit/TextField';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import type { ExpertProfile, Initiative } from '../data';
 import GanttTimeline, {
   type GanttTimelineTask,
   type GanttTimelineTaskKind,
@@ -296,7 +297,7 @@ const systemOptions: SelectOption<string>[] = [
   { label: 'Лаборатория продвинутой аналитики', value: 'system-analytics-lab' }
 ];
 
-const initiativeOptions: SelectOption<string>[] = [
+const defaultInitiativeOptions: SelectOption<string>[] = [
   { label: 'Цифровизация добычи 2025', value: 'initiative-digital-2025' },
   { label: 'Экосистема интеллектуальных скважин', value: 'initiative-smart-wells' },
   { label: 'Программа беспилотного мониторинга', value: 'initiative-drone-monitoring' },
@@ -609,7 +610,7 @@ const defaultTaskDraft: TaskDraft = {
   predecessorId: null,
   relationType: 'system',
   relatedSystemId: systemOptions[0]?.value ?? null,
-  relatedInitiativeId: initiativeOptions[0]?.value ?? null
+  relatedInitiativeId: defaultInitiativeOptions[0]?.value ?? null
 };
 
 const parseDateValue = (value: string): Date | null => {
@@ -993,7 +994,10 @@ const createPreviewTaskFromDraft = (draft: TaskDraft, id = 'draft'): TaskListIte
   };
 };
 
-const mapTaskToDraft = (task: TaskListItem): TaskDraft => {
+const mapTaskToDraft = (
+  task: TaskListItem,
+  initiativeOptions: SelectOption<string>[]
+): TaskDraft => {
   const draft: TaskDraft = {
     name: task.name,
     priority: task.priority,
@@ -1056,7 +1060,60 @@ const timelineModeTabs = [
 
 type TimelineMode = (typeof timelineModeTabs)[number];
 
-const EmployeeWorkloadTrack: React.FC = () => {
+type EmployeeWorkloadTrackProps = {
+  experts: ExpertProfile[];
+  initiatives: Initiative[];
+};
+
+const EmployeeWorkloadTrack: React.FC<EmployeeWorkloadTrackProps> = ({
+  experts,
+  initiatives
+}) => {
+  const initiativeOptions = useMemo<SelectOption<string>[]>(() => {
+    const base = initiatives.map<SelectOption<string>>((initiative) => ({
+      label: initiative.name,
+      value: initiative.id
+    }));
+    if (base.length > 0) {
+      return base;
+    }
+    return defaultInitiativeOptions;
+  }, [initiatives]);
+
+  const dynamicEmployees = useMemo<EmployeeWorkload[]>(() => {
+    const toWorkloadValue = (availability: ExpertProfile['availability']): number => {
+      switch (availability) {
+        case 'busy':
+          return 0.95;
+        case 'partial':
+          return 0.65;
+        default:
+          return 0.35;
+      }
+    };
+
+    return experts.map<EmployeeWorkload>((expert, index) => ({
+      id: expert.id,
+      fullName: expert.fullName,
+      position: expert.title,
+      rank: index + 1,
+      workload: toWorkloadValue(expert.availability),
+      availability: expert.availabilityComment || 'Доступен под запрос',
+      focus: expert.focusAreas[0] ?? expert.summary ?? 'Задачи уточняются',
+      tasks: []
+    }));
+  }, [experts]);
+
+  const employees = useMemo(() => {
+    const existingIds = new Set(mockEmployees.map((employee) => employee.id));
+    const merged = [...mockEmployees];
+    dynamicEmployees.forEach((employee) => {
+      if (!existingIds.has(employee.id)) {
+        merged.push(employee);
+      }
+    });
+    return merged;
+  }, [dynamicEmployees]);
   const [scale, setScale] = useState<TimelineScaleTab>(timelineScaleTabs[1]);
   const [timelineMode, setTimelineMode] = useState<TimelineMode>(timelineModeTabs[0]);
   const initialStoredTasks = useMemo(() => loadStoredTasks() ?? initialTaskList, []);
@@ -1066,7 +1123,10 @@ const EmployeeWorkloadTrack: React.FC = () => {
     initialStoredTasks[0]?.id ?? null
   );
   const [activeView, setActiveView] = useState<ViewTab>(viewTabs[0]);
-  const [taskDraft, setTaskDraft] = useState<TaskDraft>(defaultTaskDraft);
+  const [taskDraft, setTaskDraft] = useState<TaskDraft>((): TaskDraft => ({
+    ...defaultTaskDraft,
+    relatedInitiativeId: initiativeOptions[0]?.value ?? null
+  }));
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
 
@@ -1145,7 +1205,7 @@ const EmployeeWorkloadTrack: React.FC = () => {
   }, []);
 
   const timelineDateTasks = useMemo(() => {
-    const projectTasks = mockEmployees.flatMap((employee) =>
+    const projectTasks = employees.flatMap((employee) =>
       employee.tasks.map((task) => ({
         start: startOfDay(toDate(task.start)),
         end: startOfDay(toDate(task.end))
@@ -1158,7 +1218,7 @@ const EmployeeWorkloadTrack: React.FC = () => {
     }));
 
     return [...projectTasks, ...teamTasks];
-  }, [teamTaskWindows]);
+  }, [employees, teamTaskWindows]);
 
   const minTaskStart = useMemo(() => {
     if (timelineDateTasks.length === 0) {
@@ -1212,6 +1272,20 @@ const EmployeeWorkloadTrack: React.FC = () => {
     }));
   }, [periodOptions]);
 
+  useEffect(() => {
+    setTaskDraft((prev) => {
+      const nextInitiativeId = prev.relatedInitiativeId && initiativeOptions.some((option) => option.value === prev.relatedInitiativeId)
+        ? prev.relatedInitiativeId
+        : initiativeOptions[0]?.value ?? null;
+
+      if (nextInitiativeId === prev.relatedInitiativeId) {
+        return prev;
+      }
+
+      return { ...prev, relatedInitiativeId: nextInitiativeId };
+    });
+  }, [initiativeOptions]);
+
   const currentPeriodOptions = periodOptions[scale.value];
   const selectedPeriodValue = selectedPeriods[scale.value];
   const activePeriod = currentPeriodOptions.find((option) => option.value === selectedPeriodValue) ?? null;
@@ -1221,18 +1295,18 @@ const EmployeeWorkloadTrack: React.FC = () => {
     : undefined;
 
   const assigneeOptions = useMemo<SelectOption<string>[]>(() => {
-    return mockEmployees.map((employee) => ({
+    return employees.map((employee) => ({
       label: employee.fullName,
       value: employee.id
     }));
-  }, []);
+  }, [employees]);
 
   const employeeNameMap = useMemo<Record<string, string>>(() => {
-    return mockEmployees.reduce<Record<string, string>>((acc, employee) => {
+    return employees.reduce<Record<string, string>>((acc, employee) => {
       acc[employee.id] = employee.fullName;
       return acc;
     }, {});
-  }, []);
+  }, [employees]);
 
   const systemNameMap = useMemo<Record<string, string>>(() => {
     return systemOptions.reduce<Record<string, string>>((acc, option) => {
@@ -1246,7 +1320,7 @@ const EmployeeWorkloadTrack: React.FC = () => {
       acc[option.value] = option.label;
       return acc;
     }, {});
-  }, []);
+  }, [initiativeOptions]);
 
   const mergeInitiativeTasks = useCallback(
     (tasks: WorkloadTask[]): WorkloadTask[] => {
@@ -1318,7 +1392,7 @@ const EmployeeWorkloadTrack: React.FC = () => {
   const timelineData = useMemo(() => {
     const taskLookup = new Map<string, { task: WorkloadTask; employee: EmployeeWorkload }>();
 
-    const rows = mockEmployees.map((employee) => {
+    const rows = employees.map((employee) => {
       const sortedTasks = employee.tasks
         .slice()
         .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
@@ -1386,7 +1460,7 @@ const EmployeeWorkloadTrack: React.FC = () => {
     });
 
     return { timelineRows: rows, timelineTaskLookup: taskLookup };
-  }, [mergeInitiativeTasks, teamTimelineTasksByEmployee, timelineMode.value]);
+  }, [employees, mergeInitiativeTasks, teamTimelineTasksByEmployee, timelineMode.value]);
 
   const timelineTaskLookup = timelineData.timelineTaskLookup;
   const timelineRows = timelineData.timelineRows;
@@ -1438,7 +1512,7 @@ const EmployeeWorkloadTrack: React.FC = () => {
     (assigneeId: string, referenceTask: TaskListItem) => {
       const dueDate =
         teamTaskWindows.get(referenceTask.id)?.end ?? getScheduleDueDate(referenceTask.schedule);
-      const employee = mockEmployees.find((item) => item.id === assigneeId);
+      const employee = employees.find((item) => item.id === assigneeId);
 
       const overlappingProjectTasks = (() => {
         if (!employee || !dueDate) {
@@ -1471,7 +1545,7 @@ const EmployeeWorkloadTrack: React.FC = () => {
 
       return overlappingProjectTasks + overlappingTeamTasks;
     },
-    [tasks, teamTaskWindows]
+    [employees, tasks, teamTaskWindows]
   );
 
   const getAssigneeLoadLevel = useCallback(
@@ -1599,29 +1673,35 @@ const EmployeeWorkloadTrack: React.FC = () => {
         ? prev.map((task) => (task.id === editingTaskId ? nextTask : task))
         : [nextTask, ...prev]
     );
-    setTaskDraft(() => ({ ...defaultTaskDraft }));
+    setTaskDraft(() => ({
+      ...defaultTaskDraft,
+      relatedInitiativeId: initiativeOptions[0]?.value ?? null
+    }));
     setEditingTaskId(null);
     setFormError(null);
     setSelectedTaskId(taskId);
-  }, [editingTaskId, taskDraft]);
+  }, [editingTaskId, initiativeOptions, taskDraft]);
 
   const handleEditTask = useCallback(
     (task: TaskListItem) => {
-      setTaskDraft(mapTaskToDraft(task));
+      setTaskDraft(mapTaskToDraft(task, initiativeOptions));
       setEditingTaskId(task.id);
       setFormError(null);
       if (activeView.value !== 'planner') {
         setActiveView(viewTabs[1]);
       }
     },
-    [activeView.value, setActiveView]
+    [activeView.value, initiativeOptions, setActiveView]
   );
 
   const handleCancelEdit = useCallback(() => {
-    setTaskDraft(() => ({ ...defaultTaskDraft }));
+    setTaskDraft(() => ({
+      ...defaultTaskDraft,
+      relatedInitiativeId: initiativeOptions[0]?.value ?? null
+    }));
     setEditingTaskId(null);
     setFormError(null);
-  }, []);
+  }, [initiativeOptions]);
 
   return (
     <div className={styles.wrapper}>
@@ -2130,7 +2210,7 @@ const EmployeeWorkloadTrack: React.FC = () => {
           </Text>
           <div className={styles.summary}>
             <Text size="xs" view="secondary">
-              Сотрудники: {mockEmployees.length}
+              Сотрудники: {employees.length}
             </Text>
             <Text size="xs" view="secondary">
               Показаны кандидаты с учетом загрузки по задачам

--- a/src/utils/expertExcel.ts
+++ b/src/utils/expertExcel.ts
@@ -891,6 +891,47 @@ export const parseExpertWorkbook = async ({
   const skillMap = new Map<string, ExpertSkill>();
   const skillNameRegistry = new Map<string, string>();
 
+  const registerCompetencySkill = (
+    record: ExpertCompetencyRecord,
+    rowNumber: number
+  ): { skillId: string; isNewDefinition: boolean } | null => {
+    const name = record.name.trim();
+    if (!name) {
+      return null;
+    }
+
+    const existingDefinition = findSkillByName(name);
+    const skillId = existingDefinition?.id ?? slugifySkillId(name || `competency-${rowNumber}`);
+    if (!skillId) {
+      return null;
+    }
+
+    skillNameRegistry.set(skillId, existingDefinition?.name ?? name);
+
+    const currentSkill = skillMap.get(skillId);
+    const level = record.level ?? currentSkill?.level ?? 'P';
+    const proofStatus = record.proofStatus ?? currentSkill?.proofStatus ?? 'claimed';
+
+    const baseSkill: ExpertSkill = currentSkill ?? {
+      id: skillId,
+      level,
+      proofStatus,
+      evidence: [],
+      createdAt: skillCreationTimestamp,
+      artifacts: [],
+      interest: 'medium',
+      availableFte: 0
+    };
+
+    skillMap.set(skillId, {
+      ...baseSkill,
+      level,
+      proofStatus
+    });
+
+    return { skillId, isNewDefinition: !existingDefinition };
+  };
+
   skillRows.forEach((row, index) => {
     const rawCategory = String(row.Category ?? '');
     const skillName = String(row['Skill Name'] ?? '').trim();
@@ -1007,6 +1048,10 @@ export const parseExpertWorkbook = async ({
       interest: 'medium',
       availableFte: 0
     });
+  });
+
+  competencyCandidates.forEach((candidate) => {
+    registerCompetencySkill(candidate.record, candidate.rowNumber);
   });
 
   if (evidenceSheet) {


### PR DESCRIPTION
## Summary
- show admin-managed employees and initiative names in the employee workload view
- keep task planner defaults aligned with current initiatives
- register hard skills from imported profiles (and attach roles) so later profiles and initiatives see them

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691af082844c8332b867f0eb222a21a3)