### PR TITLE
Prevent graph recentering on selection

### DIFF
--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -678,14 +678,10 @@ const GraphView: React.FC<GraphViewProps> = ({
       return;
     }
 
-    const margin = 48;
-    const needsPan =
-      screenCoords.x < margin ||
-      screenCoords.x > width - margin ||
-      screenCoords.y < margin ||
-      screenCoords.y > height - margin;
+    const isOutsideViewport =
+      screenCoords.x < 0 || screenCoords.x > width || screenCoords.y < 0 || screenCoords.y > height;
 
-    if (needsPan) {
+    if (isOutsideViewport) {
       graph.centerAt(target.x, target.y, 400);
       const zoomValue =
         typeof graph.zoom === 'function' ? (graph.zoom() as number) : cameraStateRef.current?.zoom ?? 1;

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -673,13 +673,19 @@ const GraphView: React.FC<GraphViewProps> = ({
     }
 
     const graph = graphRef.current;
-    const screenCoords = graph.graph2ScreenCoords?.(target.x, target.y);
-    if (!screenCoords) {
+    const topLeft = graph.screen2GraphCoords?.(0, 0);
+    const bottomRight = graph.screen2GraphCoords?.(width, height);
+    if (!topLeft || !bottomRight) {
       return;
     }
 
+    const minX = Math.min(topLeft.x, bottomRight.x);
+    const maxX = Math.max(topLeft.x, bottomRight.x);
+    const minY = Math.min(topLeft.y, bottomRight.y);
+    const maxY = Math.max(topLeft.y, bottomRight.y);
+
     const isOutsideViewport =
-      screenCoords.x < 0 || screenCoords.x > width || screenCoords.y < 0 || screenCoords.y > height;
+      target.x < minX || target.x > maxX || target.y < minY || target.y > maxY;
 
     if (isOutsideViewport) {
       graph.centerAt(target.x, target.y, 400);


### PR DESCRIPTION
## Summary
- stop the graph view from panning when selecting nodes that are already visible
- only recenter when a highlighted node is outside the viewport

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69211ef2e1988332b3bd8bb9cfa5ae15)