### PR TITLE
Fix initiative risk tag text wrapping

### DIFF
--- a/src/components/InitiativePlanner.module.css
+++ b/src/components/InitiativePlanner.module.css
@@ -323,6 +323,12 @@
   max-width: 100%;
 }
 
+.riskTag :global(.Badge-Label) {
+  white-space: normal;
+  text-align: left;
+  line-height: 1.3;
+}
+
 .riskSection {
   position: sticky;
   top: 0;

--- a/src/components/InitiativePlanner.module.css
+++ b/src/components/InitiativePlanner.module.css
@@ -321,12 +321,20 @@
   word-break: break-word;
   text-align: left;
   max-width: 100%;
+  height: auto;
+  align-items: flex-start;
+  padding-top: 6px;
+  padding-bottom: 6px;
 }
 
 .riskTag :global(.Badge-Label) {
   white-space: normal;
   text-align: left;
   line-height: 1.3;
+}
+
+.riskTag :global(.Badge-Main) {
+  align-items: flex-start;
 }
 
 .riskSection {


### PR DESCRIPTION
## Summary
- allow initiative risk tag badges to wrap long text and stay within their borders

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69226645a1588332af7ac37ad20aff13)