### PR TITLE
Add offline fallback when graph storage is unavailable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,6 +93,28 @@ const MAX_LAYOUT_SPAN = 1800;
 const buildDefaultGraphCopyOptions = () =>
   new Set<GraphDataScope>(['domains', 'modules', 'artifacts', 'experts', 'initiatives']);
 
+const LOCAL_GRAPH_ID = 'local-graph';
+const LOCAL_GRAPH_NAME = 'Локальные данные';
+const LOCAL_GRAPH_SUMMARY: GraphSummary = {
+  id: LOCAL_GRAPH_ID,
+  name: LOCAL_GRAPH_NAME,
+  isDefault: true,
+  createdAt: '1970-01-01T00:00:00.000Z'
+};
+
+function buildLocalSnapshot(): GraphSnapshotPayload {
+  return {
+    version: GRAPH_SNAPSHOT_VERSION,
+    exportedAt: undefined,
+    domains: initialDomainTree,
+    modules: initialModules,
+    artifacts: initialArtifacts,
+    experts: initialExperts,
+    initiatives: initialInitiatives,
+    layout: undefined
+  };
+}
+
 const StatsDashboard = lazy(async () => ({
   default: (await import('./components/StatsDashboard')).default
 }));
@@ -464,6 +486,19 @@ function App() {
       }
 
       try {
+        if (graphId === LOCAL_GRAPH_ID) {
+          applySnapshot(buildLocalSnapshot());
+          loadedGraphsRef.current.add(graphId);
+          failedGraphLoadsRef.current.delete(graphId);
+          setSnapshotError(null);
+          setIsSyncAvailable(false);
+          setSyncStatus({
+            state: 'idle',
+            message: 'Работаем с локальными данными. Изменения не сохраняются.'
+          });
+          return;
+        }
+
         const snapshot = await fetchGraphSnapshot(graphId, controller.signal);
         if (controller.signal.aborted || activeGraphIdRef.current !== graphId) {
           return;
@@ -637,13 +672,26 @@ function App() {
         }
 
         setGraphListError(message);
-        setGraphs([]);
-        updateActiveGraph(null, { loadSnapshot: false });
+
+        const fallbackGraphs = [LOCAL_GRAPH_SUMMARY];
+        setGraphs(fallbackGraphs);
+        loadedGraphsRef.current = new Set([LOCAL_GRAPH_ID]);
+
+        if (activeGraphIdRef.current !== LOCAL_GRAPH_ID) {
+          updateActiveGraph(LOCAL_GRAPH_ID, { loadSnapshot: false });
+        }
+
+        applySnapshot(buildLocalSnapshot());
+        setIsSyncAvailable(false);
+        setSyncStatus({
+          state: 'error',
+          message: 'Нет связи с сервером. Изменения не сохранятся.'
+        });
       } finally {
         setIsGraphsLoading(false);
       }
     },
-    [updateActiveGraph]
+    [updateActiveGraph, applySnapshot]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add a local graph summary and snapshot to use when the storage API cannot be reached
- load the local snapshot without hitting the server and surface clear read-only sync status
- fall back to local data when listing graphs fails instead of leaving the graph unset

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ab523c208332a1e85a4459513042)