### PR TITLE
Add close buttons to modals

### DIFF
--- a/src/components/AdminPanel.module.css
+++ b/src/components/AdminPanel.module.css
@@ -240,6 +240,10 @@
   max-width: 640px;
 }
 
+.modalCloseButton {
+  align-self: flex-start;
+}
+
 .importSummary {
   display: grid;
   gap: 8px;

--- a/src/components/AdminPanel.module.css
+++ b/src/components/AdminPanel.module.css
@@ -241,7 +241,7 @@
 }
 
 .modalCloseButton {
-  align-self: flex-start;
+  align-self: flex-end;
 }
 
 .importSummary {

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -7,6 +7,7 @@ import { Switch } from '@consta/uikit/Switch';
 import { Tabs } from '@consta/uikit/Tabs';
 import { Text } from '@consta/uikit/Text';
 import { TextField } from '@consta/uikit/TextField';
+import { IconClose } from '@consta/icons/IconClose';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   type ArtifactNode,
@@ -4302,6 +4303,15 @@ const ExpertForm: React.FC<ExpertFormProps> = ({
       <Modal isOpen={isImportModalOpen && Boolean(importState)} hasOverlay onClose={handleImportClose}>
         {importState && (
           <div className={styles.importModal}>
+            <Button
+              size="s"
+              view="clear"
+              iconLeft={IconClose}
+              onlyIcon
+              label="Закрыть"
+              onClick={handleImportClose}
+              className={styles.modalCloseButton}
+            />
             <Text size="l" weight="semibold">
               Импорт профиля сотрудника
             </Text>

--- a/src/components/CreateGraphModal.tsx
+++ b/src/components/CreateGraphModal.tsx
@@ -70,7 +70,7 @@ export const CreateGraphModal: React.FC<CreateGraphModalProps> = ({
           onlyIcon
           label="Закрыть"
           onClick={onClose}
-          style={{ alignSelf: 'flex-start' }}
+          style={{ alignSelf: 'flex-end' }}
         />
         <Text size="l" weight="bold">
           Создание нового графа

--- a/src/components/CreateGraphModal.tsx
+++ b/src/components/CreateGraphModal.tsx
@@ -6,7 +6,7 @@ import { TextField } from '@consta/uikit/TextField';
 import { Select } from '@consta/uikit/Select';
 import { CheckboxGroup } from '@consta/uikit/CheckboxGroup';
 import { Badge } from '@consta/uikit/Badge';
-import { Layout } from '@consta/uikit/Layout';
+import { IconClose } from '@consta/icons/IconClose';
 
 // Define types locally or import if they are shared (assuming they were local in App.tsx or simple enough)
 type GraphCopyOption = 'domains' | 'modules' | 'artifacts' | 'experts' | 'initiatives';
@@ -52,7 +52,26 @@ export const CreateGraphModal: React.FC<CreateGraphModalProps> = ({
 }) => {
   return (
     <Modal isOpen={isOpen} hasOverlay onClickOutside={onClose} onEsc={onClose} title="Создание графа">
-      <div style={{ width: '100%', maxWidth: 500, padding: 24, display: 'flex', flexDirection: 'column', gap: 24, boxSizing: 'border-box' }}>
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 500,
+          padding: 24,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 24,
+          boxSizing: 'border-box'
+        }}
+      >
+        <Button
+          size="s"
+          view="clear"
+          iconLeft={IconClose}
+          onlyIcon
+          label="Закрыть"
+          onClick={onClose}
+          style={{ alignSelf: 'flex-start' }}
+        />
         <Text size="l" weight="bold">
           Создание нового графа
         </Text>

--- a/src/components/InitiativeCreationModal.module.css
+++ b/src/components/InitiativeCreationModal.module.css
@@ -47,11 +47,13 @@
 .headerMain {
   display: flex;
   align-items: flex-start;
-  gap: 12px;
+  gap: 16px;
+  flex-wrap: wrap;
+  flex: 1 1 auto;
 }
 
 .closeButton {
-  margin-top: -4px;
+  align-self: flex-start;
 }
 
 .stepInfo {

--- a/src/components/InitiativeCreationModal.module.css
+++ b/src/components/InitiativeCreationModal.module.css
@@ -44,6 +44,16 @@
   align-items: flex-start;
 }
 
+.headerMain {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.closeButton {
+  margin-top: -4px;
+}
+
 .stepInfo {
   display: flex;
   flex-direction: column;

--- a/src/components/InitiativeCreationModal.tsx
+++ b/src/components/InitiativeCreationModal.tsx
@@ -6,6 +6,7 @@ import { Modal } from '@consta/uikit/Modal';
 import { Select } from '@consta/uikit/Select';
 import { Text } from '@consta/uikit/Text';
 import { TextField } from '@consta/uikit/TextField';
+import { IconClose } from '@consta/icons/IconClose';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type {
   DomainNode,
@@ -1678,16 +1679,27 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
       >
         <div className={styles.container}>
           <header className={styles.header}>
-            <div className={styles.stepInfo}>
-              <Text size="l" weight="bold">
-                {modalTitle}
-              </Text>
-              <Text size="xs" view="secondary">
-                Шаг {currentStepIndex} из {totalSteps} · {currentStepTitle}
-              </Text>
-              <Text size="s" view="secondary">
-                {currentStepDescription}
-              </Text>
+            <div className={styles.headerMain}>
+              <Button
+                size="s"
+                view="clear"
+                iconLeft={IconClose}
+                onlyIcon
+                label="Закрыть"
+                onClick={onClose}
+                className={styles.closeButton}
+              />
+              <div className={styles.stepInfo}>
+                <Text size="l" weight="bold">
+                  {modalTitle}
+                </Text>
+                <Text size="xs" view="secondary">
+                  Шаг {currentStepIndex} из {totalSteps} · {currentStepTitle}
+                </Text>
+                <Text size="s" view="secondary">
+                  {currentStepDescription}
+                </Text>
+              </div>
             </div>
             <Select<SelectOption<InitiativeStatus>>
               size="s"

--- a/src/components/InitiativeCreationModal.tsx
+++ b/src/components/InitiativeCreationModal.tsx
@@ -1680,15 +1680,6 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
         <div className={styles.container}>
           <header className={styles.header}>
             <div className={styles.headerMain}>
-              <Button
-                size="s"
-                view="clear"
-                iconLeft={IconClose}
-                onlyIcon
-                label="Закрыть"
-                onClick={onClose}
-                className={styles.closeButton}
-              />
               <div className={styles.stepInfo}>
                 <Text size="l" weight="bold">
                   {modalTitle}
@@ -1700,14 +1691,23 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
                   {currentStepDescription}
                 </Text>
               </div>
+              <Select<SelectOption<InitiativeStatus>>
+                size="s"
+                items={statusOptions}
+                value={statusOptions.find((option) => option.value === status) ?? statusOptions[0]}
+                getItemLabel={(item) => item.label}
+                getItemKey={(item) => item.value}
+                onChange={(option) => option && setStatus(option.value)}
+              />
             </div>
-            <Select<SelectOption<InitiativeStatus>>
+            <Button
               size="s"
-              items={statusOptions}
-              value={statusOptions.find((option) => option.value === status) ?? statusOptions[0]}
-              getItemLabel={(item) => item.label}
-              getItemKey={(item) => item.value}
-              onChange={(option) => option && setStatus(option.value)}
+              view="clear"
+              iconLeft={IconClose}
+              onlyIcon
+              label="Закрыть"
+              onClick={onClose}
+              className={styles.closeButton}
             />
           </header>
           {errorMessage && (

--- a/src/components/SkillEditorModal.module.css
+++ b/src/components/SkillEditorModal.module.css
@@ -6,6 +6,10 @@
   max-height: min(80vh, 720px);
 }
 
+.closeButton {
+  align-self: flex-start;
+}
+
 .header {
   display: flex;
   flex-direction: column;

--- a/src/components/SkillEditorModal.module.css
+++ b/src/components/SkillEditorModal.module.css
@@ -7,7 +7,7 @@
 }
 
 .closeButton {
-  align-self: flex-start;
+  align-self: flex-end;
 }
 
 .header {

--- a/src/components/SkillEditorModal.tsx
+++ b/src/components/SkillEditorModal.tsx
@@ -3,6 +3,7 @@ import { Modal } from '@consta/uikit/Modal';
 import { Select } from '@consta/uikit/Select';
 import { Text } from '@consta/uikit/Text';
 import { TextField } from '@consta/uikit/TextField';
+import { IconClose } from '@consta/icons/IconClose';
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   type ExpertProfile,
@@ -302,6 +303,15 @@ const SkillEditorModal: React.FC<SkillEditorModalProps> = ({
   return (
     <Modal isOpen={isOpen} hasOverlay onClickOutside={onClose} onEsc={onClose}>
       <div className={styles.root}>
+        <Button
+          size="s"
+          view="clear"
+          iconLeft={IconClose}
+          onlyIcon
+          label="Закрыть"
+          onClick={onClose}
+          className={styles.closeButton}
+        />
         <div className={styles.header}>
           <Text size="l" weight="bold">
             Навыки эксперта

--- a/src/components/SoftSkillEditorModal.module.css
+++ b/src/components/SoftSkillEditorModal.module.css
@@ -6,6 +6,10 @@
   max-height: min(75vh, 640px);
 }
 
+.closeButton {
+  align-self: flex-start;
+}
+
 .header {
   display: flex;
   flex-direction: column;

--- a/src/components/SoftSkillEditorModal.module.css
+++ b/src/components/SoftSkillEditorModal.module.css
@@ -7,7 +7,7 @@
 }
 
 .closeButton {
-  align-self: flex-start;
+  align-self: flex-end;
 }
 
 .header {

--- a/src/components/SoftSkillEditorModal.tsx
+++ b/src/components/SoftSkillEditorModal.tsx
@@ -2,6 +2,7 @@ import { Button } from '@consta/uikit/Button';
 import { Modal } from '@consta/uikit/Modal';
 import { Text } from '@consta/uikit/Text';
 import { TextField } from '@consta/uikit/TextField';
+import { IconClose } from '@consta/icons/IconClose';
 import React, { useEffect, useMemo, useState } from 'react';
 import type { ExpertProfile } from '../data';
 import styles from './SoftSkillEditorModal.module.css';
@@ -136,6 +137,15 @@ const SoftSkillEditorModal: React.FC<SoftSkillEditorModalProps> = ({
   return (
     <Modal isOpen={isOpen} hasOverlay onClickOutside={onClose} onEsc={onClose}>
       <div className={styles.root}>
+        <Button
+          size="s"
+          view="clear"
+          iconLeft={IconClose}
+          onlyIcon
+          label="Закрыть"
+          onClick={onClose}
+          className={styles.closeButton}
+        />
         <div className={styles.header}>
           <Text size="l" weight="bold">
             Soft skills


### PR DESCRIPTION
## Summary
- add close icon buttons to all modal dialogs so users can dismiss them from the top-left corner
- update modal layouts and styles to accommodate the new close controls

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692263b6bfa88332abc5117586468718)