### PR TITLE
Handle missing experts in snapshots

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -333,7 +333,7 @@ function App() {
     const nextDomains = scopes.has('domains') ? snapshot.domains : currentDomains;
     const nextModules = scopes.has('modules') ? snapshot.modules : currentModules;
     const nextArtifacts = scopes.has('artifacts') ? snapshot.artifacts : currentArtifacts;
-    const nextExperts = scopes.has('experts') ? snapshot.experts ?? initialExperts : currentExperts;
+    const nextExperts = scopes.has('experts') ? snapshot.experts ?? [] : currentExperts;
     const nextInitiatives = scopes.has('initiatives') ? snapshot.initiatives ?? [] : currentInitiatives;
 
     const flattenedDomains = flattenDomainTree(nextDomains);


### PR DESCRIPTION
## Summary
- ensure applySnapshot uses an empty experts list when the experts scope is included but missing data
- keep existing behavior for other scopes and partial snapshots

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69206083ab58833298cc821c541c3d16)