### PR TITLE
Simplify Gantt task text layout

### DIFF
--- a/src/components/GanttTimeline.module.css
+++ b/src/components/GanttTimeline.module.css
@@ -94,7 +94,7 @@
   position: absolute;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
   padding: 10px 12px;
   border-radius: 10px;
   border: 1px solid transparent;
@@ -146,29 +146,30 @@
   border-color: rgba(47, 209, 150, 0.4);
 }
 
-.taskName {
-  max-width: 256px;
-  line-height: 1.3;
-}
-
-.taskMetaRow {
+.taskHeader {
   display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
   align-items: center;
+  gap: 8px;
+  min-width: 0;
 }
 
-.taskBadge {
-  pointer-events: none;
+.taskName {
+  flex: 1 1 auto;
+  min-width: 0;
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .taskPeriod {
+  flex: 0 1 auto;
+  min-width: 0;
   color: var(--color-typo-secondary);
   line-height: 1.2;
-}
-
-.taskDescription {
-  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 @media (max-width: 960px) {

--- a/src/components/GanttTimeline.tsx
+++ b/src/components/GanttTimeline.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@consta/uikit/Badge';
 import { Text } from '@consta/uikit/Text';
 import React, { useMemo } from 'react';
 import timelineStyles from './GanttTimeline.module.css';
@@ -484,25 +483,14 @@ const GanttTimeline: React.FC<GanttTimelineProps> = ({
                           : undefined
                       }
                     >
-                      <Text size="xs" weight="semibold" className={timelineStyles.taskName} truncate>
-                        {task.original.name}
-                      </Text>
-                      <div className={timelineStyles.taskMetaRow}>
-                        <Badge
-                          size="xs"
-                          status={task.kind === 'project' ? 'system' : task.kind === 'training' ? 'success' : 'warning'}
-                          label={task.original.badge}
-                          className={timelineStyles.taskBadge}
-                        />
+                      <div className={timelineStyles.taskHeader}>
+                        <Text size="xs" weight="semibold" className={timelineStyles.taskName} truncate>
+                          {task.original.name}
+                        </Text>
                         <Text size="2xs" view="secondary" className={timelineStyles.taskPeriod}>
                           {periodLabel}
                         </Text>
                       </div>
-                      {task.original.description && (
-                        <Text size="2xs" view="secondary" className={timelineStyles.taskDescription}>
-                          {task.original.description}
-                        </Text>
-                      )}
                     </div>
                   );
                 })}


### PR DESCRIPTION
## Summary
- remove badges and descriptions from Gantt task cards, leaving only name and period
- adjust timeline task styling for compact header layout with ellipsis truncation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69227b83f8ac83328721281b9c3ebeba)