### PR TITLE
Synchronize employee tasks across initiative and workload views

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,6 +83,9 @@ import {
   type RolePlanningDraft
 } from './utils/initiativeMatching';
 import { preparePlannerModuleSelections } from './utils/initiativePlanner';
+import { initialEmployeeTasks } from './data/employeeTasks';
+import type { TaskListItem } from './types/tasks';
+import { loadStoredTasks, persistStoredTasks } from './utils/employeeTasks';
 import { LayoutShell } from './components/LayoutShell';
 import { CreateGraphModal } from './components/CreateGraphModal';
 import GraphPersistenceControls from './components/GraphPersistenceControls';
@@ -158,11 +161,17 @@ function App() {
   const [artifactData, setArtifactData] = useState<ArtifactNode[]>(initialArtifacts);
   const [initiativeData, setInitiativeData] = useState<Initiative[]>(initialInitiatives);
   const [expertProfiles, setExpertProfiles] = useState(initialExperts);
+  const [employeeTasks, setEmployeeTasks] = useState<TaskListItem[]>(() =>
+    loadStoredTasks() ?? initialEmployeeTasks
+  );
   const domainDataRef = useRef(domainData);
   const moduleDataRef = useRef(moduleData);
   const artifactDataRef = useRef(artifactData);
   const initiativeDataRef = useRef(initiativeData);
   const expertProfilesRef = useRef(expertProfiles);
+  useEffect(() => {
+    persistStoredTasks(employeeTasks);
+  }, [employeeTasks]);
   const [selectedDomains, setSelectedDomains] = useState<Set<string>>(
     () => new Set(flattenDomainTree(initialDomainTree).map((domain) => domain.id))
   );
@@ -3632,6 +3641,7 @@ function App() {
           domains={domainData}
           modules={moduleData}
           domainNameMap={domainNameMap}
+          employeeTasks={employeeTasks}
           onTogglePin={handleToggleInitiativePin}
           onAddRisk={handleAddInitiativeRisk}
           onRemoveRisk={handleRemoveInitiativeRisk}
@@ -3647,7 +3657,12 @@ function App() {
         aria-hidden={!isEmployeeTasksActive}
         style={{ display: isEmployeeTasksActive ? undefined : 'none' }}
       >
-        <EmployeeWorkloadTrack experts={expertProfiles} initiatives={initiativeData} />
+        <EmployeeWorkloadTrack
+          experts={expertProfiles}
+          initiatives={initiativeData}
+          tasks={employeeTasks}
+          onTasksChange={setEmployeeTasks}
+        />
       </main>
       <main
         className={styles.creationMain}

--- a/src/components/EmployeeWorkloadTrack.tsx
+++ b/src/components/EmployeeWorkloadTrack.tsx
@@ -150,20 +150,6 @@ const defaultTaskDraft: TaskDraft = {
   relatedInitiativeId: defaultInitiativeOptions[0]?.value ?? null
 };
 
-const parseDateValue = (value: string): Date | null => {
-  if (!value) {
-    return null;
-  }
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? null : date;
-};
-
-const addDays = (date: Date, days: number): Date => {
-  const result = new Date(date);
-  result.setDate(result.getDate() + days);
-  return result;
-};
-
 const addMonths = (date: Date, months: number): Date => {
   const result = new Date(date);
   result.setMonth(result.getMonth() + months, 1);
@@ -174,12 +160,6 @@ const addMonths = (date: Date, months: number): Date => {
 const addYears = (date: Date, years: number): Date => {
   const result = new Date(date);
   result.setFullYear(result.getFullYear() + years, 0, 1);
-  result.setHours(0, 0, 0, 0);
-  return result;
-};
-
-const startOfDay = (date: Date): Date => {
-  const result = new Date(date);
   result.setHours(0, 0, 0, 0);
   return result;
 };

--- a/src/components/EmployeeWorkloadTrack.tsx
+++ b/src/components/EmployeeWorkloadTrack.tsx
@@ -9,6 +9,23 @@ import { Text } from '@consta/uikit/Text';
 import { TextField } from '@consta/uikit/TextField';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type { ExpertProfile, Initiative } from '../data';
+import {
+  type TaskDraft,
+  type TaskListItem,
+  type TaskPriority,
+  type TaskRelation,
+  type TaskRelationType,
+  type TaskScheduleType,
+  type TaskStatus
+} from '../types/tasks';
+import {
+  addDays,
+  formatIsoDate,
+  parseDateValue,
+  resolveTaskScheduleWindow,
+  startOfDay,
+  type TaskScheduleWindow
+} from '../utils/employeeTasks';
 import GanttTimeline, {
   type GanttTimelineTask,
   type GanttTimelineTaskKind,
@@ -45,53 +62,6 @@ type EmployeeWorkload = {
   availability: string;
   focus: string;
   tasks: WorkloadTask[];
-};
-
-type TaskPriority = 'low' | 'medium' | 'high';
-type TaskStatus = 'new' | 'in-progress' | 'paused' | 'rejected' | 'completed';
-
-type TaskScheduleType = 'due-date' | 'start-duration' | 'date-range' | 'after-task';
-
-type TaskSchedule =
-  | { type: 'due-date'; dueDate: string }
-  | { type: 'start-duration'; startDate: string; durationDays: number }
-  | { type: 'date-range'; startDate: string; endDate: string }
-  | { type: 'after-task'; predecessorId: string; durationDays: number };
-
-type TaskRelationType = 'system' | 'initiative' | 'external' | 'methodology';
-
-type TaskRelation =
-  | { type: 'system'; targetId: string | null }
-  | { type: 'initiative'; targetId: string | null }
-  | { type: 'external' }
-  | { type: 'methodology' };
-
-type TaskListItem = {
-  id: string;
-  name: string;
-  priority: TaskPriority;
-  status: TaskStatus;
-  assigneeId: string | null;
-  description: string;
-  schedule: TaskSchedule;
-  relation: TaskRelation;
-};
-
-type TaskDraft = {
-  name: string;
-  priority: TaskPriority;
-  status: TaskStatus;
-  assigneeId: string | null;
-  description: string;
-  scheduleType: TaskScheduleType;
-  dueDate: string;
-  startDate: string;
-  endDate: string;
-  durationDays: string;
-  predecessorId: string | null;
-  relationType: TaskRelationType;
-  relatedSystemId: string | null;
-  relatedInitiativeId: string | null;
 };
 
 type SelectOption<Value extends string> = {
@@ -143,10 +113,10 @@ const systemOptions: SelectOption<string>[] = [
 ];
 
 const defaultInitiativeOptions: SelectOption<string>[] = [
-  { label: 'Цифровизация добычи 2025', value: 'initiative-digital-2025' },
-  { label: 'Экосистема интеллектуальных скважин', value: 'initiative-smart-wells' },
-  { label: 'Программа беспилотного мониторинга', value: 'initiative-drone-monitoring' },
-  { label: 'Устойчивое бурение', value: 'initiative-sustainable-drilling' }
+  { label: 'Цифровая кустовая площадка', value: 'initiative-digital-pad' },
+  { label: 'Единый контур дистанционного управления', value: 'initiative-remote-operations' },
+  { label: 'Цифровой двойник удалённого промысла', value: 'initiative-dtwin-remote' },
+  { label: 'INFRAPLAN Economics M&A', value: 'initiative-infraplan-economics' }
 ];
 
 const relationTypeOptions: SelectOption<TaskRelationType>[] = [
@@ -161,284 +131,6 @@ const relationLabels: Record<TaskRelationType, string> = {
   initiative: 'К инициативе',
   external: 'Внешний запрос',
   methodology: 'Методологическая активность'
-};
-
-const initialTaskList: TaskListItem[] = [
-  {
-    id: 'team-task-1',
-    name: 'Скрининг участков',
-    priority: 'medium',
-    status: 'paused',
-    assigneeId: 'emp-1',
-    description:
-      'Провести аналитический скрининг участков и подготовить рекомендации для инвест-совета.',
-    schedule: { type: 'due-date', dueDate: '2024-03-11' },
-    relation: { type: 'system', targetId: 'system-production-control' }
-  },
-  {
-    id: 'team-task-2',
-    name: 'Первичный расчёт экономики',
-    priority: 'high',
-    status: 'in-progress',
-    assigneeId: 'emp-2',
-    description: 'Собрать исходные данные и подготовить первичный расчёт показателей экономики проекта.',
-    schedule: { type: 'start-duration', startDate: '2024-01-29', durationDays: 14 },
-    relation: { type: 'initiative', targetId: 'initiative-digital-2025' }
-  },
-  {
-    id: 'team-task-3',
-    name: 'Формирование паспорта инвест-проекта',
-    priority: 'medium',
-    status: 'new',
-    assigneeId: 'emp-3',
-    description:
-      'Согласовать исходные данные, актуализировать паспорт проекта и подтвердить ответственных исполнителей.',
-    schedule: { type: 'date-range', startDate: '2024-02-19', endDate: '2024-03-29' },
-    relation: { type: 'initiative', targetId: 'initiative-smart-wells' }
-  },
-  {
-    id: 'team-task-4',
-    name: 'Разбор запускных параметров тепловой схемы',
-    priority: 'low',
-    status: 'new',
-    assigneeId: null,
-    description: 'Подготовить рекомендации по корректировке запускных параметров и согласовать их с технологами.',
-    schedule: { type: 'due-date', dueDate: '2024-03-29' },
-    relation: { type: 'external' }
-  },
-  {
-    id: 'team-task-5',
-    name: 'Актуализация профилей добычи',
-    priority: 'low',
-    status: 'new',
-    assigneeId: 'emp-4',
-    description: 'Собрать данные по текущим профилям добычи и обновить отчётность для инвестиционного комитета.',
-    schedule: { type: 'start-duration', startDate: '2024-02-12', durationDays: 21 },
-    relation: { type: 'system', targetId: 'system-monitoring' }
-  },
-  {
-    id: 'team-task-6',
-    name: 'Расчёт кустов без учёта инфраструктуры',
-    priority: 'medium',
-    status: 'new',
-    assigneeId: null,
-    description: 'Подготовить сравнительный анализ кустовых расчётов без учёта инфраструктурных ограничений.',
-    schedule: { type: 'after-task', predecessorId: 'team-task-5', durationDays: 7 },
-    relation: { type: 'methodology' }
-  },
-  {
-    id: 'team-task-7',
-    name: 'Формирование сценариев отсечения КП',
-    priority: 'medium',
-    status: 'new',
-    assigneeId: null,
-    description: 'Разработать сценарии отсечения КП и согласовать с командой архитекторов.',
-    schedule: { type: 'date-range', startDate: '2024-03-04', endDate: '2024-03-22' },
-    relation: { type: 'system', targetId: 'system-digital-twin' }
-  },
-  {
-    id: 'team-task-8',
-    name: 'Расчёт экономики',
-    priority: 'high',
-    status: 'rejected',
-    assigneeId: 'emp-2',
-    description: 'Подготовить альтернативный расчёт экономики с учётом новых вводных от финансового блока.',
-    schedule: { type: 'due-date', dueDate: '2024-04-12' },
-    relation: { type: 'initiative', targetId: 'initiative-drone-monitoring' }
-  },
-  {
-    id: 'team-task-9',
-    name: 'План даты ввода',
-    priority: 'medium',
-    status: 'completed',
-    assigneeId: 'emp-1',
-    description: 'Согласовать график ввода объектов и передать его в проектный офис.',
-    schedule: { type: 'start-duration', startDate: '2024-01-15', durationDays: 45 },
-    relation: { type: 'system', targetId: 'system-analytics-lab' }
-  }
-];
-
-const TEAM_TASKS_STORAGE_KEY = 'employee-workload-track:team-tasks';
-
-const isRecord = (value: unknown): value is Record<string, unknown> => {
-  return Boolean(value) && typeof value === 'object';
-};
-
-const isStoredTaskSchedule = (value: unknown): value is TaskSchedule => {
-  if (!isRecord(value) || typeof value.type !== 'string') {
-    return false;
-  }
-
-  switch (value.type) {
-    case 'due-date':
-      return typeof value.dueDate === 'string';
-    case 'start-duration':
-      return typeof value.startDate === 'string' && typeof value.durationDays === 'number';
-    case 'date-range':
-      return typeof value.startDate === 'string' && typeof value.endDate === 'string';
-    case 'after-task':
-      return typeof value.predecessorId === 'string' && typeof value.durationDays === 'number';
-    default:
-      return false;
-  }
-};
-
-const isStoredTaskRelation = (value: unknown): value is TaskRelation => {
-  if (!isRecord(value) || typeof value.type !== 'string') {
-    return false;
-  }
-
-  switch (value.type) {
-    case 'system':
-    case 'initiative':
-      return value.targetId === null || typeof value.targetId === 'string';
-    case 'external':
-    case 'methodology':
-      return true;
-    default:
-      return false;
-  }
-};
-
-const isStoredTask = (value: unknown): value is TaskListItem => {
-  if (!isRecord(value)) {
-    return false;
-  }
-
-  const { id, name, priority, status, assigneeId, description, schedule, relation } = value;
-
-  if (typeof id !== 'string' || typeof name !== 'string' || typeof description !== 'string') {
-    return false;
-  }
-
-  if (assigneeId !== null && typeof assigneeId !== 'string') {
-    return false;
-  }
-
-  if (!['low', 'medium', 'high'].includes(priority as string)) {
-    return false;
-  }
-
-  if (!['new', 'in-progress', 'paused', 'rejected', 'completed'].includes(status as string)) {
-    return false;
-  }
-
-  if (!isStoredTaskSchedule(schedule)) {
-    return false;
-  }
-
-  if (!isStoredTaskRelation(relation)) {
-    return false;
-  }
-
-  return true;
-};
-
-const loadStoredTasks = (): TaskListItem[] | null => {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-
-  const rawValue = window.localStorage.getItem(TEAM_TASKS_STORAGE_KEY);
-  if (!rawValue) {
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(rawValue) as unknown;
-    if (!Array.isArray(parsed)) {
-      return null;
-    }
-
-    const normalized = parsed.filter(isStoredTask).map((task) => ({
-      ...task,
-      assigneeId: task.assigneeId ?? null,
-      schedule: { ...task.schedule },
-      relation: { ...task.relation }
-    }));
-
-    return normalized;
-  } catch {
-    return null;
-  }
-};
-
-const persistStoredTasks = (tasks: TaskListItem[]): void => {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  try {
-    window.localStorage.setItem(TEAM_TASKS_STORAGE_KEY, JSON.stringify(tasks));
-  } catch {
-    // ignore storage errors
-  }
-};
-
-type TaskScheduleWindow = { start: Date; end: Date };
-
-const formatIsoDate = (date: Date): string => {
-  const year = date.getFullYear();
-  const month = `${date.getMonth() + 1}`.padStart(2, '0');
-  const day = `${date.getDate()}`.padStart(2, '0');
-  return `${year}-${month}-${day}`;
-};
-
-const resolveTaskScheduleWindow = (
-  task: TaskListItem,
-  taskMap: Map<string, TaskListItem>,
-  stack: Set<string> = new Set()
-): TaskScheduleWindow | null => {
-  if (stack.has(task.id)) {
-    return null;
-  }
-
-  const nextStack = new Set(stack);
-  nextStack.add(task.id);
-
-  const { schedule } = task;
-
-  switch (schedule.type) {
-    case 'due-date': {
-      const dueDate = parseDateValue(schedule.dueDate);
-      if (!dueDate) {
-        return null;
-      }
-      const day = startOfDay(dueDate);
-      return { start: day, end: day };
-    }
-    case 'start-duration': {
-      const startDate = parseDateValue(schedule.startDate);
-      if (!startDate) {
-        return null;
-      }
-      const dueDate = addDays(startDate, schedule.durationDays);
-      return { start: startOfDay(startDate), end: startOfDay(dueDate) };
-    }
-    case 'date-range': {
-      const startDate = parseDateValue(schedule.startDate);
-      const endDate = parseDateValue(schedule.endDate);
-      if (!startDate || !endDate || endDate.getTime() < startDate.getTime()) {
-        return null;
-      }
-      return { start: startOfDay(startDate), end: startOfDay(endDate) };
-    }
-    case 'after-task': {
-      const predecessor = schedule.predecessorId ? taskMap.get(schedule.predecessorId) : undefined;
-      if (!predecessor) {
-        return null;
-      }
-      const predecessorWindow = resolveTaskScheduleWindow(predecessor, taskMap, nextStack);
-      if (!predecessorWindow) {
-        return null;
-      }
-      const startDate = addDays(predecessorWindow.end, 1);
-      const dueDate = addDays(predecessorWindow.end, schedule.durationDays);
-      return { start: startOfDay(startDate), end: startOfDay(dueDate) };
-    }
-    default:
-      return null;
-  }
 };
 
 const defaultTaskDraft: TaskDraft = {
@@ -922,11 +614,15 @@ type TimelineMode = (typeof timelineModeTabs)[number];
 type EmployeeWorkloadTrackProps = {
   experts: ExpertProfile[];
   initiatives: Initiative[];
+  tasks: TaskListItem[];
+  onTasksChange: (tasks: TaskListItem[]) => void;
 };
 
 const EmployeeWorkloadTrack: React.FC<EmployeeWorkloadTrackProps> = ({
   experts,
-  initiatives
+  initiatives,
+  tasks,
+  onTasksChange
 }) => {
   const initiativeOptions = useMemo<SelectOption<string>[]>(() => {
     const base = initiatives.map<SelectOption<string>>((initiative) => ({
@@ -968,12 +664,15 @@ const EmployeeWorkloadTrack: React.FC<EmployeeWorkloadTrackProps> = ({
   }, [dynamicEmployees]);
   const [scale, setScale] = useState<TimelineScaleTab>(timelineScaleTabs[1]);
   const [timelineMode, setTimelineMode] = useState<TimelineMode>(timelineModeTabs[0]);
-  const initialStoredTasks = useMemo(() => loadStoredTasks() ?? initialTaskList, []);
-
-  const [tasks, setTasks] = useState<TaskListItem[]>(initialStoredTasks);
-  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(
-    initialStoredTasks[0]?.id ?? null
+  const applyTasksChange = useCallback(
+    (updater: TaskListItem[] | ((prev: TaskListItem[]) => TaskListItem[])) => {
+      const next = typeof updater === 'function' ? updater(tasks) : updater;
+      onTasksChange(next);
+    },
+    [onTasksChange, tasks]
   );
+
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(tasks[0]?.id ?? null);
   const [activeView, setActiveView] = useState<ViewTab>(viewTabs[0]);
   const [taskDraft, setTaskDraft] = useState<TaskDraft>((): TaskDraft => ({
     ...defaultTaskDraft,
@@ -983,7 +682,7 @@ const EmployeeWorkloadTrack: React.FC<EmployeeWorkloadTrackProps> = ({
   const [formError, setFormError] = useState<string | null>(null);
 
   useEffect(() => {
-    setTasks((prev) => {
+    applyTasksChange((prev) => {
       const availableEmployeeIds = new Set(employees.map((employee) => employee.id));
       let changed = false;
 
@@ -997,7 +696,7 @@ const EmployeeWorkloadTrack: React.FC<EmployeeWorkloadTrackProps> = ({
 
       return changed ? normalized : prev;
     });
-  }, [employees]);
+  }, [applyTasksChange, employees]);
 
   const taskMap = useMemo(() => {
     const map = new Map<string, TaskListItem>();
@@ -1017,10 +716,6 @@ const EmployeeWorkloadTrack: React.FC<EmployeeWorkloadTrackProps> = ({
     });
     return windows;
   }, [taskMap, tasks]);
-
-  useEffect(() => {
-    persistStoredTasks(tasks);
-  }, [tasks]);
 
   useEffect(() => {
     if (tasks.length === 0) {
@@ -1067,6 +762,41 @@ const EmployeeWorkloadTrack: React.FC<EmployeeWorkloadTrackProps> = ({
 
     return map;
   }, [tasks, teamTaskWindows]);
+
+  const initiativeTimelineTasksByEmployee = useMemo(() => {
+    const map = new Map<string, WorkloadTask[]>();
+
+    initiatives.forEach((initiative) => {
+      const baseStart = initiative.startDate ? startOfDay(new Date(initiative.startDate)) : TIMELINE_PERIOD_START;
+      initiative.roles.forEach((role) => {
+        (role.workItems ?? []).forEach((item) => {
+          if (!item.assignedExpertId) {
+            return;
+          }
+          const startDate = addDays(baseStart, item.startDay);
+          const endDate = addDays(startDate, Math.max(item.durationDays - 1, 0));
+          const entry = map.get(item.assignedExpertId) ?? [];
+          entry.push({
+            id: `${initiative.id}-${item.id}`,
+            name: item.title,
+            start: formatIsoDate(startDate),
+            end: formatIsoDate(endDate),
+            initiativeId: initiative.id,
+            kind: 'project',
+            badge: initiative.name,
+            description: item.description
+          });
+          map.set(item.assignedExpertId, entry);
+        });
+      });
+    });
+
+    map.forEach((list) => {
+      list.sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
+    });
+
+    return map;
+  }, [initiatives]);
 
   const baseStart = TIMELINE_PERIOD_START;
 
@@ -1288,11 +1018,12 @@ const EmployeeWorkloadTrack: React.FC<EmployeeWorkloadTrackProps> = ({
       }));
 
       const teamTasks = teamTimelineTasksByEmployee.get(employee.id) ?? [];
+      const initiativeTasks = initiativeTimelineTasksByEmployee.get(employee.id) ?? [];
 
       const mergedTasks =
         timelineMode.value === 'initiatives'
-          ? mergeInitiativeTasks([...baseTasks, ...teamTasks])
-          : [...baseTasks, ...teamTasks].sort(
+          ? mergeInitiativeTasks([...baseTasks, ...teamTasks, ...initiativeTasks])
+          : [...baseTasks, ...teamTasks, ...initiativeTasks].sort(
               (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()
             );
 
@@ -1343,7 +1074,13 @@ const EmployeeWorkloadTrack: React.FC<EmployeeWorkloadTrackProps> = ({
     });
 
     return { timelineRows: rows, timelineTaskLookup: taskLookup };
-  }, [employees, mergeInitiativeTasks, teamTimelineTasksByEmployee, timelineMode.value]);
+  }, [
+    employees,
+    initiativeTimelineTasksByEmployee,
+    mergeInitiativeTasks,
+    teamTimelineTasksByEmployee,
+    timelineMode.value
+  ]);
 
   const timelineTaskLookup = timelineData.timelineTaskLookup;
   const timelineRows = timelineData.timelineRows;
@@ -1480,7 +1217,7 @@ const EmployeeWorkloadTrack: React.FC<EmployeeWorkloadTrackProps> = ({
   );
 
   const handleAssignTask = useCallback((taskId: string, assigneeId: string | null) => {
-    setTasks((prev) =>
+    applyTasksChange((prev) =>
       prev.map((task) =>
         task.id === taskId
           ? {
@@ -1490,7 +1227,7 @@ const EmployeeWorkloadTrack: React.FC<EmployeeWorkloadTrackProps> = ({
           : task
       )
     );
-  }, []);
+  }, [applyTasksChange]);
 
   const handleSubmitTask = useCallback(() => {
     const trimmedName = taskDraft.name.trim();
@@ -1551,7 +1288,7 @@ const EmployeeWorkloadTrack: React.FC<EmployeeWorkloadTrackProps> = ({
       relation
     };
 
-    setTasks((prev) =>
+    applyTasksChange((prev) =>
       editingTaskId
         ? prev.map((task) => (task.id === editingTaskId ? nextTask : task))
         : [nextTask, ...prev]
@@ -1563,7 +1300,7 @@ const EmployeeWorkloadTrack: React.FC<EmployeeWorkloadTrackProps> = ({
     setEditingTaskId(null);
     setFormError(null);
     setSelectedTaskId(taskId);
-  }, [editingTaskId, initiativeOptions, taskDraft]);
+  }, [applyTasksChange, editingTaskId, initiativeOptions, taskDraft]);
 
   const handleEditTask = useCallback(
     (task: TaskListItem) => {

--- a/src/components/InitiativePlanner.tsx
+++ b/src/components/InitiativePlanner.tsx
@@ -3,6 +3,7 @@ import { Button } from '@consta/uikit/Button';
 import { Card } from '@consta/uikit/Card';
 import { Select } from '@consta/uikit/Select';
 import { Steps } from '@consta/uikit/Steps';
+import { Tabs } from '@consta/uikit/Tabs';
 import { Text } from '@consta/uikit/Text';
 import clsx from 'clsx';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -14,6 +15,7 @@ import type {
   InitiativeStatus,
   ModuleNode
 } from '../data';
+import type { TaskListItem } from '../types/tasks';
 import InitiativeCreationModal from './InitiativeCreationModal';
 import InitiativeGanttChart, {
   type InitiativeGanttBlocker,
@@ -25,6 +27,7 @@ import type { InitiativeCreationRequest } from '../types/initiativeCreation';
 import { buildCreationRequestFromInitiative } from '../utils/initiativePlanner';
 import styles from './InitiativePlanner.module.css';
 import { getSkillNameById } from '../data/skills';
+import { resolveTaskScheduleWindow, startOfDay } from '../utils/employeeTasks';
 
 type SelectItem<Value extends string> = {
   label: string;
@@ -37,6 +40,7 @@ type InitiativePlannerProps = {
   domains: DomainNode[];
   modules: ModuleNode[];
   domainNameMap: Record<string, string>;
+  employeeTasks: TaskListItem[];
   onTogglePin: (initiativeId: string, roleId: string, expertId: string) => void;
   onAddRisk: (
     initiativeId: string,
@@ -96,12 +100,22 @@ const severityBadgeMeta: Record<InitiativeRisk['severity'], { label: string; sta
   high: { label: 'Высокий', status: 'error' }
 };
 
+type TimelineSource = 'initiative' | 'employee';
+
+const timelineSourceTabs: Array<{ label: string; value: TimelineSource }> = [
+  { label: 'Инициативы', value: 'initiative' },
+  { label: 'Задачи сотрудников', value: 'employee' }
+];
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
 const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
   initiatives,
   experts,
   domains,
   modules,
   domainNameMap,
+  employeeTasks,
   onTogglePin,
   onAddRisk,
   onRemoveRisk,
@@ -121,6 +135,7 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
   const [modalInitialDraft, setModalInitialDraft] = useState<InitiativeCreationRequest | null>(null);
   const [isModalSubmitting, setIsModalSubmitting] = useState(false);
   const [modalError, setModalError] = useState<string | null>(null);
+  const [timelineSource, setTimelineSource] = useState<TimelineSource>('initiative');
   const lastInitiativeIdRef = useRef<string | null>(null);
   const lastRoleIdsRef = useRef<Set<string>>(new Set());
 
@@ -188,6 +203,85 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
     });
     return map;
   }, [experts]);
+
+  const timelineBaseStart = useMemo(() => {
+    if (selectedInitiative?.startDate) {
+      return startOfDay(new Date(selectedInitiative.startDate));
+    }
+    return startOfDay(new Date());
+  }, [selectedInitiative]);
+
+  const employeeTaskMap = useMemo(
+    () => new Map(employeeTasks.map((task) => [task.id, task])),
+    [employeeTasks]
+  );
+
+  const employeeTimelineTasks = useMemo<InitiativeGanttTask[]>(() => {
+    if (!selectedInitiative) {
+      return [];
+    }
+
+    return employeeTasks
+      .filter(
+        (task) =>
+          task.assigneeId &&
+          task.relation.type === 'initiative' &&
+          task.relation.targetId === selectedInitiative.id
+      )
+      .map((task) => {
+        const window = resolveTaskScheduleWindow(task, employeeTaskMap);
+        if (!window) {
+          return null;
+        }
+        const startDay = Math.max(
+          0,
+          Math.round((window.start.getTime() - timelineBaseStart.getTime()) / DAY_MS)
+        );
+        const durationDays = Math.max(
+          1,
+          Math.round((window.end.getTime() - window.start.getTime()) / DAY_MS) + 1
+        );
+        const expert = task.assigneeId ? expertMap.get(task.assigneeId) : undefined;
+        const assigneeName = expert?.fullName ?? task.assigneeId ?? 'Исполнитель не выбран';
+
+        return {
+          id: `employee-${task.id}`,
+          name: task.name,
+          role: expert?.title ?? 'Участник инициативы',
+          projectId: selectedInitiative.id,
+          projectName: selectedInitiative.name,
+          workId: 'employee-task',
+          workName: 'Задачи сотрудников',
+          startDay,
+          durationDays,
+          effortDays: durationDays,
+          effortHours: durationDays * 8,
+          minUnits: 1,
+          maxUnits: 1,
+          canSplit: false,
+          parallelAllowed: true,
+          durationMode: 'fixed-effort',
+          constraints: undefined,
+          priority: 1,
+          wipLimitTag: 'employee-tasks',
+          assignedExpert: assigneeName,
+          resources:
+            task.assigneeId && assigneeName
+              ? [
+                  {
+                    id: task.assigneeId,
+                    name: assigneeName,
+                    role: expert?.title ?? 'Эксперт',
+                    units: 1
+                  }
+                ]
+              : [],
+          blockers: [],
+          scenarioBranch: 'Задачи сотрудников'
+        } satisfies InitiativeGanttTask;
+      })
+      .filter((task): task is InitiativeGanttTask => Boolean(task));
+  }, [employeeTaskMap, employeeTasks, expertMap, selectedInitiative, timelineBaseStart]);
 
   const timelineTasks = useMemo<InitiativeGanttTask[]>(() => {
     if (!selectedInitiative) {
@@ -263,6 +357,11 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
       return workTasks;
     });
   }, [expertMap, selectedInitiative]);
+
+  const displayedTimelineTasks = useMemo(
+    () => (timelineSource === 'initiative' ? timelineTasks : employeeTimelineTasks),
+    [employeeTimelineTasks, timelineSource, timelineTasks]
+  );
 
   const handleOpenCreate = () => {
     setModalMode('create');
@@ -394,6 +493,13 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
       </section>
     );
   }
+
+  const activeTimelineTab =
+    timelineSourceTabs.find((tab) => tab.value === timelineSource) ?? timelineSourceTabs[0];
+  const timelineEmptyText =
+    timelineSource === 'employee'
+      ? 'Назначьте задачи сотрудникам во вкладке «Задачи» или выберите исполнителя.'
+      : 'Диаграмма появится после добавления работ по ролям.';
 
   const handleOpenEdit = () => {
     if (!selectedInitiative) {
@@ -664,14 +770,22 @@ const InitiativePlanner: React.FC<InitiativePlannerProps> = ({
                 План работ
               </Text>
               <Text size="xs" view="secondary">
-                {timelineTasks.length > 0
-                  ? `Задач в расписании: ${timelineTasks.length}`
-                  : 'Диаграмма появится после добавления работ по ролям.'}
+                {displayedTimelineTasks.length > 0
+                  ? `Задач в расписании: ${displayedTimelineTasks.length}`
+                  : timelineEmptyText}
               </Text>
             </div>
+            <Tabs
+              size="s"
+              items={timelineSourceTabs}
+              value={activeTimelineTab}
+              getItemKey={(item) => item.value}
+              getItemLabel={(item) => item.label}
+              onChange={(item) => item && setTimelineSource(item.value)}
+            />
             <div className={styles.timelineBody}>
               <InitiativeGanttChart
-                tasks={timelineTasks}
+                tasks={displayedTimelineTasks}
                 startDate={selectedInitiative.startDate}
               />
             </div>

--- a/src/data.ts
+++ b/src/data.ts
@@ -2606,6 +2606,28 @@ const initiativeExtras: Record<string, InitiativeExtra> = {
         role: 'Архитектор',
         required: 1,
         pinnedExpertIds: ['expert-raisa-chistyakova'],
+        workItems: [
+          {
+            id: 'dtwin-arch-pipeline',
+            title: 'Архитектура потоков телеметрии',
+            description: 'Схема доставки данных и требования к отказоустойчивости.',
+            startDay: 0,
+            durationDays: 18,
+            effortDays: 18,
+            tasks: ['streaming-pipelines'],
+            assignedExpertId: 'expert-raisa-chistyakova'
+          },
+          {
+            id: 'dtwin-arch-quality',
+            title: 'Контроль качества и каталогизация',
+            description: 'Метрики потерь данных и управление справочниками.',
+            startDay: 12,
+            durationDays: 12,
+            effortDays: 12,
+            tasks: ['data-governance'],
+            assignedExpertId: 'expert-viktoria-berezhnaya'
+          }
+        ],
         candidates: [
           {
             expertId: 'expert-raisa-chistyakova',
@@ -2648,6 +2670,28 @@ const initiativeExtras: Record<string, InitiativeExtra> = {
         role: 'Backend',
         required: 2,
         pinnedExpertIds: [],
+        workItems: [
+          {
+            id: 'dtwin-backend-stream',
+            title: 'Настройка пайплайнов',
+            description: 'Подготовка ETL и потоковой обработки для телеметрии.',
+            startDay: 5,
+            durationDays: 14,
+            effortDays: 14,
+            tasks: ['streaming-pipelines'],
+            assignedExpertId: 'expert-viktoria-berezhnaya'
+          },
+          {
+            id: 'dtwin-backend-api',
+            title: 'Интерфейсы SCADA',
+            description: 'Интеграция с диспетчерскими сервисами и тестирование API.',
+            startDay: 18,
+            durationDays: 10,
+            effortDays: 10,
+            tasks: ['Интеграция SCADA'],
+            assignedExpertId: 'expert-anton-vlasov'
+          }
+        ],
         candidates: [
           {
             expertId: 'expert-viktoria-berezhnaya',

--- a/src/data/employeeTasks.ts
+++ b/src/data/employeeTasks.ts
@@ -1,0 +1,59 @@
+import type { TaskListItem } from '../types/tasks';
+
+export const initialEmployeeTasks: TaskListItem[] = [
+  {
+    id: 'employee-task-digital-pad-data',
+    name: 'Подготовка исходных данных для цифровой площадки',
+    priority: 'medium',
+    status: 'in-progress',
+    assigneeId: 'expert-viktoria-berezhnaya',
+    description:
+      'Согласовать перечень источников, очистить справочники и выстроить поток данных в INFRAPLAN.',
+    schedule: { type: 'start-duration', startDate: '2024-12-02', durationDays: 14 },
+    relation: { type: 'initiative', targetId: 'initiative-digital-pad' }
+  },
+  {
+    id: 'employee-task-remote-ops-alerting',
+    name: 'Настройка алертов для дистанционного управления',
+    priority: 'medium',
+    status: 'new',
+    assigneeId: 'expert-anton-vlasov',
+    description:
+      'Определить критичные события, согласовать пороги с диспетчерами и подготовить план тестирования.',
+    schedule: { type: 'due-date', dueDate: '2025-01-15' },
+    relation: { type: 'initiative', targetId: 'initiative-remote-operations' }
+  },
+  {
+    id: 'employee-task-dtwin-pipeline',
+    name: 'Проектирование пайплайна телеметрии',
+    priority: 'high',
+    status: 'in-progress',
+    assigneeId: 'expert-raisa-chistyakova',
+    description:
+      'Подготовить отказоустойчивый маршрут доставки телеметрии, включить ретрай и контроль качества.',
+    schedule: { type: 'date-range', startDate: '2024-11-18', endDate: '2024-12-20' },
+    relation: { type: 'initiative', targetId: 'initiative-dtwin-remote' }
+  },
+  {
+    id: 'employee-task-economics-method',
+    name: 'Методология расчёта экономики',
+    priority: 'low',
+    status: 'paused',
+    assigneeId: 'expert-pavel-kolosov',
+    description:
+      'Согласовать допущения для оценки сделок M&A и подготовить шаблон отчёта.',
+    schedule: { type: 'start-duration', startDate: '2024-12-09', durationDays: 10 },
+    relation: { type: 'initiative', targetId: 'initiative-infraplan-economics' }
+  },
+  {
+    id: 'employee-task-dtwin-guides',
+    name: 'Документация сценариев реагирования',
+    priority: 'medium',
+    status: 'new',
+    assigneeId: null,
+    description:
+      'Описать порядок действий операторов при срабатывании моделей отклонений и согласовать с охраной труда.',
+    schedule: { type: 'due-date', dueDate: '2024-12-27' },
+    relation: { type: 'initiative', targetId: 'initiative-dtwin-remote' }
+  }
+];

--- a/src/types/tasks.ts
+++ b/src/types/tasks.ts
@@ -1,0 +1,46 @@
+export type TaskPriority = 'low' | 'medium' | 'high';
+export type TaskStatus = 'new' | 'in-progress' | 'paused' | 'rejected' | 'completed';
+
+export type TaskScheduleType = 'due-date' | 'start-duration' | 'date-range' | 'after-task';
+
+export type TaskSchedule =
+  | { type: 'due-date'; dueDate: string }
+  | { type: 'start-duration'; startDate: string; durationDays: number }
+  | { type: 'date-range'; startDate: string; endDate: string }
+  | { type: 'after-task'; predecessorId: string; durationDays: number };
+
+export type TaskRelationType = 'system' | 'initiative' | 'external' | 'methodology';
+
+export type TaskRelation =
+  | { type: 'system'; targetId: string | null }
+  | { type: 'initiative'; targetId: string | null }
+  | { type: 'external' }
+  | { type: 'methodology' };
+
+export type TaskListItem = {
+  id: string;
+  name: string;
+  priority: TaskPriority;
+  status: TaskStatus;
+  assigneeId: string | null;
+  description: string;
+  schedule: TaskSchedule;
+  relation: TaskRelation;
+};
+
+export type TaskDraft = {
+  name: string;
+  priority: TaskPriority;
+  status: TaskStatus;
+  assigneeId: string | null;
+  description: string;
+  scheduleType: TaskScheduleType;
+  dueDate: string;
+  startDate: string;
+  endDate: string;
+  durationDays: string;
+  predecessorId: string | null;
+  relationType: TaskRelationType;
+  relatedSystemId: string | null;
+  relatedInitiativeId: string | null;
+};

--- a/src/utils/employeeTasks.ts
+++ b/src/utils/employeeTasks.ts
@@ -1,0 +1,209 @@
+import type { TaskListItem, TaskRelation, TaskSchedule } from '../types/tasks';
+
+export const EMPLOYEE_TASKS_STORAGE_KEY = 'employee-workload-track:team-tasks';
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return Boolean(value) && typeof value === 'object';
+};
+
+const isStoredTaskSchedule = (value: unknown): value is TaskSchedule => {
+  if (!isRecord(value) || typeof value.type !== 'string') {
+    return false;
+  }
+
+  switch (value.type) {
+    case 'due-date':
+      return typeof value.dueDate === 'string';
+    case 'start-duration':
+      return typeof value.startDate === 'string' && typeof value.durationDays === 'number';
+    case 'date-range':
+      return typeof value.startDate === 'string' && typeof value.endDate === 'string';
+    case 'after-task':
+      return typeof value.predecessorId === 'string' && typeof value.durationDays === 'number';
+    default:
+      return false;
+  }
+};
+
+const isStoredTaskRelation = (value: unknown): value is TaskRelation => {
+  if (!isRecord(value) || typeof value.type !== 'string') {
+    return false;
+  }
+
+  switch (value.type) {
+    case 'system':
+    case 'initiative':
+      return value.targetId === null || typeof value.targetId === 'string';
+    case 'external':
+    case 'methodology':
+      return true;
+    default:
+      return false;
+  }
+};
+
+const isStoredTask = (value: unknown): value is TaskListItem => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const { id, name, priority, status, assigneeId, description, schedule, relation } = value;
+
+  if (typeof id !== 'string' || typeof name !== 'string' || typeof description !== 'string') {
+    return false;
+  }
+
+  if (assigneeId !== null && typeof assigneeId !== 'string') {
+    return false;
+  }
+
+  if (!['low', 'medium', 'high'].includes(priority as string)) {
+    return false;
+  }
+
+  if (!['new', 'in-progress', 'paused', 'rejected', 'completed'].includes(status as string)) {
+    return false;
+  }
+
+  if (!isStoredTaskSchedule(schedule)) {
+    return false;
+  }
+
+  if (!isStoredTaskRelation(relation)) {
+    return false;
+  }
+
+  return true;
+};
+
+export const loadStoredTasks = (
+  storageKey: string = EMPLOYEE_TASKS_STORAGE_KEY
+): TaskListItem[] | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const rawValue = window.localStorage.getItem(storageKey);
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue) as unknown;
+    if (!Array.isArray(parsed)) {
+      return null;
+    }
+
+    const normalized = parsed.filter(isStoredTask).map((task) => ({
+      ...task,
+      assigneeId: task.assigneeId ?? null,
+      schedule: { ...task.schedule },
+      relation: { ...task.relation }
+    }));
+
+    return normalized;
+  } catch {
+    return null;
+  }
+};
+
+export const persistStoredTasks = (
+  tasks: TaskListItem[],
+  storageKey: string = EMPLOYEE_TASKS_STORAGE_KEY
+): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(storageKey, JSON.stringify(tasks));
+  } catch {
+    // ignore storage errors
+  }
+};
+
+export const formatIsoDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+export const parseDateValue = (value: string): Date | null => {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+export const addDays = (date: Date, days: number): Date => {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+};
+
+export const startOfDay = (date: Date): Date => {
+  const result = new Date(date);
+  result.setHours(0, 0, 0, 0);
+  return result;
+};
+
+export type TaskScheduleWindow = { start: Date; end: Date };
+
+export const resolveTaskScheduleWindow = (
+  task: TaskListItem,
+  taskMap: Map<string, TaskListItem>,
+  stack: Set<string> = new Set()
+): TaskScheduleWindow | null => {
+  if (stack.has(task.id)) {
+    return null;
+  }
+
+  const nextStack = new Set(stack);
+  nextStack.add(task.id);
+
+  const { schedule } = task;
+
+  switch (schedule.type) {
+    case 'due-date': {
+      const dueDate = parseDateValue(schedule.dueDate);
+      if (!dueDate) {
+        return null;
+      }
+      const day = startOfDay(dueDate);
+      return { start: day, end: day };
+    }
+    case 'start-duration': {
+      const startDate = parseDateValue(schedule.startDate);
+      if (!startDate) {
+        return null;
+      }
+      const dueDate = addDays(startDate, schedule.durationDays);
+      return { start: startOfDay(startDate), end: startOfDay(dueDate) };
+    }
+    case 'date-range': {
+      const startDate = parseDateValue(schedule.startDate);
+      const endDate = parseDateValue(schedule.endDate);
+      if (!startDate || !endDate || endDate.getTime() < startDate.getTime()) {
+        return null;
+      }
+      return { start: startOfDay(startDate), end: startOfDay(endDate) };
+    }
+    case 'after-task': {
+      const predecessor = schedule.predecessorId ? taskMap.get(schedule.predecessorId) : undefined;
+      if (!predecessor) {
+        return null;
+      }
+      const predecessorWindow = resolveTaskScheduleWindow(predecessor, taskMap, nextStack);
+      if (!predecessorWindow) {
+        return null;
+      }
+      const startDate = addDays(predecessorWindow.end, 1);
+      const dueDate = addDays(predecessorWindow.end, schedule.durationDays);
+      return { start: startOfDay(startDate), end: startOfDay(dueDate) };
+    }
+    default:
+      return null;
+  }
+};


### PR DESCRIPTION
## Summary
- add shared task typing, storage helpers, and initial employee task fixtures tied to active initiatives
- surface employee tasks alongside initiative work through shared state in the planner and workload timeline, including new employee/initiative tabs
- align initiative role work items and timeline data with assigned experts for coherent cross-view display

## Testing
- npm test -- --runInBand --watch=false *(fails: vitest package missing in runtime environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922750ed1288332b4220d15a033eeb1)