### PR TITLE
Adjust modal positioning relative to sidebar

### DIFF
--- a/src/components/InitiativeCreationModal.module.css
+++ b/src/components/InitiativeCreationModal.module.css
@@ -1,7 +1,7 @@
 .modal {
-  width: calc(100vw - 32px);
+  width: calc(100vw - var(--layout-sidebar-offset, 0px) - 32px);
   max-width: none;
-  margin: 16px auto;
+  margin: 16px 16px 16px calc(var(--layout-sidebar-offset, 0px) + 16px);
 }
 
 .container {

--- a/src/components/LayoutShell.tsx
+++ b/src/components/LayoutShell.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useRef } from 'react';
+import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { Text } from '@consta/uikit/Text';
 import { Button } from '@consta/uikit/Button';
 import { Select } from '@consta/uikit/Select';
@@ -52,6 +52,10 @@ const MENU_ITEMS: Array<{
   { id: 'admin', label: 'Администрирование', icon: IconSettings },
 ];
 
+const SIDEBAR_WIDTH = 280;
+const SIDEBAR_WIDTH_COLLAPSED = 80;
+const MOBILE_BREAKPOINT = 768;
+
 export const LayoutShell: React.FC<LayoutShellProps> = ({
   currentView,
   onViewChange,
@@ -73,6 +77,23 @@ export const LayoutShell: React.FC<LayoutShellProps> = ({
   const [isCollapsed, setIsCollapsed] = useState(false);
   const graphDropdownRef = useRef<HTMLDivElement | null>(null);
   const [selectedGraphId, setSelectedGraphId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const updateSidebarOffset = () => {
+      const isMobile = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT}px)`).matches;
+      const width = isMobile ? 0 : isCollapsed ? SIDEBAR_WIDTH_COLLAPSED : SIDEBAR_WIDTH;
+      document.documentElement.style.setProperty('--layout-sidebar-offset', `${width}px`);
+    };
+
+    updateSidebarOffset();
+
+    const mediaQuery = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT}px)`);
+    mediaQuery.addEventListener('change', updateSidebarOffset);
+
+    return () => {
+      mediaQuery.removeEventListener('change', updateSidebarOffset);
+    };
+  }, [isCollapsed]);
 
   const handleViewChange = (view: ViewMode) => {
     onViewChange(view);


### PR DESCRIPTION
## Summary
- add a sidebar offset CSS variable that tracks the current navigation width
- update the initiative modal layout to start after the navigation sidebar with consistent margins

## Testing
- npm run lint (fails: existing lint errors unrelated to this change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69211bc3ba688332b7a33e980b6e6769)