### PR TITLE
Improve admin notice text contrast

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -41,14 +41,15 @@
   gap: 12px;
   padding: 12px 24px;
   border-bottom: 1px solid var(--color-bg-border);
+  color: var(--color-typo-primary);
 }
 
 .noticeSuccess {
   background: var(--color-bg-success);
 }
 
-.noticeSuccessMessage {
-  color: var(--color-bg-success);
+.noticeMessage {
+  color: var(--color-typo-primary);
 }
 
 .noticeError {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3465,10 +3465,8 @@ function App() {
             >
               <Text
                 size="s"
-                view={adminNotice.type === 'error' ? 'alert' : 'success'}
-                className={
-                  adminNotice.type === 'success' ? styles.noticeSuccessMessage : undefined
-                }
+                view="primary"
+                className={styles.noticeMessage}
               >
                 {adminNotice.message}
               </Text>


### PR DESCRIPTION
## Summary
- set admin notice banners to use readable text color
- align admin notice text styling with theme typography

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69231e384d1c833287b66a8b7a3a7a3e)