### PR TITLE
Handle default copy options when creating graphs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,6 +90,8 @@ import GraphPersistenceControls from './components/GraphPersistenceControls';
 const allStatuses: ModuleStatus[] = ['production', 'in-dev', 'deprecated'];
 const initialProducts = buildProductList(initialModules);
 const MAX_LAYOUT_SPAN = 1800;
+const buildDefaultGraphCopyOptions = () =>
+  new Set<GraphDataScope>(['domains', 'modules', 'artifacts', 'experts', 'initiatives']);
 
 const StatsDashboard = lazy(async () => ({
   default: (await import('./components/StatsDashboard')).default
@@ -205,13 +207,20 @@ function App() {
 
   const [graphNameDraft, setGraphNameDraft] = useState('');
   const [graphSourceIdDraft, setGraphSourceIdDraft] = useState<string | null>(null);
-  const [graphCopyOptions, setGraphCopyOptions] = useState<
-    Set<'domains' | 'modules' | 'artifacts' | 'experts' | 'initiatives'>
-  >(() => new Set(['domains', 'modules', 'artifacts', 'experts', 'initiatives']));
+  const [graphCopyOptions, setGraphCopyOptions] = useState<Set<GraphDataScope>>(
+    buildDefaultGraphCopyOptions
+  );
   const [isGraphActionInProgress, setIsGraphActionInProgress] = useState(false);
   const [graphActionStatus, setGraphActionStatus] = useState<
     { type: 'success' | 'error'; message: string } | null
   >(null);
+  const handleGraphSourceIdChange = useCallback((value: string | null) => {
+    setGraphSourceIdDraft(value);
+
+    if (value === null) {
+      setGraphCopyOptions(buildDefaultGraphCopyOptions());
+    }
+  }, []);
   const handleUpdateExpertSkills = useCallback((expertId: string, skills: ExpertSkill[]) => {
     setExpertProfiles((prev) =>
       prev.map((expert) => (expert.id === expertId ? { ...expert, skills } : expert))
@@ -2988,11 +2997,19 @@ function App() {
       return;
     }
 
-    const includeDomains = graphCopyOptions.has('domains');
-    const includeModules = graphCopyOptions.has('modules');
-    const includeArtifacts = graphCopyOptions.has('artifacts');
-    const includeExperts = graphCopyOptions.has('experts');
-    const includeInitiatives = graphCopyOptions.has('initiatives');
+    const effectiveCopyOptions = graphSourceIdDraft
+      ? graphCopyOptions
+      : buildDefaultGraphCopyOptions();
+
+    if (!graphSourceIdDraft) {
+      setGraphCopyOptions(effectiveCopyOptions);
+    }
+
+    const includeDomains = effectiveCopyOptions.has('domains');
+    const includeModules = effectiveCopyOptions.has('modules');
+    const includeArtifacts = effectiveCopyOptions.has('artifacts');
+    const includeExperts = effectiveCopyOptions.has('experts');
+    const includeInitiatives = effectiveCopyOptions.has('initiatives');
 
     if (
       graphSourceIdDraft &&
@@ -3206,7 +3223,7 @@ function App() {
         graphName={graphNameDraft}
         onGraphNameChange={(val) => setGraphNameDraft(val)}
         sourceGraphId={graphSourceIdDraft}
-        onSourceGraphIdChange={setGraphSourceIdDraft}
+        onSourceGraphIdChange={handleGraphSourceIdChange}
         copyOptions={graphCopyOptions}
         onCopyOptionsChange={setGraphCopyOptions}
         isSubmitting={isGraphActionInProgress}

--- a/src/components/CreateGraphModal.tsx
+++ b/src/components/CreateGraphModal.tsx
@@ -77,7 +77,17 @@ export const CreateGraphModal: React.FC<CreateGraphModalProps> = ({
             getItemKey={(item) => item.value}
             placeholder="Создать пустой граф"
             disabled={isSubmitting || graphOptions.length <= 0}
-            onChange={(option) => onSourceGraphIdChange(option?.value ?? null)}
+            onChange={(option) => {
+              const nextSourceId = option?.value ?? null;
+
+              onSourceGraphIdChange(nextSourceId);
+
+              if (nextSourceId === null) {
+                onCopyOptionsChange(
+                  new Set<GraphCopyOption>(['domains', 'modules', 'artifacts', 'experts', 'initiatives'])
+                );
+              }
+            }}
             width="full"
           />
 
@@ -117,7 +127,7 @@ export const CreateGraphModal: React.FC<CreateGraphModalProps> = ({
           <Text size="xs" view="secondary">
             {sourceGraphId
               ? 'Выберите, какие данные скопировать из выбранного графа.'
-              : 'Если источник не выбран, граф создаётся пустым.'}
+              : 'Если источник не выбран, граф создаётся с данными по умолчанию.'}
           </Text>
 
           {status && (


### PR DESCRIPTION
## Summary
- ensure new graphs created without a source always include the full default dataset and reset copy options
- reset copy option state when clearing the source graph in the creation modal and clarify the helper text

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692060fda8508332b78569e66e8fe673)