### PR TITLE
Improve graph palette resolution for theme-aware styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3291,6 +3291,7 @@ function App() {
                 artifacts={graphArtifacts}
                 initiatives={graphInitiatives}
                 links={filteredLinks}
+                graphVersion={activeGraphId ?? 'local'}
                 onSelect={handleSelectNode}
                 highlightedNode={selectedNode?.id ?? null}
                 visibleDomainIds={relevantDomainIds}

--- a/src/components/ExpertExplorer.tsx
+++ b/src/components/ExpertExplorer.tsx
@@ -276,6 +276,13 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   const roleGraphContainerRef = useRef<HTMLDivElement | null>(null);
   const [roleGraphDimensions, setRoleGraphDimensions] = useState({ width: 0, height: 0 });
 
+  const refreshGraphInstance = useCallback((ref: React.RefObject<ForceGraphMethods | null>) => {
+    const refresh = (ref.current as unknown as { refresh?: () => void })?.refresh;
+    if (typeof refresh === 'function') {
+      refresh.call(ref.current);
+    }
+  }, []);
+
   useLayoutEffect(() => {
     const applyPalette = () => {
       const nextPalette = resolveExpertPalette(themeClassNames);
@@ -297,9 +304,9 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   }, [theme, themeClassNames]);
 
   useEffect(() => {
-    graphRef.current?.refresh();
-    roleGraphRef.current?.refresh();
-  }, [palette]);
+    refreshGraphInstance(graphRef);
+    refreshGraphInstance(roleGraphRef);
+  }, [palette, refreshGraphInstance]);
   useEffect(() => {
     if (!includeSoftSkills && focusedSkill?.type === 'soft') {
       setFocusedSkill(null);

--- a/src/components/ExpertExplorer.tsx
+++ b/src/components/ExpertExplorer.tsx
@@ -313,6 +313,11 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   useEffect(() => {
     setGraphInstanceKey((value) => value + 1);
     setRoleGraphInstanceKey((value) => value + 1);
+    graphRef.current = null;
+    roleGraphRef.current = null;
+    setFocusedSkill(null);
+    setFocusedAssignment(null);
+    setSelectedRole(null);
     initialGraphZoomAppliedRef.current = { graph: false, assignments: false };
     roleGraphZoomAppliedRef.current = false;
   }, [palette]);

--- a/src/components/ExpertExplorer.tsx
+++ b/src/components/ExpertExplorer.tsx
@@ -3037,7 +3037,32 @@ function resolveExpertPalette(themeClassName?: string): ExpertPalette {
     return DEFAULT_PALETTE;
   }
 
-  const themeElement = themeClassName ? document.querySelector(`.${themeClassName}`) : null;
+  const themeElement = (() => {
+    if (!themeClassName) {
+      return document.querySelector('.Theme');
+    }
+
+    const tokens = themeClassName.split(/\s+/).filter(Boolean);
+    const selectorVariants = [
+      tokens.length > 0 ? tokens.map((token) => `.${token}`).join('') : null,
+      tokens[0] ? `.${tokens[0]}` : null,
+      '.Theme'
+    ].filter(Boolean) as string[];
+
+    for (const selector of selectorVariants) {
+      try {
+        const element = document.querySelector(selector);
+        if (element) {
+          return element;
+        }
+      } catch {
+        // Ignore invalid selectors and try the next fallback
+      }
+    }
+
+    return null;
+  })();
+
   const stylesRef = getComputedStyle((themeElement as HTMLElement) ?? document.body);
   const getVar = (token: string, fallback: string) =>
     stylesRef.getPropertyValue(token).trim() || fallback;

--- a/src/components/ExpertExplorer.tsx
+++ b/src/components/ExpertExplorer.tsx
@@ -263,6 +263,8 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   const [focusedSkill, setFocusedSkill] = useState<SkillFocus | null>(null);
   const [focusedAssignment, setFocusedAssignment] = useState<AssignmentFocus | null>(null);
   const [selectedRole, setSelectedRole] = useState<TeamRole | null>(null);
+  const [graphInstanceKey, setGraphInstanceKey] = useState(0);
+  const [roleGraphInstanceKey, setRoleGraphInstanceKey] = useState(0);
 
   const graphRef = useRef<ForceGraphMethods | null>(null);
   const initialGraphZoomAppliedRef = useRef<Record<'graph' | 'assignments', boolean>>({
@@ -307,6 +309,13 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
     refreshGraphInstance(graphRef);
     refreshGraphInstance(roleGraphRef);
   }, [palette, refreshGraphInstance]);
+
+  useEffect(() => {
+    setGraphInstanceKey((value) => value + 1);
+    setRoleGraphInstanceKey((value) => value + 1);
+    initialGraphZoomAppliedRef.current = { graph: false, assignments: false };
+    roleGraphZoomAppliedRef.current = false;
+  }, [palette]);
   useEffect(() => {
     if (!includeSoftSkills && focusedSkill?.type === 'soft') {
       setFocusedSkill(null);
@@ -1393,6 +1402,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
     graphDimensions.width,
     skillGraphLinks,
     skillGraphNodes,
+    graphInstanceKey,
     viewMode
   ]);
 
@@ -1421,7 +1431,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
     }
 
     graph.d3ReheatSimulation();
-  }, [assignmentGraphLinks, skillGraphLinks, viewMode]);
+  }, [assignmentGraphLinks, graphInstanceKey, skillGraphLinks, viewMode]);
 
   useEffect(() => {
     if (viewMode !== 'graph') {
@@ -1576,7 +1586,13 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
     }, 250);
 
     return () => window.clearTimeout(timeout);
-  }, [roleGraphData, roleGraphDimensions.height, roleGraphDimensions.width, viewMode]);
+  }, [
+    roleGraphData,
+    roleGraphDimensions.height,
+    roleGraphDimensions.width,
+    roleGraphInstanceKey,
+    viewMode
+  ]);
 
   useEffect(() => {
     if (viewMode !== 'graph' && viewMode !== 'assignments') {
@@ -1609,6 +1625,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
     assignmentGraphNodes,
     skillGraphLinks,
     skillGraphNodes,
+    graphInstanceKey,
     viewMode
   ]);
 
@@ -1634,7 +1651,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
     if (linkForce && typeof (linkForce as { strength?: unknown }).strength === 'function') {
       (linkForce as { strength: (value: number) => void }).strength(0.7);
     }
-  }, [roleGraphData, viewMode]);
+  }, [roleGraphData, roleGraphInstanceKey, viewMode]);
 
   const highlightNodeIds = useMemo(() => {
     const set = new Set<string>();
@@ -2469,6 +2486,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
                 </div>
               ) : (
                 <ForceGraph2D
+                  key={graphInstanceKey}
                   ref={graphRef}
                   width={graphDimensions.width}
                   height={graphDimensions.height}
@@ -2630,6 +2648,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
                 </div>
               ) : (
                 <ForceGraph2D
+                  key={graphInstanceKey}
                   ref={graphRef}
                   width={graphDimensions.width}
                   height={graphDimensions.height}
@@ -2768,6 +2787,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
                           </div>
                         ) : (
                           <ForceGraph2D
+                            key={roleGraphInstanceKey}
                             ref={roleGraphRef}
                             width={roleGraphDimensions.width}
                             height={roleGraphDimensions.height}

--- a/src/components/ExpertExplorer.tsx
+++ b/src/components/ExpertExplorer.tsx
@@ -6,7 +6,7 @@ import { Switch } from '@consta/uikit/Switch';
 import { Tabs } from '@consta/uikit/Tabs';
 import { Text } from '@consta/uikit/Text';
 import { TextField } from '@consta/uikit/TextField';
-import { useTheme } from '@consta/uikit/Theme';
+import { useTheme, type ThemePreset } from '@consta/uikit/Theme';
 import clsx from 'clsx';
 import React, {
   useCallback,
@@ -242,11 +242,10 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   onUpdateExpertSkills,
   onUpdateExpertSoftSkills
 }) => {
-  const { theme } = useTheme();
-  const themeClassName = theme?.className;
+  const { theme, themeClassNames } = useTheme();
   const palette = useMemo(
-    () => resolveExpertPalette(themeClassName),
-    [themeClassName]
+    () => resolveExpertPalette(themeClassNames),
+    [theme, themeClassNames]
   );
 
   const [viewMode, setViewMode] = useState<ViewMode>('list');
@@ -279,6 +278,11 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   const roleGraphZoomAppliedRef = useRef(false);
   const roleGraphContainerRef = useRef<HTMLDivElement | null>(null);
   const [roleGraphDimensions, setRoleGraphDimensions] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    graphRef.current?.refresh();
+    roleGraphRef.current?.refresh();
+  }, [palette]);
   useEffect(() => {
     if (!includeSoftSkills && focusedSkill?.type === 'soft') {
       setFocusedSkill(null);
@@ -3032,17 +3036,32 @@ const ExpertDetails: React.FC<ExpertDetailsProps> = ({
   );
 };
 
-function resolveExpertPalette(themeClassName?: string): ExpertPalette {
+function resolveExpertPalette(themeClassNames?: ThemePreset | string): ExpertPalette {
   if (typeof window === 'undefined') {
     return DEFAULT_PALETTE;
   }
 
   const themeElement = (() => {
-    if (!themeClassName) {
-      return document.querySelector('.Theme');
+    const tokens: string[] = [];
+
+    if (typeof themeClassNames === 'string') {
+      tokens.push(...themeClassNames.split(/\s+/).filter(Boolean));
+    } else if (themeClassNames && typeof themeClassNames === 'object') {
+      const color = (themeClassNames as ThemePreset).color;
+      const colorToken = typeof color === 'string' ? color : color?.primary;
+
+      [
+        colorToken,
+        (themeClassNames as ThemePreset).control,
+        (themeClassNames as ThemePreset).font,
+        (themeClassNames as ThemePreset).size,
+        (themeClassNames as ThemePreset).space,
+        (themeClassNames as ThemePreset).shadow
+      ]
+        .filter((token): token is string => Boolean(token && token.trim()))
+        .forEach((token) => tokens.push(token.trim()));
     }
 
-    const tokens = themeClassName.split(/\s+/).filter(Boolean);
     const selectorVariants = [
       tokens.length > 0 ? tokens.map((token) => `.${token}`).join('') : null,
       tokens[0] ? `.${tokens[0]}` : null,

--- a/src/components/ExpertExplorer.tsx
+++ b/src/components/ExpertExplorer.tsx
@@ -243,10 +243,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   onUpdateExpertSoftSkills
 }) => {
   const { theme, themeClassNames } = useTheme();
-  const palette = useMemo(
-    () => resolveExpertPalette(themeClassNames),
-    [theme, themeClassNames]
-  );
+  const [palette, setPalette] = useState<ExpertPalette>(() => resolveExpertPalette(themeClassNames));
 
   const [viewMode, setViewMode] = useState<ViewMode>('list');
   const [search, setSearch] = useState('');
@@ -278,6 +275,26 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   const roleGraphZoomAppliedRef = useRef(false);
   const roleGraphContainerRef = useRef<HTMLDivElement | null>(null);
   const [roleGraphDimensions, setRoleGraphDimensions] = useState({ width: 0, height: 0 });
+
+  useLayoutEffect(() => {
+    const applyPalette = () => {
+      const nextPalette = resolveExpertPalette(themeClassNames);
+      setPalette((prev) => (areExpertPalettesEqual(prev, nextPalette) ? prev : nextPalette));
+    };
+
+    applyPalette();
+
+    if (typeof MutationObserver === 'undefined' || typeof window === 'undefined') {
+      return;
+    }
+
+    const target = findThemeElement(themeClassNames) ?? document.body;
+    const observer = new MutationObserver(applyPalette);
+
+    observer.observe(target, { attributes: true, attributeFilter: ['class', 'style'] });
+
+    return () => observer.disconnect();
+  }, [theme, themeClassNames]);
 
   useEffect(() => {
     graphRef.current?.refresh();
@@ -3041,48 +3058,7 @@ function resolveExpertPalette(themeClassNames?: ThemePreset | string): ExpertPal
     return DEFAULT_PALETTE;
   }
 
-  const themeElement = (() => {
-    const tokens: string[] = [];
-
-    if (typeof themeClassNames === 'string') {
-      tokens.push(...themeClassNames.split(/\s+/).filter(Boolean));
-    } else if (themeClassNames && typeof themeClassNames === 'object') {
-      const color = (themeClassNames as ThemePreset).color;
-      const colorToken = typeof color === 'string' ? color : color?.primary;
-
-      [
-        colorToken,
-        (themeClassNames as ThemePreset).control,
-        (themeClassNames as ThemePreset).font,
-        (themeClassNames as ThemePreset).size,
-        (themeClassNames as ThemePreset).space,
-        (themeClassNames as ThemePreset).shadow
-      ]
-        .filter((token): token is string => Boolean(token && token.trim()))
-        .forEach((token) => tokens.push(token.trim()));
-    }
-
-    const selectorVariants = [
-      tokens.length > 0 ? tokens.map((token) => `.${token}`).join('') : null,
-      tokens[0] ? `.${tokens[0]}` : null,
-      '.Theme'
-    ].filter(Boolean) as string[];
-
-    for (const selector of selectorVariants) {
-      try {
-        const element = document.querySelector(selector);
-        if (element) {
-          return element;
-        }
-      } catch {
-        // Ignore invalid selectors and try the next fallback
-      }
-    }
-
-    return null;
-  })();
-
-  const stylesRef = getComputedStyle((themeElement as HTMLElement) ?? document.body);
+  const stylesRef = getComputedStyle((findThemeElement(themeClassNames) as HTMLElement) ?? document.body);
   const getVar = (token: string, fallback: string) =>
     stylesRef.getPropertyValue(token).trim() || fallback;
 
@@ -3110,6 +3086,70 @@ function resolveExpertPalette(themeClassNames?: ThemePreset | string): ExpertPal
     initiativeEdge: withAlpha(initiativeColor, 0.45),
     planEdge: withAlpha(initiativeColor, 0.32)
   };
+}
+
+function findThemeElement(themeClassNames?: ThemePreset | string): Element | null {
+  const tokens: string[] = [];
+
+  if (typeof themeClassNames === 'string') {
+    tokens.push(...themeClassNames.split(/\s+/).filter(Boolean));
+  } else if (themeClassNames && typeof themeClassNames === 'object') {
+    const color = (themeClassNames as ThemePreset).color;
+    const colorToken = typeof color === 'string' ? color : color?.primary;
+
+    [
+      colorToken,
+      (themeClassNames as ThemePreset).control,
+      (themeClassNames as ThemePreset).font,
+      (themeClassNames as ThemePreset).size,
+      (themeClassNames as ThemePreset).space,
+      (themeClassNames as ThemePreset).shadow
+    ]
+      .filter((token): token is string => Boolean(token && token.trim()))
+      .forEach((token) => tokens.push(token.trim()));
+  }
+
+  const selectorVariants = [
+    tokens.length > 0 ? tokens.map((token) => `.${token}`).join('') : null,
+    tokens[0] ? `.${tokens[0]}` : null,
+    '.Theme'
+  ].filter(Boolean) as string[];
+
+  for (const selector of selectorVariants) {
+    try {
+      const element = document.querySelector(selector);
+      if (element) {
+        return element;
+      }
+    } catch {
+      // Ignore invalid selectors and try the next fallback
+    }
+  }
+
+  return null;
+}
+
+function areExpertPalettesEqual(a: ExpertPalette, b: ExpertPalette): boolean {
+  return (
+    a.background === b.background &&
+    a.text === b.text &&
+    a.textMuted === b.textMuted &&
+    a.textOnAccent === b.textOnAccent &&
+    a.expert === b.expert &&
+    a.domain === b.domain &&
+    a.competency === b.competency &&
+    a.consulting === b.consulting &&
+    a.soft === b.soft &&
+    a.role === b.role &&
+    a.module === b.module &&
+    a.initiative === b.initiative &&
+    a.edge === b.edge &&
+    a.edgeHighlight === b.edgeHighlight &&
+    a.roleEdge === b.roleEdge &&
+    a.moduleEdge === b.moduleEdge &&
+    a.initiativeEdge === b.initiativeEdge &&
+    a.planEdge === b.planEdge
+  );
 }
 
 function getReadableTextColor(backgroundColor: string, palette: ExpertPalette): string {

--- a/src/components/ExpertExplorer.tsx
+++ b/src/components/ExpertExplorer.tsx
@@ -265,6 +265,8 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   const [selectedRole, setSelectedRole] = useState<TeamRole | null>(null);
   const [graphInstanceKey, setGraphInstanceKey] = useState(0);
   const [roleGraphInstanceKey, setRoleGraphInstanceKey] = useState(0);
+  const [isSkillGraphVisible, setIsSkillGraphVisible] = useState(true);
+  const [isRoleGraphVisible, setIsRoleGraphVisible] = useState(true);
 
   const graphRef = useRef<ForceGraphMethods | null>(null);
   const initialGraphZoomAppliedRef = useRef<Record<'graph' | 'assignments', boolean>>({
@@ -311,8 +313,15 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   }, [palette, refreshGraphInstance]);
 
   useEffect(() => {
-    setGraphInstanceKey((value) => value + 1);
-    setRoleGraphInstanceKey((value) => value + 1);
+    setIsSkillGraphVisible(false);
+    setIsRoleGraphVisible(false);
+    const frame = window.requestAnimationFrame(() => {
+      setGraphInstanceKey((value) => value + 1);
+      setRoleGraphInstanceKey((value) => value + 1);
+      setIsSkillGraphVisible(true);
+      setIsRoleGraphVisible(true);
+    });
+
     graphRef.current = null;
     roleGraphRef.current = null;
     setFocusedSkill(null);
@@ -320,6 +329,8 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
     setSelectedRole(null);
     initialGraphZoomAppliedRef.current = { graph: false, assignments: false };
     roleGraphZoomAppliedRef.current = false;
+
+    return () => window.cancelAnimationFrame(frame);
   }, [palette]);
   useEffect(() => {
     if (!includeSoftSkills && focusedSkill?.type === 'soft') {
@@ -759,7 +770,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   }, [roleAggregationMap, roleAggregations, selectedRole]);
 
   useEffect(() => {
-    if (viewMode !== 'roles') {
+    if (!isRoleGraphVisible || viewMode !== 'roles') {
       return;
     }
 
@@ -899,7 +910,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
       return;
     }
 
-    if (viewMode !== 'graph' && viewMode !== 'assignments') {
+    if (!isSkillGraphVisible || (viewMode !== 'graph' && viewMode !== 'assignments')) {
       return;
     }
 
@@ -1378,7 +1389,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   }, [viewMode]);
 
   useEffect(() => {
-    if (viewMode !== 'graph' && viewMode !== 'assignments') {
+    if (!isSkillGraphVisible || (viewMode !== 'graph' && viewMode !== 'assignments')) {
       return;
     }
 
@@ -1408,12 +1419,13 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
     skillGraphLinks,
     skillGraphNodes,
     graphInstanceKey,
+    isSkillGraphVisible,
     viewMode
   ]);
 
   useEffect(() => {
     const graph = graphRef.current;
-    if (!graph) {
+    if (!isSkillGraphVisible || !graph) {
       return;
     }
 
@@ -1436,7 +1448,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
     }
 
     graph.d3ReheatSimulation();
-  }, [assignmentGraphLinks, graphInstanceKey, skillGraphLinks, viewMode]);
+  }, [assignmentGraphLinks, graphInstanceKey, isSkillGraphVisible, skillGraphLinks, viewMode]);
 
   useEffect(() => {
     if (viewMode !== 'graph') {
@@ -1592,6 +1604,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
 
     return () => window.clearTimeout(timeout);
   }, [
+    isRoleGraphVisible,
     roleGraphData,
     roleGraphDimensions.height,
     roleGraphDimensions.width,
@@ -1656,7 +1669,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
     if (linkForce && typeof (linkForce as { strength?: unknown }).strength === 'function') {
       (linkForce as { strength: (value: number) => void }).strength(0.7);
     }
-  }, [roleGraphData, roleGraphInstanceKey, viewMode]);
+  }, [isSkillGraphVisible, roleGraphData, roleGraphInstanceKey, viewMode]);
 
   const highlightNodeIds = useMemo(() => {
     const set = new Set<string>();
@@ -2489,7 +2502,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
                     Нет данных для построения графа с выбранными фильтрами.
                   </Text>
                 </div>
-              ) : (
+              ) : isSkillGraphVisible ? (
                 <ForceGraph2D
                   key={graphInstanceKey}
                   ref={graphRef}
@@ -2507,6 +2520,8 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
                   enableZoomInteraction
                   enablePanInteraction
                 />
+              ) : (
+                <Loader size="m" />
               )}
             </div>
             </div>
@@ -2651,7 +2666,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
                     Нет данных для визуализации назначений с выбранными фильтрами.
                   </Text>
                 </div>
-              ) : (
+              ) : isSkillGraphVisible ? (
                 <ForceGraph2D
                   key={graphInstanceKey}
                   ref={graphRef}
@@ -2669,6 +2684,8 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
                   enableZoomInteraction
                   enablePanInteraction
                 />
+              ) : (
+                <Loader size="m" />
               )}
             </div>
           </div>
@@ -2790,7 +2807,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
                               Нет данных для построения графа по выбранной роли.
                             </Text>
                           </div>
-                        ) : (
+                        ) : isRoleGraphVisible ? (
                           <ForceGraph2D
                             key={roleGraphInstanceKey}
                             ref={roleGraphRef}
@@ -2808,6 +2825,8 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
                             enableZoomInteraction
                             enablePanInteraction
                           />
+                        ) : (
+                          <Loader size="m" />
                         )}
                       </div>
                       <Card className={styles.roleExpertsCard} verticalSpace="m" horizontalSpace="l" shadow={false}>

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -151,6 +151,13 @@ const GraphView: React.FC<GraphViewProps> = ({
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const [isFocusedView, setIsFocusedView] = useState(false);
 
+  const refreshGraphInstance = useCallback(() => {
+    const refresh = (graphRef.current as unknown as { refresh?: () => void })?.refresh;
+    if (typeof refresh === 'function') {
+      refresh.call(graphRef.current);
+    }
+  }, []);
+
   useLayoutEffect(() => {
     const applyPalette = () => {
       const nextPalette = resolvePalette(themeClassNames);
@@ -172,8 +179,8 @@ const GraphView: React.FC<GraphViewProps> = ({
   }, [theme, themeClassNames]);
 
   useEffect(() => {
-    graphRef.current?.refresh();
-  }, [palette]);
+    refreshGraphInstance();
+  }, [palette, refreshGraphInstance]);
 
   useEffect(() => {
     lastReportedLayoutRef.current = JSON.stringify(layoutPositions ?? {});

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -2,7 +2,14 @@ import { Badge } from '@consta/uikit/Badge';
 import { Loader } from '@consta/uikit/Loader';
 import { useTheme, type ThemePreset } from '@consta/uikit/Theme';
 import { forceCollide } from 'd3-force-3d';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
 import ForceGraph2D, {
   ForceGraphMethods,
   LinkObject,
@@ -128,10 +135,7 @@ const GraphView: React.FC<GraphViewProps> = ({
   onLayoutChange
 }) => {
   const { theme, themeClassNames } = useTheme();
-  const palette = useMemo(
-    () => resolvePalette(themeClassNames),
-    [theme, themeClassNames]
-  );
+  const [palette, setPalette] = useState<GraphPalette>(() => resolvePalette(themeClassNames));
   const initialCameraState = useMemo(() => readStoredCameraState(), []);
   const graphRef = useRef<ForceGraphMethods | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -146,6 +150,26 @@ const GraphView: React.FC<GraphViewProps> = ({
   const maxNodeCountRef = useRef(0);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const [isFocusedView, setIsFocusedView] = useState(false);
+
+  useLayoutEffect(() => {
+    const applyPalette = () => {
+      const nextPalette = resolvePalette(themeClassNames);
+      setPalette((prev) => (arePalettesEqual(prev, nextPalette) ? prev : nextPalette));
+    };
+
+    applyPalette();
+
+    if (typeof MutationObserver === 'undefined' || typeof window === 'undefined') {
+      return;
+    }
+
+    const target = findThemeElement(themeClassNames) ?? document.body;
+    const observer = new MutationObserver(applyPalette);
+
+    observer.observe(target, { attributes: true, attributeFilter: ['class', 'style'] });
+
+    return () => observer.disconnect();
+  }, [theme, themeClassNames]);
 
   useEffect(() => {
     graphRef.current?.refresh();
@@ -1315,48 +1339,7 @@ function resolvePalette(themeClassNames?: ThemePreset | string): GraphPalette {
     return DEFAULT_PALETTE;
   }
 
-  const themeElement = (() => {
-    const tokens: string[] = [];
-
-    if (typeof themeClassNames === 'string') {
-      tokens.push(...themeClassNames.split(/\s+/).filter(Boolean));
-    } else if (themeClassNames && typeof themeClassNames === 'object') {
-      const color = (themeClassNames as ThemePreset).color;
-      const colorToken = typeof color === 'string' ? color : color?.primary;
-
-      [
-        colorToken,
-        (themeClassNames as ThemePreset).control,
-        (themeClassNames as ThemePreset).font,
-        (themeClassNames as ThemePreset).size,
-        (themeClassNames as ThemePreset).space,
-        (themeClassNames as ThemePreset).shadow
-      ]
-        .filter((token): token is string => Boolean(token && token.trim()))
-        .forEach((token) => tokens.push(token.trim()));
-    }
-
-    const selectorVariants = [
-      tokens.length > 0 ? tokens.map((token) => `.${token}`).join('') : null,
-      tokens[0] ? `.${tokens[0]}` : null,
-      '.Theme'
-    ].filter(Boolean) as string[];
-
-    for (const selector of selectorVariants) {
-      try {
-        const element = document.querySelector(selector);
-        if (element) {
-          return element;
-        }
-      } catch {
-        // Ignore invalid selectors and try the next fallback
-      }
-    }
-
-    return null;
-  })();
-
-  const styles = getComputedStyle((themeElement as HTMLElement) ?? document.body);
+  const styles = getComputedStyle((findThemeElement(themeClassNames) as HTMLElement) ?? document.body);
   const getVar = (token: string, fallback: string) => styles.getPropertyValue(token).trim() || fallback;
 
   return {
@@ -1373,6 +1356,64 @@ function resolvePalette(themeClassNames?: ThemePreset | string): GraphPalette {
     linkConsumes: getVar('--color-bg-normal', DEFAULT_PALETTE.linkConsumes),
     linkInitiative: getVar('--color-bg-accent', DEFAULT_PALETTE.linkInitiative)
   };
+}
+
+function findThemeElement(themeClassNames?: ThemePreset | string): Element | null {
+  const tokens: string[] = [];
+
+  if (typeof themeClassNames === 'string') {
+    tokens.push(...themeClassNames.split(/\s+/).filter(Boolean));
+  } else if (themeClassNames && typeof themeClassNames === 'object') {
+    const color = (themeClassNames as ThemePreset).color;
+    const colorToken = typeof color === 'string' ? color : color?.primary;
+
+    [
+      colorToken,
+      (themeClassNames as ThemePreset).control,
+      (themeClassNames as ThemePreset).font,
+      (themeClassNames as ThemePreset).size,
+      (themeClassNames as ThemePreset).space,
+      (themeClassNames as ThemePreset).shadow
+    ]
+      .filter((token): token is string => Boolean(token && token.trim()))
+      .forEach((token) => tokens.push(token.trim()));
+  }
+
+  const selectorVariants = [
+    tokens.length > 0 ? tokens.map((token) => `.${token}`).join('') : null,
+    tokens[0] ? `.${tokens[0]}` : null,
+    '.Theme'
+  ].filter(Boolean) as string[];
+
+  for (const selector of selectorVariants) {
+    try {
+      const element = document.querySelector(selector);
+      if (element) {
+        return element;
+      }
+    } catch {
+      // Ignore invalid selectors and try the next fallback
+    }
+  }
+
+  return null;
+}
+
+function arePalettesEqual(a: GraphPalette, b: GraphPalette): boolean {
+  return (
+    a.moduleProduction === b.moduleProduction &&
+    a.moduleInDev === b.moduleInDev &&
+    a.moduleDeprecated === b.moduleDeprecated &&
+    a.domain === b.domain &&
+    a.artifact === b.artifact &&
+    a.initiative === b.initiative &&
+    a.text === b.text &&
+    a.linkDependency === b.linkDependency &&
+    a.linkProduces === b.linkProduces &&
+    a.linkRelates === b.linkRelates &&
+    a.linkConsumes === b.linkConsumes &&
+    a.linkInitiative === b.linkInitiative
+  );
 }
 
 function clamp(value: number, min: number, max: number): number {

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -150,6 +150,7 @@ const GraphView: React.FC<GraphViewProps> = ({
   const maxNodeCountRef = useRef(0);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const [isFocusedView, setIsFocusedView] = useState(false);
+  const [graphInstanceKey, setGraphInstanceKey] = useState(0);
 
   const refreshGraphInstance = useCallback(() => {
     const refresh = (graphRef.current as unknown as { refresh?: () => void })?.refresh;
@@ -177,6 +178,11 @@ const GraphView: React.FC<GraphViewProps> = ({
 
     return () => observer.disconnect();
   }, [theme, themeClassNames]);
+
+  useEffect(() => {
+    nodeCacheRef.current.clear();
+    setGraphInstanceKey((value) => value + 1);
+  }, [palette]);
 
   useEffect(() => {
     refreshGraphInstance();
@@ -604,7 +610,8 @@ const GraphView: React.FC<GraphViewProps> = ({
 
   useEffect(() => {
     configureSimulation();
-  }, [configureSimulation]);
+    restoreCamera();
+  }, [configureSimulation, graphInstanceKey, restoreCamera]);
 
   useEffect(() => {
     if (!highlightedNode) {
@@ -927,6 +934,7 @@ const GraphView: React.FC<GraphViewProps> = ({
       <div className={styles.graphWrapper} ref={wrapperRef}>
         <React.Suspense fallback={<Loader size="m" />}>
           <ForceGraph2D
+            key={graphInstanceKey}
             ref={graphRef}
             width={dimensions.width || 600}
             height={dimensions.height || 400}

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -151,6 +151,7 @@ const GraphView: React.FC<GraphViewProps> = ({
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const [isFocusedView, setIsFocusedView] = useState(false);
   const [graphInstanceKey, setGraphInstanceKey] = useState(0);
+  const [isGraphVisible, setIsGraphVisible] = useState(true);
 
   const refreshGraphInstance = useCallback(() => {
     const refresh = (graphRef.current as unknown as { refresh?: () => void })?.refresh;
@@ -186,7 +187,13 @@ const GraphView: React.FC<GraphViewProps> = ({
     hasInitialFitRef.current = false;
     lastFocusedNodeRef.current = null;
     setIsFocusedView(false);
-    setGraphInstanceKey((value) => value + 1);
+    setIsGraphVisible(false);
+    const frame = window.requestAnimationFrame(() => {
+      setGraphInstanceKey((value) => value + 1);
+      setIsGraphVisible(true);
+    });
+
+    return () => window.cancelAnimationFrame(frame);
   }, [palette]);
 
   useEffect(() => {
@@ -614,9 +621,17 @@ const GraphView: React.FC<GraphViewProps> = ({
   ]);
 
   useEffect(() => {
-    configureSimulation();
-    restoreCamera();
-  }, [configureSimulation, graphInstanceKey, restoreCamera]);
+    if (!isGraphVisible || !graphRef.current) {
+      return;
+    }
+
+    const frame = window.requestAnimationFrame(() => {
+      configureSimulation();
+      restoreCamera();
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [configureSimulation, graphInstanceKey, isGraphVisible, restoreCamera]);
 
   useEffect(() => {
     if (!highlightedNode) {
@@ -938,40 +953,44 @@ const GraphView: React.FC<GraphViewProps> = ({
       </div>
       <div className={styles.graphWrapper} ref={wrapperRef}>
         <React.Suspense fallback={<Loader size="m" />}>
-          <ForceGraph2D
-            key={graphInstanceKey}
-            ref={graphRef}
-            width={dimensions.width || 600}
-            height={dimensions.height || 400}
-            graphData={graphData}
-          nodeLabel={(node: ForceNode) => node.name ?? node.id}
-          linkColor={(link: ForceLink) =>
-            resolveLinkColor(link, palette, visibleDomainIds, visibleModuleStatuses, moduleStatusMap)
-          }
-          nodeCanvasObject={(node: ForceNode, ctx, globalScale) => {
-            drawNode(
-              node,
-              ctx,
-              globalScale,
-              highlightedNode,
-              palette,
-              visibleDomainIds,
-              visibleModuleStatuses
-            );
-          }}
-          nodeCanvasObjectMode={() => 'replace'}
-          onNodeClick={(node) => {
-            onSelect(node as ForceNode);
-          }}
-          onNodeDoubleClick={(node) => {
-            handleNodeDoubleClick(node as ForceNode);
-          }}
-          onNodeDragEnd={handleNodeDragEnd}
-          onEngineStop={handleEngineStop}
-          onZoom={handleZoomTransform}
-          onZoomEnd={handleZoomEnd}
-        />
-      </React.Suspense>
+          {isGraphVisible ? (
+            <ForceGraph2D
+              key={graphInstanceKey}
+              ref={graphRef}
+              width={dimensions.width || 600}
+              height={dimensions.height || 400}
+              graphData={graphData}
+              nodeLabel={(node: ForceNode) => node.name ?? node.id}
+              linkColor={(link: ForceLink) =>
+                resolveLinkColor(link, palette, visibleDomainIds, visibleModuleStatuses, moduleStatusMap)
+              }
+              nodeCanvasObject={(node: ForceNode, ctx, globalScale) => {
+                drawNode(
+                  node,
+                  ctx,
+                  globalScale,
+                  highlightedNode,
+                  palette,
+                  visibleDomainIds,
+                  visibleModuleStatuses
+                );
+              }}
+              nodeCanvasObjectMode={() => 'replace'}
+              onNodeClick={(node) => {
+                onSelect(node as ForceNode);
+              }}
+              onNodeDoubleClick={(node) => {
+                handleNodeDoubleClick(node as ForceNode);
+              }}
+              onNodeDragEnd={handleNodeDragEnd}
+              onEngineStop={handleEngineStop}
+              onZoom={handleZoomTransform}
+              onZoomEnd={handleZoomEnd}
+            />
+          ) : (
+            <Loader size="m" />
+          )}
+        </React.Suspense>
       </div>
     </div>
   );

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -1310,7 +1310,32 @@ function resolvePalette(themeClassName?: string): GraphPalette {
     return DEFAULT_PALETTE;
   }
 
-  const themeElement = themeClassName ? document.querySelector(`.${themeClassName}`) : null;
+  const themeElement = (() => {
+    if (!themeClassName) {
+      return document.querySelector('.Theme');
+    }
+
+    const tokens = themeClassName.split(/\s+/).filter(Boolean);
+    const selectorVariants = [
+      tokens.length > 0 ? tokens.map((token) => `.${token}`).join('') : null,
+      tokens[0] ? `.${tokens[0]}` : null,
+      '.Theme'
+    ].filter(Boolean) as string[];
+
+    for (const selector of selectorVariants) {
+      try {
+        const element = document.querySelector(selector);
+        if (element) {
+          return element;
+        }
+      } catch {
+        // Ignore invalid selectors and try the next fallback
+      }
+    }
+
+    return null;
+  })();
+
   const styles = getComputedStyle((themeElement as HTMLElement) ?? document.body);
   const getVar = (token: string, fallback: string) => styles.getPropertyValue(token).trim() || fallback;
 

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -181,6 +181,11 @@ const GraphView: React.FC<GraphViewProps> = ({
 
   useEffect(() => {
     nodeCacheRef.current.clear();
+    graphRef.current = null;
+    cameraStateRef.current = null;
+    hasInitialFitRef.current = false;
+    lastFocusedNodeRef.current = null;
+    setIsFocusedView(false);
     setGraphInstanceKey((value) => value + 1);
   }, [palette]);
 

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -42,6 +42,7 @@ type GraphViewProps = {
   artifacts: ArtifactNode[];
   initiatives: Initiative[];
   links: GraphLink[];
+  graphVersion?: string | number;
   onSelect: (node: GraphNode | null) => void;
   highlightedNode: string | null;
   visibleDomainIds: Set<string>;
@@ -62,13 +63,17 @@ type CameraState = {
   zoom: number;
 };
 
-function readStoredCameraState(): CameraState | null {
+function resolveCameraStorageKey(graphVersion?: string | number): string {
+  return graphVersion ? `${CAMERA_STORAGE_KEY}:${graphVersion}` : CAMERA_STORAGE_KEY;
+}
+
+function readStoredCameraState(storageKey: string): CameraState | null {
   if (typeof window === 'undefined') {
     return null;
   }
 
   try {
-    const rawValue = window.sessionStorage.getItem(CAMERA_STORAGE_KEY);
+    const rawValue = window.sessionStorage.getItem(storageKey);
     if (!rawValue) {
       return null;
     }
@@ -103,18 +108,18 @@ function readStoredCameraState(): CameraState | null {
   return null;
 }
 
-function writeStoredCameraState(state: CameraState | null): void {
+function writeStoredCameraState(storageKey: string, state: CameraState | null): void {
   if (typeof window === 'undefined') {
     return;
   }
 
   try {
     if (!state) {
-      window.sessionStorage.removeItem(CAMERA_STORAGE_KEY);
+      window.sessionStorage.removeItem(storageKey);
       return;
     }
 
-    window.sessionStorage.setItem(CAMERA_STORAGE_KEY, JSON.stringify(state));
+    window.sessionStorage.setItem(storageKey, JSON.stringify(state));
   } catch (error) {
     console.warn('Failed to persist camera state', error);
   }
@@ -126,6 +131,7 @@ const GraphView: React.FC<GraphViewProps> = ({
   artifacts,
   initiatives,
   links,
+  graphVersion,
   onSelect,
   highlightedNode,
   visibleDomainIds,
@@ -136,7 +142,14 @@ const GraphView: React.FC<GraphViewProps> = ({
 }) => {
   const { theme, themeClassNames } = useTheme();
   const [palette, setPalette] = useState<GraphPalette>(() => resolvePalette(themeClassNames));
-  const initialCameraState = useMemo(() => readStoredCameraState(), []);
+  const cameraStorageKey = useMemo(
+    () => resolveCameraStorageKey(graphVersion),
+    [graphVersion]
+  );
+  const initialCameraState = useMemo(
+    () => readStoredCameraState(cameraStorageKey),
+    [cameraStorageKey]
+  );
   const graphRef = useRef<ForceGraphMethods | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
@@ -183,7 +196,7 @@ const GraphView: React.FC<GraphViewProps> = ({
   useEffect(() => {
     nodeCacheRef.current.clear();
     graphRef.current = null;
-    cameraStateRef.current = null;
+    cameraStateRef.current = initialCameraState;
     hasInitialFitRef.current = false;
     lastFocusedNodeRef.current = null;
     setIsFocusedView(false);
@@ -194,7 +207,7 @@ const GraphView: React.FC<GraphViewProps> = ({
     });
 
     return () => window.cancelAnimationFrame(frame);
-  }, [palette]);
+  }, [graphVersion, initialCameraState, palette]);
 
   useEffect(() => {
     refreshGraphInstance();
@@ -445,9 +458,9 @@ const GraphView: React.FC<GraphViewProps> = ({
         zoom: zoomValue
       };
       cameraStateRef.current = nextState;
-      writeStoredCameraState(nextState);
+      writeStoredCameraState(cameraStorageKey, nextState);
     }
-  }, [getViewportSize]);
+  }, [cameraStorageKey, getViewportSize]);
 
   const scheduleCameraCapture = useCallback(
     (delay = 0) => {
@@ -676,10 +689,10 @@ const GraphView: React.FC<GraphViewProps> = ({
         zoom: zoomValue
       };
       cameraStateRef.current = nextState;
-      writeStoredCameraState(nextState);
+      writeStoredCameraState(cameraStorageKey, nextState);
       scheduleCameraCapture(420);
     }
-  }, [getViewportSize, highlightedNode, scheduleCameraCapture]);
+  }, [cameraStorageKey, getViewportSize, highlightedNode, scheduleCameraCapture]);
 
   const focusOnNode = useCallback(
     (node: ForceNode): boolean => {
@@ -702,12 +715,12 @@ const GraphView: React.FC<GraphViewProps> = ({
         zoom: targetZoom
       };
       cameraStateRef.current = nextState;
-      writeStoredCameraState(nextState);
+      writeStoredCameraState(cameraStorageKey, nextState);
       lastFocusedNodeRef.current = node.id;
       scheduleCameraCapture(420);
       return true;
     },
-    [getViewportSize, scheduleCameraCapture]
+    [cameraStorageKey, getViewportSize, scheduleCameraCapture]
   );
 
   const showEntireGraph = useCallback(() => {
@@ -719,10 +732,10 @@ const GraphView: React.FC<GraphViewProps> = ({
     lastFocusedNodeRef.current = null;
     setIsFocusedView(false);
     cameraStateRef.current = null;
-    writeStoredCameraState(null);
+    writeStoredCameraState(cameraStorageKey, null);
     graph.zoomToFit?.(400, 80);
     scheduleCameraCapture(450);
-  }, [scheduleCameraCapture]);
+  }, [cameraStorageKey, scheduleCameraCapture]);
 
   useEffect(() => {
     if (cameraStateRef.current || hasInitialFitRef.current) {
@@ -809,9 +822,9 @@ const GraphView: React.FC<GraphViewProps> = ({
         zoom: k
       };
       cameraStateRef.current = nextState;
-      writeStoredCameraState(nextState);
+      writeStoredCameraState(cameraStorageKey, nextState);
     },
-    [getViewportSize]
+    [cameraStorageKey, getViewportSize]
   );
 
   const handleZoomEnd = useCallback(() => {

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -1,6 +1,6 @@
 import { Badge } from '@consta/uikit/Badge';
 import { Loader } from '@consta/uikit/Loader';
-import { useTheme } from '@consta/uikit/Theme';
+import { useTheme, type ThemePreset } from '@consta/uikit/Theme';
 import { forceCollide } from 'd3-force-3d';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ForceGraph2D, {
@@ -127,10 +127,11 @@ const GraphView: React.FC<GraphViewProps> = ({
   normalizationRequest,
   onLayoutChange
 }) => {
-  const { theme } = useTheme();
-  const themeClassName = theme?.className ?? 'default';
-
-  const palette = useMemo(() => resolvePalette(themeClassName), [themeClassName]);
+  const { theme, themeClassNames } = useTheme();
+  const palette = useMemo(
+    () => resolvePalette(themeClassNames),
+    [theme, themeClassNames]
+  );
   const initialCameraState = useMemo(() => readStoredCameraState(), []);
   const graphRef = useRef<ForceGraphMethods | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -145,6 +146,10 @@ const GraphView: React.FC<GraphViewProps> = ({
   const maxNodeCountRef = useRef(0);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const [isFocusedView, setIsFocusedView] = useState(false);
+
+  useEffect(() => {
+    graphRef.current?.refresh();
+  }, [palette]);
 
   useEffect(() => {
     lastReportedLayoutRef.current = JSON.stringify(layoutPositions ?? {});
@@ -1305,17 +1310,32 @@ function resolveNodeIcon(node: GraphNode): string {
   return '';
 }
 
-function resolvePalette(themeClassName?: string): GraphPalette {
+function resolvePalette(themeClassNames?: ThemePreset | string): GraphPalette {
   if (typeof window === 'undefined') {
     return DEFAULT_PALETTE;
   }
 
   const themeElement = (() => {
-    if (!themeClassName) {
-      return document.querySelector('.Theme');
+    const tokens: string[] = [];
+
+    if (typeof themeClassNames === 'string') {
+      tokens.push(...themeClassNames.split(/\s+/).filter(Boolean));
+    } else if (themeClassNames && typeof themeClassNames === 'object') {
+      const color = (themeClassNames as ThemePreset).color;
+      const colorToken = typeof color === 'string' ? color : color?.primary;
+
+      [
+        colorToken,
+        (themeClassNames as ThemePreset).control,
+        (themeClassNames as ThemePreset).font,
+        (themeClassNames as ThemePreset).size,
+        (themeClassNames as ThemePreset).space,
+        (themeClassNames as ThemePreset).shadow
+      ]
+        .filter((token): token is string => Boolean(token && token.trim()))
+        .forEach((token) => tokens.push(token.trim()));
     }
 
-    const tokens = themeClassName.split(/\s+/).filter(Boolean);
     const selectorVariants = [
       tokens.length > 0 ? tokens.map((token) => `.${token}`).join('') : null,
       tokens[0] ? `.${tokens[0]}` : null,


### PR DESCRIPTION
## Summary
- add robust theme element resolution to read Consta CSS variables
- ensure expert graph palette uses actual theme colors for better dark mode visibility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f703f52008332b8fe068f17bb0c4a)