### PR TITLE
Ensure default graph is selected on load

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -629,7 +629,7 @@ function App() {
         return;
       }
 
-      const isValidTarget = graphs.some((graph) => graph.id === graphId);
+      const isValidTarget = graphsRef.current.some((graph) => graph.id === graphId);
       if (!isValidTarget) {
         // Показываем уведомление только если граф был явно выбран пользователем и не является локальным
         if (graphId !== LOCAL_GRAPH_ID && activeGraphIdRef.current === graphId && graphId !== null) {
@@ -675,7 +675,7 @@ function App() {
 
       setGraphRenderEpoch((value) => value + 1);
     },
-    [graphs, loadSnapshot, showAdminNotice]
+    [loadSnapshot, showAdminNotice]
   );
 
   updateActiveGraphRef.current = updateActiveGraph;
@@ -689,6 +689,7 @@ function App() {
       setIsGraphsLoading(true);
       try {
         const list = await fetchGraphSummaries();
+        graphsRef.current = list;
         setGraphs(list);
         setGraphListError(null);
         loadedGraphsRef.current = new Set(
@@ -768,6 +769,7 @@ function App() {
         } else {
           // Переключаемся на локальный граф при ошибке загрузки списка
           const fallbackGraphs = [LOCAL_GRAPH_SUMMARY];
+          graphsRef.current = fallbackGraphs;
           setGraphs(fallbackGraphs);
           loadedGraphsRef.current = new Set([LOCAL_GRAPH_ID]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -683,9 +683,9 @@ function App() {
   const refreshGraphs = useCallback(
     async (
       preferredGraphId?: string | null,
-      options: { preserveSelection?: boolean } = {}
+      options: { preserveSelection?: boolean; preferDefault?: boolean } = {}
     ) => {
-      const { preserveSelection = true } = options;
+      const { preserveSelection = true, preferDefault = false } = options;
       setIsGraphsLoading(true);
       try {
         const list = await fetchGraphSummaries();
@@ -705,14 +705,21 @@ function App() {
           if (preserveSelection && currentActiveId && list.some((graph) => graph.id === currentActiveId)) {
             return currentActiveId;
           }
-          // 3. Пытаемся восстановить из localStorage (только если не preserveSelection)
-          if (!preserveSelection && typeof window !== 'undefined') {
+          // 3. Если нужно принудительно выбрать основной граф, делаем это до восстановления из localStorage
+          if (preferDefault) {
+            const defaultGraph = list.find((graph) => graph.isDefault);
+            if (defaultGraph) {
+              return defaultGraph.id;
+            }
+          }
+          // 4. Пытаемся восстановить из localStorage (только если не preserveSelection и не запрошен основной граф)
+          if (!preserveSelection && !preferDefault && typeof window !== 'undefined') {
             const savedGraphId = localStorage.getItem(STORAGE_KEY_ACTIVE_GRAPH_ID);
             if (savedGraphId && list.some((graph) => graph.id === savedGraphId)) {
               return savedGraphId;
             }
           }
-          // 4. По умолчанию выбираем основной граф (isDefault), если его нет - первый в списке
+          // 5. По умолчанию выбираем основной граф (isDefault), если его нет - первый в списке
           // Это гарантирует, что при первом заходе всегда будет выбран граф
           const defaultGraph = list.find((graph) => graph.isDefault);
           if (defaultGraph) {
@@ -788,11 +795,8 @@ function App() {
   );
 
   useEffect(() => {
-    // Восстанавливаем сохраненный граф из localStorage при первой загрузке
-    const savedGraphId = typeof window !== 'undefined' 
-      ? localStorage.getItem(STORAGE_KEY_ACTIVE_GRAPH_ID) 
-      : null;
-    void refreshGraphs(savedGraphId ?? null, { preserveSelection: false });
+    // При первой загрузке и обновлении страницы автоматически выбираем основной граф
+    void refreshGraphs(null, { preserveSelection: false, preferDefault: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## Summary
- add a refreshGraphs option to explicitly prioritize the default graph
- automatically select the default graph on initial load or page refresh

## Testing
- not run (vitest install prompt in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692118cf486083329c38405d46f9438a)