### PR TITLE
Handle unavailable graph selection errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,6 +115,9 @@ type AdminNotice = {
   message: string;
 };
 
+const GRAPH_UNAVAILABLE_MESSAGE =
+  'Выбранный граф недоступен. Обновите список графов и попробуйте снова.';
+
 const isAnalyticsPanelEnabled =
   (import.meta.env.VITE_ENABLE_ANALYTICS_PANEL ?? 'true').toLowerCase() !== 'false';
 
@@ -162,6 +165,9 @@ function App() {
   const hasPendingPersistRef = useRef(false);
   const activeSnapshotControllerRef = useRef<AbortController | null>(null);
   const activeGraphIdRef = useRef<string | null>(null);
+  const updateActiveGraphRef = useRef<
+    (graphId: string | null, options?: { loadSnapshot?: boolean }) => void
+  >();
   const loadedGraphsRef = useRef(new Set<string>());
   const adminNoticeIdRef = useRef(0);
   const moduleDraftPrefillIdRef = useRef(0);
@@ -433,7 +439,13 @@ function App() {
   }, []);
 
   const loadSnapshot = useCallback(
-    async (graphId: string, { withOverlay }: { withOverlay?: boolean } = {}) => {
+    async (
+      graphId: string,
+      {
+        withOverlay,
+        fallbackGraphId
+      }: { withOverlay?: boolean; fallbackGraphId?: string | null } = {}
+    ) => {
       activeSnapshotControllerRef.current?.abort();
 
       const controller = new AbortController();
@@ -466,10 +478,11 @@ function App() {
 
         console.error(`Не удалось загрузить граф ${graphId}`, error);
         const detail = error instanceof Error ? error.message : null;
+        showAdminNotice('error', GRAPH_UNAVAILABLE_MESSAGE);
         setSnapshotError(
           detail
-            ? `Не удалось загрузить данные графа (${detail}). Используются локальные данные.`
-            : 'Не удалось загрузить данные графа. Используются локальные данные.'
+            ? `Не удалось загрузить данные графа (${detail}). Выберите другой граф или попробуйте ещё раз.`
+            : 'Не удалось загрузить данные графа. Выберите другой граф или попробуйте ещё раз.'
         );
         setIsSyncAvailable(false);
         const syncErrorMessage = detail
@@ -479,6 +492,20 @@ function App() {
           state: 'error',
           message: syncErrorMessage
         });
+
+        if (fallbackGraphId !== undefined && updateActiveGraphRef.current) {
+          const fallbackId =
+            fallbackGraphId && graphs.some((graph) => graph.id === fallbackGraphId)
+              ? fallbackGraphId
+              : null;
+
+          if (fallbackId) {
+            const shouldReloadFallback = !loadedGraphsRef.current.has(fallbackId);
+            updateActiveGraphRef.current(fallbackId, { loadSnapshot: shouldReloadFallback });
+          } else {
+            updateActiveGraphRef.current(null, { loadSnapshot: false });
+          }
+        }
       } finally {
         const isCurrentRequest = activeSnapshotControllerRef.current === controller;
 
@@ -495,7 +522,7 @@ function App() {
         }
       }
     },
-    [applySnapshot]
+    [applySnapshot, graphs, showAdminNotice]
   );
 
   const updateActiveGraph = useCallback(
@@ -518,6 +545,12 @@ function App() {
         return;
       }
 
+      const isValidTarget = graphs.some((graph) => graph.id === graphId);
+      if (!isValidTarget) {
+        showAdminNotice('error', GRAPH_UNAVAILABLE_MESSAGE);
+        return;
+      }
+
       if (previousGraphId === graphId) {
         return;
       }
@@ -534,15 +567,17 @@ function App() {
 
       if (shouldLoadSnapshot) {
         setIsSnapshotLoading(true);
-        void loadSnapshot(graphId, { withOverlay: true });
+        void loadSnapshot(graphId, { withOverlay: true, fallbackGraphId: previousGraphId });
       } else {
         setIsSnapshotLoading(false);
       }
 
       setGraphRenderEpoch((value) => value + 1);
     },
-    [loadSnapshot]
+    [graphs, loadSnapshot, showAdminNotice]
   );
+
+  updateActiveGraphRef.current = updateActiveGraph;
 
   const refreshGraphs = useCallback(
     async (


### PR DESCRIPTION
## Summary
- validate graph selections and surface an error notice when a graph is unavailable
- reset the active graph to a fallback or null after failed snapshot loads
- update snapshot error messaging to guide users to choose a different graph

## Testing
- npm test -- --runInBand *(fails: Vitest dependency not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692063eb18888332a7e87d61d172b3fa)