### PR TITLE
Restore JSON graph import/export in admin panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import AdminPanel, {
 import FiltersPanel from './components/FiltersPanel';
 import {
   GRAPH_SNAPSHOT_VERSION,
+  type GraphDataScope,
   type GraphLayoutNodePosition,
   type GraphLayoutSnapshot,
   type GraphSnapshotPayload,
@@ -285,22 +286,32 @@ function App() {
 
   const applySnapshot = useCallback(
     (snapshot: GraphSnapshotPayload) => {
-      const flattenedDomains = flattenDomainTree(snapshot.domains);
+      const scopes = new Set<GraphDataScope>(
+        snapshot.scopesIncluded ?? ['domains', 'modules', 'artifacts', 'experts', 'initiatives']
+      );
+
+      const nextDomains = scopes.has('domains') ? snapshot.domains : domainData;
+      const nextModules = scopes.has('modules') ? snapshot.modules : moduleData;
+      const nextArtifacts = scopes.has('artifacts') ? snapshot.artifacts : artifactData;
+      const nextExperts = scopes.has('experts') ? snapshot.experts ?? initialExperts : expertProfiles;
+      const nextInitiatives = scopes.has('initiatives') ? snapshot.initiatives ?? [] : initiativeData;
+
+      const flattenedDomains = flattenDomainTree(nextDomains);
       const domainIds = flattenedDomains.map((domain) => domain.id);
       const activeNodeIds = new Set<string>([...domainIds]);
-      snapshot.modules.forEach((module) => activeNodeIds.add(module.id));
-      snapshot.artifacts.forEach((artifact) => activeNodeIds.add(artifact.id));
-      (snapshot.initiatives ?? []).forEach((initiative) => activeNodeIds.add(initiative.id));
+      nextModules.forEach((module) => activeNodeIds.add(module.id));
+      nextArtifacts.forEach((artifact) => activeNodeIds.add(artifact.id));
+      nextInitiatives.forEach((initiative) => activeNodeIds.add(initiative.id));
 
-      setDomainData(snapshot.domains);
-      setModuleDataState(recalculateReuseScores(snapshot.modules));
-      setArtifactData(snapshot.artifacts);
-      setInitiativeData(snapshot.initiatives ?? []);
-      setExpertProfiles(snapshot.experts ?? initialExperts);
+      setDomainData(nextDomains);
+      setModuleDataState(recalculateReuseScores(nextModules));
+      setArtifactData(nextArtifacts);
+      setInitiativeData(nextInitiatives);
+      setExpertProfiles(nextExperts);
       setSelectedNode(null);
       setSearch('');
       setStatusFilters(new Set(allStatuses));
-      setProductFilter(buildProductList(snapshot.modules));
+      setProductFilter(buildProductList(nextModules));
       setCompanyFilter(null);
       setSelectedDomains(new Set(domainIds));
       let resolvedLayoutPositions: Record<string, GraphLayoutNodePosition> | null = null;
@@ -375,7 +386,7 @@ function App() {
         hasPendingPersistRef.current = false;
       }
     },
-    []
+    [artifactData, domainData, expertProfiles, initiativeData, moduleData]
   );
 
   const loadSnapshot = useCallback(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,6 +84,7 @@ import {
 import { preparePlannerModuleSelections } from './utils/initiativePlanner';
 import { LayoutShell } from './components/LayoutShell';
 import { CreateGraphModal } from './components/CreateGraphModal';
+import GraphPersistenceControls from './components/GraphPersistenceControls';
 
 const allStatuses: ModuleStatus[] = ['production', 'in-dev', 'deprecated'];
 const initialProducts = buildProductList(initialModules);
@@ -3377,6 +3378,26 @@ function App() {
         aria-hidden={!isAdminActive}
         style={{ display: isAdminActive ? undefined : 'none' }}
       >
+        <GraphPersistenceControls
+          modules={moduleData}
+          domains={domainData}
+          artifacts={artifactData}
+          experts={expertProfiles}
+          initiatives={initiativeData}
+          onImport={handleImportGraph}
+          onImportFromGraph={handleImportFromExistingGraph}
+          graphs={graphs}
+          activeGraphId={activeGraphId}
+          onGraphSelect={handleGraphSelect}
+          onGraphCreate={handleCreateGraph}
+          onGraphDelete={activeGraphId ? () => handleDeleteGraph(activeGraphId) : undefined}
+          isGraphListLoading={isGraphsLoading}
+          syncStatus={syncStatus}
+          layout={layoutSnapshot}
+          isSyncAvailable={isSyncAvailable}
+          onRetryLoad={handleRetryLoadSnapshot}
+          isReloading={isReloadingSnapshot}
+        />
         <AdminPanel
           modules={moduleData}
           domains={domainData}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2876,7 +2876,6 @@ function App() {
     (snapshot: GraphSnapshotPayload) => {
       applySnapshot(snapshot);
       markGraphDirty();
-      skipNextSyncRef.current = true;
     },
     [applySnapshot, markGraphDirty]
   );
@@ -2893,7 +2892,6 @@ function App() {
       try {
         const snapshot = await importGraphFromSource(request);
         applySnapshot(snapshot);
-        skipNextSyncRef.current = true;
         setIsSyncAvailable(true);
         markGraphDirty();
         return {

--- a/src/components/ExpertExplorer.tsx
+++ b/src/components/ExpertExplorer.tsx
@@ -508,7 +508,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   );
 
   const domainOptions = useMemo(() => {
-    const set = new Set<string>();
+    const set = new Set<string>(Object.keys(domainNameMap));
     experts.forEach((expert) => {
       const result = matchesFilters(expert, { applyDomain: false });
       if (!result.passes) {
@@ -519,7 +519,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
     return Array.from(set).sort((a, b) =>
       resolveDomainName(a).localeCompare(resolveDomainName(b), 'ru')
     );
-  }, [experts, matchesFilters, resolveDomainName]);
+  }, [domainNameMap, experts, matchesFilters, resolveDomainName]);
 
   const competencyOptions = useMemo(() => {
     const set = new Set<string>();

--- a/src/components/GraphPersistenceControls.module.css
+++ b/src/components/GraphPersistenceControls.module.css
@@ -50,6 +50,20 @@
   gap: 12px;
 }
 
+.transferSection {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.transferOptions {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
 .copySection {
   display: flex;
   flex-direction: column;

--- a/src/components/GraphPersistenceControls.tsx
+++ b/src/components/GraphPersistenceControls.tsx
@@ -22,6 +22,8 @@ type StatusMessage =
   | { type: 'success'; message: string }
   | { type: 'error'; message: string };
 
+type GraphDataScope = 'domains' | 'modules' | 'artifacts' | 'experts' | 'initiatives';
+
 type GraphPersistenceControlsProps = {
   modules: ModuleNode[];
   domains: DomainNode[];
@@ -80,6 +82,9 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
   const [copyOptions, setCopyOptions] = useState<
     Set<'domains' | 'modules' | 'artifacts' | 'experts' | 'initiatives'>
   >(() => new Set(['domains', 'modules', 'artifacts', 'experts', 'initiatives']));
+  const [fileTransferOptions, setFileTransferOptions] = useState<
+    Set<GraphDataScope>
+  >(() => new Set(['domains', 'modules', 'artifacts', 'experts', 'initiatives']));
   const [isGraphImporting, setIsGraphImporting] = useState(false);
 
   const buildSnapshot = useCallback((): GraphSnapshotPayload => {
@@ -97,8 +102,13 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
   }, [artifacts, domains, experts, initiatives, layout, modules]);
 
   const handleExport = () => {
+    if (fileTransferOptions.size === 0) {
+      setStatus({ type: 'error', message: 'Выберите типы данных для экспорта.' });
+      return;
+    }
+
     try {
-      const snapshot = buildSnapshot();
+      const snapshot = filterSnapshotByScope(buildSnapshot(), fileTransferOptions);
       const data = JSON.stringify(snapshot, null, 2);
       const blob = new Blob([data], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
@@ -140,14 +150,19 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
           throw new Error('Файл не соответствует структуре графа');
         }
 
-        const normalized = normalizeImportedSnapshot(parsed);
+        if (fileTransferOptions.size === 0) {
+          throw new Error('Выберите хотя бы один тип данных для импорта.');
+        }
 
-        onImport(normalized);
-        const moduleCount = normalized.modules.length;
-        const domainCount = normalized.domains.length;
-        const artifactCount = normalized.artifacts.length;
-        const expertCount = normalized.experts?.length ?? 0;
-        const initiativeCount = normalized.initiatives?.length ?? 0;
+        const normalized = normalizeImportedSnapshot(parsed);
+        const filtered = filterSnapshotByScope(normalized, fileTransferOptions);
+
+        onImport(filtered);
+        const moduleCount = filtered.modules.length;
+        const domainCount = filtered.domains.length;
+        const artifactCount = filtered.artifacts.length;
+        const expertCount = filtered.experts?.length ?? 0;
+        const initiativeCount = filtered.initiatives?.length ?? 0;
         setStatus({
           type: 'success',
           message:
@@ -194,7 +209,7 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
     [graphOptions, sourceGraphId]
   );
 
-  const copyOptionItems = useMemo(
+  const dataScopeItems = useMemo(
     () =>
       [
         { id: 'domains' as const, label: 'Домены' },
@@ -207,9 +222,16 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
   );
 
   const selectedCopyOptionItems = useMemo(
-    () => copyOptionItems.filter((item) => copyOptions.has(item.id)),
-    [copyOptionItems, copyOptions]
+    () => dataScopeItems.filter((item) => copyOptions.has(item.id)),
+    [dataScopeItems, copyOptions]
   );
+
+  const selectedTransferOptionItems = useMemo(
+    () => dataScopeItems.filter((item) => fileTransferOptions.has(item.id)),
+    [dataScopeItems, fileTransferOptions]
+  );
+
+  const isFileTransferSelectionEmpty = fileTransferOptions.size === 0;
 
   const isCopySectionAvailable = Boolean(onImportFromGraph) && graphOptions.length > 0;
   const canImportFromGraph =
@@ -385,25 +407,58 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
         )}
       </div>
 
-      <div className={styles.actions}>
-        <Button size="s" view="secondary" label="Экспорт в JSON" onClick={handleExport} />
-        <Button size="s" view="primary" label="Импорт из файла" onClick={handleTriggerImport} />
-        {onForceSave && (
+      <div className={styles.transferSection}>
+        <div className={styles.transferOptions}>
+          <Text size="xs" view="secondary">
+            Выберите типы данных для экспорта и импорта из файла JSON.
+          </Text>
+          <CheckboxGroup
+            size="s"
+            direction="row"
+            items={dataScopeItems}
+            value={selectedTransferOptionItems}
+            getItemKey={(item) => item.id}
+            getItemLabel={(item) => item.label}
+            onChange={(items) => {
+              setFileTransferOptions(new Set((items ?? []).map((item) => item.id)));
+            }}
+          />
+          <Text size="xs" view="secondary">
+            Даже если в файле присутствуют все сущности, будут загружены только выбранные.
+          </Text>
+        </div>
+        <div className={styles.actions}>
           <Button
             size="s"
-            view="ghost"
-            label="Сохранить в хранилище"
-            onClick={onForceSave}
-            disabled={!isSyncAvailable}
+            view="secondary"
+            label="Экспорт в JSON"
+            onClick={handleExport}
+            disabled={isFileTransferSelectionEmpty}
           />
-        )}
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="application/json"
-          onChange={handleFileChange}
-          style={{ display: 'none' }}
-        />
+          <Button
+            size="s"
+            view="primary"
+            label="Импорт из файла"
+            onClick={handleTriggerImport}
+            disabled={isFileTransferSelectionEmpty}
+          />
+          {onForceSave && (
+            <Button
+              size="s"
+              view="ghost"
+              label="Сохранить в хранилище"
+              onClick={onForceSave}
+              disabled={!isSyncAvailable}
+            />
+          )}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/json"
+            onChange={handleFileChange}
+            style={{ display: 'none' }}
+          />
+        </div>
       </div>
 
       {isCopySectionAvailable && (
@@ -449,7 +504,7 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
               <CheckboxGroup
                 size="s"
                 direction="row"
-                items={copyOptionItems}
+                items={dataScopeItems}
                 value={selectedCopyOptionItems}
                 getItemKey={(item) => item.id}
                 getItemLabel={(item) => item.label}
@@ -555,6 +610,71 @@ function isGraphSnapshotLike(value: unknown): value is GraphSnapshotLike {
   }
 
   return true;
+}
+
+function filterSnapshotByScope(
+  snapshot: GraphSnapshotPayload,
+  scopes: Set<GraphDataScope>
+): GraphSnapshotPayload {
+  const includeDomains = scopes.has('domains');
+  const includeModules = scopes.has('modules');
+  const includeArtifacts = scopes.has('artifacts');
+  const includeExperts = scopes.has('experts');
+  const includeInitiatives = scopes.has('initiatives');
+
+  const allowedNodeIds = new Set<string>();
+
+  if (includeDomains) {
+    snapshot.domains.forEach((domain) => allowedNodeIds.add(domain.id));
+  }
+
+  if (includeModules) {
+    snapshot.modules.forEach((module) => allowedNodeIds.add(module.id));
+  }
+
+  if (includeArtifacts) {
+    snapshot.artifacts.forEach((artifact) => allowedNodeIds.add(artifact.id));
+  }
+
+  if (includeInitiatives) {
+    snapshot.initiatives?.forEach((initiative) => allowedNodeIds.add(initiative.id));
+  }
+
+  const filteredLayout =
+    snapshot.layout && allowedNodeIds.size > 0
+      ? filterLayoutByNodes(snapshot.layout, allowedNodeIds)
+      : undefined;
+
+  return {
+    version: snapshot.version,
+    exportedAt: snapshot.exportedAt,
+    domains: includeDomains ? snapshot.domains : [],
+    modules: includeModules ? snapshot.modules : [],
+    artifacts: includeArtifacts ? snapshot.artifacts : [],
+    experts: includeExperts ? snapshot.experts ?? [] : [],
+    initiatives: includeInitiatives ? snapshot.initiatives ?? [] : [],
+    layout: filteredLayout
+  };
+}
+
+function filterLayoutByNodes(
+  layout: GraphLayoutSnapshot,
+  allowedNodeIds: Set<string>
+): GraphLayoutSnapshot | undefined {
+  const filteredEntries = Object.entries(layout.nodes ?? {}).reduce<
+    GraphLayoutSnapshot['nodes']
+  >((acc, [id, position]) => {
+    if (allowedNodeIds.has(id)) {
+      acc[id] = position;
+    }
+    return acc;
+  }, {});
+
+  if (Object.keys(filteredEntries).length === 0) {
+    return undefined;
+  }
+
+  return { nodes: filteredEntries };
 }
 
 function normalizeImportedSnapshot(snapshot: GraphSnapshotLike): GraphSnapshotPayload {

--- a/src/components/GraphPersistenceControls.tsx
+++ b/src/components/GraphPersistenceControls.tsx
@@ -279,83 +279,131 @@ const GraphPersistenceControls: React.FC<GraphPersistenceControlsProps> = ({
     [graphsOptions, activeGraphId]
   );
 
+  const formattedLastUpdated = useMemo(() => {
+    if (!lastUpdated) {
+      return null;
+    }
+
+    const date = new Date(lastUpdated);
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+
+    return date.toLocaleString('ru-RU');
+  }, [lastUpdated]);
+
   return (
     <section className={styles.wrapper} aria-label="Управление графами">
       <div className={styles.topBar}>
-         <div className={styles.selectorGroup}>
-            <Select<{ label: string; value: string }>
-              size="s"
-              items={graphsOptions}
-              value={currentGraphOption}
-              placeholder={isGraphListLoading ? 'Загрузка...' : 'Выберите граф'}
-              getItemLabel={(item) => item.label}
-              getItemKey={(item) => item.value}
-              disabled={isGraphListLoading || isReloading}
-              onChange={handleGraphSelectChange}
-              className={styles.graphSelect}
+        <div className={styles.selectorGroup}>
+          <Select<{ label: string; value: string }>
+            size="s"
+            items={graphsOptions}
+            value={currentGraphOption}
+            placeholder={isGraphListLoading ? 'Загрузка...' : 'Выберите граф'}
+            getItemLabel={(item) => item.label}
+            getItemKey={(item) => item.value}
+            disabled={isGraphListLoading || isReloading}
+            onChange={handleGraphSelectChange}
+            className={styles.graphSelect}
+          />
+          {activeGraphId && (
+            <div className={styles.graphActions}>
+              {onGraphCreate && (
+                <Button
+                  size="s"
+                  view="clear"
+                  iconLeft={IconAdd}
+                  onlyIcon
+                  onClick={onGraphCreate}
+                  title="Создать новый граф"
+                />
+              )}
+              {onGraphDelete && (
+                <Button
+                  size="s"
+                  view="clear"
+                  status="alert"
+                  iconLeft={IconTrash}
+                  onlyIcon
+                  onClick={onGraphDelete}
+                  title="Удалить текущий граф"
+                />
+              )}
+            </div>
+          )}
+          {!activeGraphId && onGraphCreate && (
+            <Button size="s" view="secondary" label="Создать граф" onClick={onGraphCreate} />
+          )}
+        </div>
+
+        <div className={styles.syncStatus}>
+          {syncStatus && (
+            <Text
+              size="xs"
+              view={
+                syncStatus.state === 'error'
+                  ? 'alert'
+                  : syncStatus.state === 'saving'
+                    ? 'ghost'
+                    : 'secondary'
+              }
+            >
+              {syncStatus.message ??
+                (syncStatus.state === 'saving'
+                  ? 'Сохранение...'
+                  : syncStatus.state === 'error'
+                    ? 'Ошибка'
+                    : 'Синхронизировано')}
+            </Text>
+          )}
+          {activeGraphId && isSyncAvailable && onRetryLoad && (
+            <Button
+              size="xs"
+              view="clear"
+              iconLeft={IconRestart}
+              onlyIcon
+              loading={isReloading}
+              onClick={onRetryLoad}
+              title="Перезагрузить данные"
             />
-            {activeGraphId && (
-               <div className={styles.graphActions}>
-                  {onGraphCreate && (
-                     <Button 
-                       size="s" 
-                       view="clear" 
-                       iconLeft={IconAdd} 
-                       onlyIcon 
-                       onClick={onGraphCreate} 
-                       title="Создать новый граф"
-                     />
-                  )}
-                  {onGraphDelete && (
-                     <Button 
-                       size="s" 
-                       view="clear" 
-                       status="alert"
-                       iconLeft={IconTrash} 
-                       onlyIcon 
-                       onClick={onGraphDelete}
-                       title="Удалить текущий граф"
-                     />
-                  )}
-               </div>
-            )}
-             {!activeGraphId && onGraphCreate && (
-                <Button size="s" view="secondary" label="Создать граф" onClick={onGraphCreate} />
-             )}
-         </div>
-         
-         <div className={styles.syncStatus}>
-            {syncStatus && (
-                <Text
-                  size="xs"
-                  view={
-                    syncStatus.state === 'error'
-                      ? 'alert'
-                      : syncStatus.state === 'saving'
-                        ? 'ghost'
-                        : 'secondary'
-                  }
-                >
-                  {syncStatus.message ??
-                    (syncStatus.state === 'saving'
-                      ? 'Сохранение...'
-                      : syncStatus.state === 'error'
-                        ? 'Ошибка'
-                        : 'Синхронизировано')}
-                </Text>
-              )}
-              {activeGraphId && isSyncAvailable && onRetryLoad && (
-                 <Button
-                    size="xs"
-                    view="clear"
-                    iconLeft={IconRestart}
-                    onlyIcon
-                    loading={isReloading}
-                    onClick={onRetryLoad}
-                    title="Перезагрузить данные"
-                 />
-              )}
-         </div>
+          )}
+        </div>
+      </div>
+
+      <div className={styles.header}>
+        <Text size="s" weight="semibold">
+          Импорт и экспорт графа
+        </Text>
+        <Text size="xs" view="secondary">
+          Сохраните текущие данные в файл JSON или загрузите ранее выгруженный граф.
+        </Text>
+        {formattedLastUpdated && (
+          <Text size="xs" view="secondary">
+            Последнее обновление: {formattedLastUpdated}
+          </Text>
+        )}
+      </div>
+
+      <div className={styles.actions}>
+        <Button size="s" view="secondary" label="Экспорт в JSON" onClick={handleExport} />
+        <Button size="s" view="primary" label="Импорт из файла" onClick={handleTriggerImport} />
+        {onForceSave && (
+          <Button
+            size="s"
+            view="ghost"
+            label="Сохранить в хранилище"
+            onClick={onForceSave}
+            disabled={!isSyncAvailable}
+          />
+        )}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/json"
+          onChange={handleFileChange}
+          style={{ display: 'none' }}
+        />
       </div>
 
       {isCopySectionAvailable && (

--- a/src/components/GraphPersistenceControls.tsx
+++ b/src/components/GraphPersistenceControls.tsx
@@ -11,6 +11,7 @@ import type { ArtifactNode, DomainNode, ExpertProfile, Initiative, ModuleNode } 
 import { normalizeLayoutSnapshot } from '../services/graphStorage';
 import {
   GRAPH_SNAPSHOT_VERSION,
+  type GraphDataScope,
   type GraphLayoutSnapshot,
   type GraphSnapshotPayload,
   type GraphSummary,
@@ -21,8 +22,6 @@ import styles from './GraphPersistenceControls.module.css';
 type StatusMessage =
   | { type: 'success'; message: string }
   | { type: 'error'; message: string };
-
-type GraphDataScope = 'domains' | 'modules' | 'artifacts' | 'experts' | 'initiatives';
 
 type GraphPersistenceControlsProps = {
   modules: ModuleNode[];
@@ -579,6 +578,7 @@ type GraphSnapshotLike = {
   experts?: ExpertProfile[];
   initiatives?: Initiative[];
   layout?: GraphSnapshotPayload['layout'];
+  scopesIncluded?: GraphDataScope[];
 };
 
 function isGraphSnapshotLike(value: unknown): value is GraphSnapshotLike {
@@ -653,7 +653,8 @@ function filterSnapshotByScope(
     artifacts: includeArtifacts ? snapshot.artifacts : [],
     experts: includeExperts ? snapshot.experts ?? [] : [],
     initiatives: includeInitiatives ? snapshot.initiatives ?? [] : [],
-    layout: filteredLayout
+    layout: filteredLayout,
+    scopesIncluded: Array.from(scopes)
   };
 }
 
@@ -678,6 +679,17 @@ function filterLayoutByNodes(
 }
 
 function normalizeImportedSnapshot(snapshot: GraphSnapshotLike): GraphSnapshotPayload {
+  const scopes = snapshot.scopesIncluded ?? [];
+  const validScopes = Array.isArray(scopes)
+    ? scopes.filter((scope): scope is GraphDataScope =>
+        scope === 'domains' ||
+        scope === 'modules' ||
+        scope === 'artifacts' ||
+        scope === 'experts' ||
+        scope === 'initiatives'
+      )
+    : [];
+
   return {
     version:
       typeof snapshot.version === 'number' && Number.isFinite(snapshot.version)
@@ -689,7 +701,8 @@ function normalizeImportedSnapshot(snapshot: GraphSnapshotLike): GraphSnapshotPa
     artifacts: snapshot.artifacts,
     experts: snapshot.experts ?? undefined,
     initiatives: snapshot.initiatives ?? [],
-    layout: normalizeLayoutSnapshot(snapshot.layout) ?? undefined
+    layout: normalizeLayoutSnapshot(snapshot.layout) ?? undefined,
+    scopesIncluded: validScopes.length ? validScopes : undefined
   };
 }
 

--- a/src/services/graphStorage.ts
+++ b/src/services/graphStorage.ts
@@ -1,6 +1,7 @@
 import {
   GRAPH_SNAPSHOT_VERSION,
   type GraphCopyRequest,
+  type GraphDataScope,
   type GraphLayoutSnapshot,
   type GraphSnapshotPayload,
   type GraphSummary
@@ -158,6 +159,32 @@ export async function importGraphFromSource(
   signal?: AbortSignal
 ): Promise<GraphSnapshotPayload> {
   const snapshot = await fetchGraphSnapshot(request.graphId, signal);
+  const scopes: GraphDataScope[] = [];
+
+  if (request.includeDomains) scopes.push('domains');
+  if (request.includeModules) scopes.push('modules');
+  if (request.includeArtifacts) scopes.push('artifacts');
+  if (request.includeExperts) scopes.push('experts');
+  if (request.includeInitiatives) scopes.push('initiatives');
+
+  const allowedNodeIds = new Set<string>();
+
+  if (request.includeDomains) snapshot.domains.forEach((domain) => allowedNodeIds.add(domain.id));
+  if (request.includeModules) snapshot.modules.forEach((module) => allowedNodeIds.add(module.id));
+  if (request.includeArtifacts) snapshot.artifacts.forEach((artifact) => allowedNodeIds.add(artifact.id));
+  if (request.includeInitiatives) {
+    snapshot.initiatives?.forEach((initiative) => allowedNodeIds.add(initiative.id));
+  }
+
+  const filteredLayout =
+    snapshot.layout && allowedNodeIds.size > 0
+      ? normalizeLayoutSnapshot({
+          nodes: Object.fromEntries(
+            Object.entries(snapshot.layout.nodes ?? {}).filter(([id]) => allowedNodeIds.has(id))
+          )
+        }) ?? undefined
+      : undefined;
+
   return {
     version: snapshot.version,
     exportedAt: snapshot.exportedAt,
@@ -166,10 +193,8 @@ export async function importGraphFromSource(
     artifacts: request.includeArtifacts ? snapshot.artifacts : [],
     experts: request.includeExperts ? snapshot.experts ?? [] : [],
     initiatives: request.includeInitiatives ? snapshot.initiatives ?? [] : [],
-    layout:
-      request.includeModules && snapshot.layout
-        ? normalizeLayoutSnapshot(snapshot.layout) ?? undefined
-        : undefined
+    layout: filteredLayout,
+    scopesIncluded: scopes
   };
 }
 

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -19,6 +19,8 @@ export type GraphLayoutSnapshot = {
   nodes: Record<string, GraphLayoutNodePosition>;
 };
 
+export type GraphDataScope = 'domains' | 'modules' | 'artifacts' | 'experts' | 'initiatives';
+
 export type GraphSnapshotPayload = {
   version: number;
   exportedAt?: string;
@@ -28,6 +30,11 @@ export type GraphSnapshotPayload = {
   experts?: ExpertProfile[];
   initiatives?: Initiative[];
   layout?: GraphLayoutSnapshot;
+  /**
+   * Ограничивает, какие сущности нужно заменить при загрузке снапшота.
+   * Если не указано, считается что снимок содержит все сущности.
+   */
+  scopesIncluded?: GraphDataScope[];
 };
 
 export type GraphSyncStatus =


### PR DESCRIPTION
## Summary
- add graph persistence controls with JSON import/export back into the admin area
- integrate graph selection and sync helpers alongside admin tools

## Testing
- npm run lint (fails: existing lint issues in unrelated files)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f2d17c83483329e11045783ea3a8f)