### PR TITLE
Add role competency admin management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "tsx": "4.19.1",
         "typescript": "5.6.3",
         "vite": "5.4.10",
-        "vitest": "^4.0.12"
+        "vitest": "^4.0.13"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -2752,16 +2752,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.12.tgz",
-      "integrity": "sha512-is+g0w8V3/ZhRNrRizrJNr8PFQKwYmctWlU4qg8zy5r9aIV5w8IxXLlfbbxJCwSpsVl2PXPTm2/zruqTqz3QSg==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.13.tgz",
+      "integrity": "sha512-zYtcnNIBm6yS7Gpr7nFTmq8ncowlMdOJkWLqYvhr/zweY6tFbDkDi8BPPOeHxEtK1rSI69H7Fd4+1sqvEGli6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.12",
-        "@vitest/utils": "4.0.12",
+        "@vitest/spy": "4.0.13",
+        "@vitest/utils": "4.0.13",
         "chai": "^6.2.1",
         "tinyrainbow": "^3.0.3"
       },
@@ -2770,9 +2770,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.12.tgz",
-      "integrity": "sha512-R7nMAcnienG17MvRN8TPMJiCG8rrZJblV9mhT7oMFdBXvS0x+QD6S1G4DxFusR2E0QIS73f7DqSR1n87rrmE+g==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.13.tgz",
+      "integrity": "sha512-ooqfze8URWbI2ozOeLDMh8YZxWDpGXoeY3VOgcDnsUxN0jPyPWSUvjPQWqDGCBks+opWlN1E4oP1UYl3C/2EQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2783,13 +2783,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.12.tgz",
-      "integrity": "sha512-hDlCIJWuwlcLumfukPsNfPDOJokTv79hnOlf11V+n7E14rHNPz0Sp/BO6h8sh9qw4/UjZiKyYpVxK2ZNi+3ceQ==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.13.tgz",
+      "integrity": "sha512-9IKlAru58wcVaWy7hz6qWPb2QzJTKt+IOVKjAx5vb5rzEFPTL6H4/R9BMvjZ2ppkxKgTrFONEJFtzvnyEpiT+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.12",
+        "@vitest/utils": "4.0.13",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2797,13 +2797,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.12.tgz",
-      "integrity": "sha512-2jz9zAuBDUSbnfyixnyOd1S2YDBrZO23rt1bicAb6MA/ya5rHdKFRikPIDpBj/Dwvh6cbImDmudegnDAkHvmRQ==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.13.tgz",
+      "integrity": "sha512-hb7Usvyika1huG6G6l191qu1urNPsq1iFc2hmdzQY3F5/rTgqQnwwplyf8zoYHkpt7H6rw5UfIw6i/3qf9oSxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.12",
+        "@vitest/pretty-format": "4.0.13",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2812,9 +2812,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.12.tgz",
-      "integrity": "sha512-GZjI9PPhiOYNX8Nsyqdw7JQB+u0BptL5fSnXiottAUBHlcMzgADV58A7SLTXXQwcN1yZ6gfd1DH+2bqjuUlCzw==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.13.tgz",
+      "integrity": "sha512-hSu+m4se0lDV5yVIcNWqjuncrmBgwaXa2utFLIrBkQCQkt+pSwyZTPFQAZiiF/63j8jYa8uAeUZ3RSfcdWaYWw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2822,13 +2822,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.12.tgz",
-      "integrity": "sha512-DVS/TLkLdvGvj1avRy0LSmKfrcI9MNFvNGN6ECjTUHWJdlcgPDOXhjMis5Dh7rBH62nAmSXnkPbE+DZ5YD75Rw==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.13.tgz",
+      "integrity": "sha512-ydozWyQ4LZuu8rLp47xFUWis5VOKMdHjXCWhs1LuJsTNKww+pTHQNK4e0assIB9K80TxFyskENL6vCu3j34EYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.12",
+        "@vitest/pretty-format": "4.0.13",
         "tinyrainbow": "^3.0.3"
       },
       "funding": {
@@ -10076,19 +10076,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.12.tgz",
-      "integrity": "sha512-pmW4GCKQ8t5Ko1jYjC3SqOr7TUKN7uHOHB/XGsAIb69eYu6d1ionGSsb5H9chmPf+WeXt0VE7jTXsB1IvWoNbw==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.13.tgz",
+      "integrity": "sha512-QSD4I0fN6uZQfftryIXuqvqgBxTvJ3ZNkF6RWECd82YGAYAfhcppBLFXzXJHQAAhVFyYEuFTrq6h0hQqjB7jIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.12",
-        "@vitest/mocker": "4.0.12",
-        "@vitest/pretty-format": "4.0.12",
-        "@vitest/runner": "4.0.12",
-        "@vitest/snapshot": "4.0.12",
-        "@vitest/spy": "4.0.12",
-        "@vitest/utils": "4.0.12",
+        "@vitest/expect": "4.0.13",
+        "@vitest/mocker": "4.0.13",
+        "@vitest/pretty-format": "4.0.13",
+        "@vitest/runner": "4.0.13",
+        "@vitest/snapshot": "4.0.13",
+        "@vitest/spy": "4.0.13",
+        "@vitest/utils": "4.0.13",
         "debug": "^4.4.3",
         "es-module-lexer": "^1.7.0",
         "expect-type": "^1.2.2",
@@ -10117,10 +10117,10 @@
         "@opentelemetry/api": "^1.9.0",
         "@types/debug": "^4.1.12",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.12",
-        "@vitest/browser-preview": "4.0.12",
-        "@vitest/browser-webdriverio": "4.0.12",
-        "@vitest/ui": "4.0.12",
+        "@vitest/browser-playwright": "4.0.13",
+        "@vitest/browser-preview": "4.0.13",
+        "@vitest/browser-webdriverio": "4.0.13",
+        "@vitest/ui": "4.0.13",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -10874,13 +10874,13 @@
       ]
     },
     "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.12.tgz",
-      "integrity": "sha512-GsmA/tD5Ht3RUFoz41mZsMU1AXch3lhmgbTnoSPTdH231g7S3ytNN1aU0bZDSyxWs8WA7KDyMPD5L4q6V6vj9w==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.13.tgz",
+      "integrity": "sha512-eNCwzrI5djoauklwP1fuslHBjrbR8rqIVbvNlAnkq1OTa6XT+lX68mrtPirNM9TnR69XUPt4puBCx2Wexseylg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.12",
+        "@vitest/spy": "4.0.13",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "tsx": "4.19.1",
     "typescript": "5.6.3",
     "vite": "5.4.10",
-    "vitest": "^4.0.12"
+    "vitest": "^4.0.13"
   },
   "overrides": {
     "three-bmfont-text": "https://github.com/dmarcos/three-bmfont-text/archive/eed4878795be9b3e38cf6aec6b903f56acd1f695.tar.gz"

--- a/src/components/AdminPanel.module.css
+++ b/src/components/AdminPanel.module.css
@@ -423,6 +423,54 @@
   gap: 24px;
 }
 
+.roleManager {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+  border-radius: 12px;
+  background: var(--color-bg-default);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.roleRow {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+  align-items: end;
+}
+
+.roleActions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.roleGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+.roleCard {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid var(--color-bg-border);
+  background: var(--color-bg-ghost);
+}
+
+.roleHint {
+  margin: 0;
+}
+
+.roleStatus {
+  margin: 0;
+}
+
 @media (max-width: 1200px) {
   .container {
     grid-template-columns: 1fr;

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -29,10 +29,12 @@ import {
   type TeamRole,
   type UserStats,
   evidenceStatuses,
+  getKnownRoles,
   findSkillByName,
   getSkillNameById,
   getRolesForSkill,
   getSkillsByRole,
+  registerRole,
   registerRoleCompetency,
   registerSkillDefinition,
   skillLevels
@@ -45,6 +47,7 @@ import type {
   MissingSkillEntry
 } from '../utils/expertExcel';
 import { useSkillRegistryVersion } from '../utils/useSkillRegistryVersion';
+import RoleCompetencyAdmin from './RoleCompetencyAdmin';
 import styles from './AdminPanel.module.css';
 
 export type ModuleDraftPayload = {
@@ -128,7 +131,7 @@ type AdminPanelProps = {
   onDeleteExpert: (id: string) => void;
 };
 
-type AdminTab = 'module' | 'domain' | 'artifact' | 'expert';
+type AdminTab = 'module' | 'domain' | 'artifact' | 'expert' | 'role';
 
 type SelectItem<Value extends string> = {
   label: string;
@@ -178,7 +181,8 @@ const adminTabs = [
   { label: 'Модули', value: 'module' },
   { label: 'Домены', value: 'domain' },
   { label: 'Артефакты', value: 'artifact' },
-  { label: 'Сотрудники', value: 'expert' }
+  { label: 'Сотрудники', value: 'expert' },
+  { label: 'Роли и компетенции', value: 'role' }
 ] as const satisfies readonly { label: string; value: AdminTab }[];
 
 const ROOT_DOMAIN_OPTION = '__root__';
@@ -199,18 +203,6 @@ const deploymentToolLabels: Record<ModuleNode['deploymentTool'], string> = {
   docker: 'Docker',
   kubernetes: 'Kubernetes'
 };
-
-const TEAM_ROLES: TeamRole[] = [
-  'Владелец продукта',
-  'Эксперт R&D',
-  'Аналитик',
-  'Backend',
-  'Frontend',
-  'Архитектор',
-  'Тестировщик',
-  'Руководитель проекта',
-  'UX'
-];
 
 const AdminPanel: React.FC<AdminPanelProps> = ({
   modules,
@@ -233,6 +225,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
   onDeleteExpert
 }) => {
   const [activeTab, setActiveTab] = useState<AdminTab>('module');
+  const skillRegistryVersion = useSkillRegistryVersion();
 
   const domainLabelMap = useMemo(() => buildDomainLabelMap(domains), [domains]);
   const moduleLabelMap = useMemo(() => buildModuleLabelMap(modules), [modules]);
@@ -368,9 +361,19 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
     [domainLabelMap]
   );
 
+  useEffect(() => {
+    experts.forEach((expert) => registerRole(expert.title));
+  }, [experts]);
+
   const availableRoles = useMemo<TeamRole[]>(
-    () => mergeStringCollections(TEAM_ROLES, experts.map((expert) => expert.title)) as TeamRole[],
-    [experts]
+    () => {
+      void skillRegistryVersion;
+      return mergeStringCollections(
+        getKnownRoles(),
+        experts.map((expert) => expert.title)
+      ) as TeamRole[];
+    },
+    [experts, skillRegistryVersion]
   );
 
   const [selectedModuleId, setSelectedModuleId] = useState<string>('__new__');
@@ -886,6 +889,8 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
           />
         )}
 
+        {activeTab === 'role' && <RoleCompetencyAdmin />}
+
       </div>
     </div>
   );
@@ -956,6 +961,7 @@ const ModuleForm: React.FC<ModuleFormProps> = ({
   onSubmit,
   onDelete
 }) => {
+  const skillRegistryVersion = useSkillRegistryVersion();
   const current = Math.min(Math.max(step, 0), moduleSections.length - 1);
   const goToStep = (next: number) => {
     onStepChange(Math.min(Math.max(next, 0), moduleSections.length - 1));
@@ -989,8 +995,11 @@ const ModuleForm: React.FC<ModuleFormProps> = ({
   );
 
   const teamRoleItems = useMemo<SelectItem<TeamRole>[]>(
-    () => TEAM_ROLES.map((role) => ({ label: role, value: role })),
-    []
+    () => {
+      void skillRegistryVersion;
+      return getKnownRoles().map((role) => ({ label: role, value: role }));
+    },
+    [skillRegistryVersion]
   );
 
   const CREATE_PRODUCT_OPTION = '__create_product__';

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -363,12 +363,9 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
   const availableRoles = useMemo<TeamRole[]>(
     () => {
       void skillRegistryVersion;
-      return mergeStringCollections(
-        getKnownRoles(),
-        experts.map((expert) => expert.title)
-      ) as TeamRole[];
+      return getKnownRoles();
     },
-    [experts, skillRegistryVersion]
+    [skillRegistryVersion]
   );
 
   const [selectedModuleId, setSelectedModuleId] = useState<string>('__new__');

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -34,7 +34,6 @@ import {
   getSkillNameById,
   getRolesForSkill,
   getSkillsByRole,
-  registerRole,
   registerRoleCompetency,
   registerSkillDefinition,
   skillLevels
@@ -360,10 +359,6 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
     () => ({ [ROOT_DOMAIN_OPTION]: 'Корневой каталог', ...domainLabelMap }),
     [domainLabelMap]
   );
-
-  useEffect(() => {
-    experts.forEach((expert) => registerRole(expert.title));
-  }, [experts]);
 
   const availableRoles = useMemo<TeamRole[]>(
     () => {

--- a/src/components/InitiativeCreationModal.tsx
+++ b/src/components/InitiativeCreationModal.tsx
@@ -17,7 +17,12 @@ import type {
   InitiativeWorkItemStatus,
   TeamRole
 } from '../data';
-import { getKnownRoles, getSkillNameById, getSkillsByRole } from '../data/skills';
+import {
+  defaultTeamRoles,
+  getKnownRoles,
+  getSkillNameById,
+  getSkillsByRole
+} from '../data/skills';
 import InitiativeGanttChart, {
   type InitiativeGanttBlocker,
   type InitiativeGanttDependency,
@@ -239,30 +244,6 @@ const statusOptions: SelectOption<InitiativeStatus>[] = [
   { label: 'В работе', value: 'in-progress' },
   { label: 'Конвертирована', value: 'converted' }
 ];
-
-const defaultRoles: TeamRole[] = [
-  'Владелец продукта',
-  'Эксперт R&D',
-  'Аналитик',
-  'Backend',
-  'Frontend',
-  'Архитектор',
-  'Тестировщик',
-  'Руководитель проекта',
-  'UX'
-];
-
-const mergeRoles = (base: TeamRole[], extra: TeamRole[]): TeamRole[] => {
-  const set = new Set<TeamRole>();
-  base.forEach((role) => set.add(role));
-  extra.forEach((role) => {
-    const normalized = role.trim();
-    if (normalized) {
-      set.add(normalized as TeamRole);
-    }
-  });
-  return Array.from(set);
-};
 
 const buildRoleOptions = (roles: TeamRole[]): SelectOption<TeamRole>[] =>
   roles.map((role) => ({ label: role, value: role }));
@@ -574,7 +555,10 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
   const [customerRepresentative, setCustomerRepresentative] = useState('');
   const [customerContact, setCustomerContact] = useState('');
   const [customerComment, setCustomerComment] = useState('');
-  const [works, setWorks] = useState<WorkDraft[]>([createWorkDraft(DEFAULT_ROLE)]);
+  const initialRegistryRoles = getKnownRoles();
+  const initialPrimaryRole = initialRegistryRoles[0] ?? DEFAULT_ROLE;
+
+  const [works, setWorks] = useState<WorkDraft[]>([createWorkDraft(initialPrimaryRole)]);
   const [collapsedWorkIds, setCollapsedWorkIds] = useState<string[]>([]);
   const [approvalStages, setApprovalStages] = useState<ApprovalStageDraft[]>([
     createApprovalStageDraft()
@@ -584,8 +568,8 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
   const roleOptions = useMemo<SelectOption<TeamRole>[]>(() => {
     void skillRegistryVersion;
     const registryRoles = getKnownRoles();
-    const mergedRoles = mergeRoles(defaultRoles, registryRoles);
-    return buildRoleOptions(mergedRoles);
+    const resolvedRoles = registryRoles.length > 0 ? registryRoles : defaultTeamRoles;
+    return buildRoleOptions(resolvedRoles);
   }, [skillRegistryVersion]);
   const primaryRole = useMemo<TeamRole>(
     () => roleOptions[0]?.value ?? DEFAULT_ROLE,
@@ -596,6 +580,7 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
       roleOptions.reduce((acc, option) => {
         void skillRegistryVersion;
         const skillOptions = getSkillsByRole(option.value)
+          .filter((skill) => skill.category === 'hard')
           .map((skill) => ({
             id: skill.id,
             label: skill.name,
@@ -622,9 +607,13 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
   useEffect(() => {
     setRoleSkillOptions((prev) => {
       const next = createRoleSkillState();
+      const allowedRoles = new Set(roleOptions.map((option) => option.value));
 
       Object.entries(prev).forEach(([role, options]) => {
         const roleKey = role as TeamRole;
+        if (!allowedRoles.has(roleKey)) {
+          return;
+        }
         const existing = next[roleKey] ?? [];
         const merged = [...existing];
 
@@ -640,6 +629,26 @@ const InitiativeCreationModal: React.FC<InitiativeCreationModalProps> = ({
       return next;
     });
   }, [createRoleSkillState]);
+
+  useEffect(() => {
+    const allowedRoles = new Set(roleOptions.map((option) => option.value));
+    setWorks((prev) =>
+      prev.map((work) => ({
+        ...work,
+        assignments: work.assignments.map((assignment) => {
+          const normalizedRole = allowedRoles.has(assignment.role) ? assignment.role : primaryRole;
+          const roleChanged = normalizedRole !== assignment.role;
+
+          return {
+            ...assignment,
+            role: normalizedRole,
+            task: roleChanged ? '' : assignment.task,
+            isCustom: roleChanged ? undefined : assignment.isCustom
+          };
+        })
+      }))
+    );
+  }, [primaryRole, roleOptions]);
 
   const hydrateFromDraft = useCallback(
     (draft: InitiativeCreationRequest | null) => {

--- a/src/components/RoleCompetencyAdmin.tsx
+++ b/src/components/RoleCompetencyAdmin.tsx
@@ -9,6 +9,7 @@ import {
   getKnownRoles,
   getSkillsByRole,
   registerRole,
+  registerAdHocSkill,
   renameRole,
   setRoleSkills,
   skills
@@ -27,6 +28,8 @@ const RoleCompetencyAdmin: React.FC = () => {
   const [roleNameDraft, setRoleNameDraft] = useState('');
   const [hardSelection, setHardSelection] = useState<string[]>([]);
   const [softSelection, setSoftSelection] = useState<string[]>([]);
+  const [newHardSkillName, setNewHardSkillName] = useState('');
+  const [newSoftSkillName, setNewSoftSkillName] = useState('');
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
 
   const sortedSkills = useMemo(() => {
@@ -94,6 +97,31 @@ const RoleCompetencyAdmin: React.FC = () => {
     renameRole(selectedRole, normalized);
     setSelectedRole(normalized as TeamRole);
     setStatusMessage('Название роли обновлено.');
+  };
+
+  const handleAddSkill = (category: 'hard' | 'soft') => {
+    if (!selectedRole) {
+      setStatusMessage('Сначала выберите или создайте роль.');
+      return;
+    }
+
+    const value = category === 'hard' ? newHardSkillName : newSoftSkillName;
+    const definition = registerAdHocSkill(value, category, [selectedRole]);
+
+    if (!definition) {
+      setStatusMessage('Введите название навыка, чтобы добавить его.');
+      return;
+    }
+
+    if (category === 'hard') {
+      setHardSelection((prev) => Array.from(new Set([...prev, definition.id])));
+      setNewHardSkillName('');
+    } else {
+      setSoftSelection((prev) => Array.from(new Set([...prev, definition.id])));
+      setNewSoftSkillName('');
+    }
+
+    setStatusMessage(`Навык «${definition.name}» добавлен для роли ${selectedRole}.`);
   };
 
   const handleSaveSkills = () => {
@@ -216,6 +244,21 @@ const RoleCompetencyAdmin: React.FC = () => {
           <Text size="xs" view="secondary" className={styles.roleHint}>
             Выбрано: {hardSelectionValue.length}
           </Text>
+          <div className={styles.inlineForm}>
+            <TextField
+              size="s"
+              placeholder="Добавить новый hard skill"
+              value={newHardSkillName}
+              onChange={(value) => setNewHardSkillName(value ?? '')}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  handleAddSkill('hard');
+                }
+              }}
+            />
+            <Button size="s" view="secondary" label="Добавить" onClick={() => handleAddSkill('hard')} />
+          </div>
         </div>
         <div className={styles.roleCard}>
           <Text size="s" weight="semibold" className={styles.label}>
@@ -237,6 +280,21 @@ const RoleCompetencyAdmin: React.FC = () => {
           <Text size="xs" view="secondary" className={styles.roleHint}>
             Выбрано: {softSelectionValue.length}
           </Text>
+          <div className={styles.inlineForm}>
+            <TextField
+              size="s"
+              placeholder="Добавить новый soft skill"
+              value={newSoftSkillName}
+              onChange={(value) => setNewSoftSkillName(value ?? '')}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  handleAddSkill('soft');
+                }
+              }}
+            />
+            <Button size="s" view="secondary" label="Добавить" onClick={() => handleAddSkill('soft')} />
+          </div>
         </div>
       </div>
 

--- a/src/components/RoleCompetencyAdmin.tsx
+++ b/src/components/RoleCompetencyAdmin.tsx
@@ -1,0 +1,265 @@
+import { Button } from '@consta/uikit/Button';
+import { Combobox } from '@consta/uikit/Combobox';
+import { Text } from '@consta/uikit/Text';
+import { TextField } from '@consta/uikit/TextField';
+import React, { useEffect, useMemo, useState } from 'react';
+import type { TeamRole } from '../data';
+import {
+  deleteRole,
+  getKnownRoles,
+  getSkillsByRole,
+  registerRole,
+  renameRole,
+  setRoleSkills,
+  skills
+} from '../data/skills';
+import { useSkillRegistryVersion } from '../utils/useSkillRegistryVersion';
+import styles from './AdminPanel.module.css';
+
+const RoleCompetencyAdmin: React.FC = () => {
+  const registryVersion = useSkillRegistryVersion();
+  const roles = useMemo(() => {
+    void registryVersion;
+    return getKnownRoles();
+  }, [registryVersion]);
+  const [selectedRole, setSelectedRole] = useState<TeamRole | null>(() => roles[0] ?? null);
+  const [newRoleName, setNewRoleName] = useState('');
+  const [roleNameDraft, setRoleNameDraft] = useState('');
+  const [hardSelection, setHardSelection] = useState<string[]>([]);
+  const [softSelection, setSoftSelection] = useState<string[]>([]);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  const sortedSkills = useMemo(() => {
+    void registryVersion;
+    return Object.values(skills).sort((a, b) => a.name.localeCompare(b.name, 'ru'));
+  }, [registryVersion]);
+
+  const hardSkillIds = useMemo(
+    () => sortedSkills.filter((skill) => skill.category === 'hard').map((skill) => skill.id),
+    [sortedSkills]
+  );
+  const softSkillIds = useMemo(
+    () => sortedSkills.filter((skill) => skill.category === 'soft').map((skill) => skill.id),
+    [sortedSkills]
+  );
+  const skillLabelMap = useMemo(() => {
+    const map = new Map<string, string>();
+    sortedSkills.forEach((skill) => map.set(skill.id, skill.name));
+    return map;
+  }, [sortedSkills]);
+
+  useEffect(() => {
+    if (!selectedRole || roles.length === 0) {
+      setSelectedRole(roles[0] ?? null);
+      return;
+    }
+    if (!roles.includes(selectedRole)) {
+      setSelectedRole(roles[0] ?? null);
+    }
+  }, [roles, selectedRole]);
+
+  useEffect(() => {
+    if (!selectedRole) {
+      setRoleNameDraft('');
+      setHardSelection([]);
+      setSoftSelection([]);
+      return;
+    }
+    setRoleNameDraft(selectedRole);
+    const roleSkills = getSkillsByRole(selectedRole as TeamRole);
+    setHardSelection(roleSkills.filter((skill) => skill.category === 'hard').map((skill) => skill.id));
+    setSoftSelection(roleSkills.filter((skill) => skill.category === 'soft').map((skill) => skill.id));
+  }, [selectedRole, registryVersion]);
+
+  const handleCreateRole = () => {
+    const created = registerRole(newRoleName);
+    if (!created) {
+      setStatusMessage('Введите название роли, чтобы добавить её.');
+      return;
+    }
+    setSelectedRole(created);
+    setNewRoleName('');
+    setStatusMessage('Новая роль создана. Настройте компетенции и сохраните изменения.');
+  };
+
+  const handleRenameRole = () => {
+    if (!selectedRole) {
+      return;
+    }
+    const normalized = roleNameDraft.trim();
+    if (!normalized) {
+      setStatusMessage('Название роли не может быть пустым.');
+      return;
+    }
+    renameRole(selectedRole, normalized);
+    setSelectedRole(normalized as TeamRole);
+    setStatusMessage('Название роли обновлено.');
+  };
+
+  const handleSaveSkills = () => {
+    if (!selectedRole) {
+      return;
+    }
+    const mergedSkills = Array.from(new Set([...hardSelection, ...softSelection]));
+    setRoleSkills(selectedRole, mergedSkills);
+    setStatusMessage('Набор компетенций сохранён.');
+  };
+
+  const handleDeleteRole = () => {
+    if (!selectedRole) {
+      return;
+    }
+    deleteRole(selectedRole);
+    setSelectedRole(null);
+    setStatusMessage('Роль удалена. Выберите другую роль или создайте новую.');
+  };
+
+  const hardSelectionValue = hardSelection.filter((id) => hardSkillIds.includes(id));
+  const softSelectionValue = softSelection.filter((id) => softSkillIds.includes(id));
+
+  return (
+    <div className={styles.roleManager}>
+      <div>
+        <Text size="l" weight="semibold" className={styles.formTitle}>
+          Управление ролями и компетенциями
+        </Text>
+        <Text size="s" view="secondary" className={styles.formSubtitle}>
+          Редактируйте названия ролей и настраивайте их ключевые hard и soft skills.
+        </Text>
+      </div>
+
+      <div className={styles.roleRow}>
+        <label className={styles.field}>
+          <Text size="xs" weight="semibold" className={styles.label}>
+            Текущая роль
+          </Text>
+          <Combobox<string>
+            size="s"
+            items={roles}
+            value={selectedRole}
+            getItemKey={(item) => item}
+            getItemLabel={(item) => item || '—'}
+            placeholder={roles.length === 0 ? 'Создайте новую роль' : 'Выберите роль'}
+            onChange={(value) => setSelectedRole(value)}
+          />
+        </label>
+        <label className={styles.field}>
+          <Text size="xs" weight="semibold" className={styles.label}>
+            Создать новую роль
+          </Text>
+          <div className={styles.inlineForm}>
+            <input
+              className={styles.input}
+              value={newRoleName}
+              placeholder="Название роли"
+              onChange={(event) => setNewRoleName(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  handleCreateRole();
+                }
+              }}
+            />
+            <Button size="s" view="primary" label="Добавить" onClick={handleCreateRole} />
+          </div>
+        </label>
+      </div>
+
+      <div className={styles.fieldGroup}>
+        <label className={styles.field}>
+          <Text size="xs" weight="semibold" className={styles.label}>
+            Название роли
+          </Text>
+          <TextField
+            size="s"
+            placeholder="Введите название"
+            disabled={!selectedRole}
+            value={roleNameDraft}
+            onChange={(value) => setRoleNameDraft(value ?? '')}
+          />
+        </label>
+        <div className={styles.roleActions}>
+          <Button
+            size="s"
+            view="primary"
+            disabled={!selectedRole || roleNameDraft.trim().length === 0}
+            label="Сохранить название"
+            onClick={handleRenameRole}
+          />
+          <Button
+            size="s"
+            view="ghost"
+            disabled={!selectedRole}
+            label="Удалить роль"
+            onClick={handleDeleteRole}
+          />
+        </div>
+      </div>
+
+      <div className={styles.roleGrid}>
+        <div className={styles.roleCard}>
+          <Text size="s" weight="semibold" className={styles.label}>
+            Ключевые hard skills
+          </Text>
+          <Text size="xs" view="secondary" className={styles.roleHint}>
+            Выберите навыки, которые считаются обязательными или базовыми для роли.
+          </Text>
+          <Combobox<string>
+            size="s"
+            multiple
+            items={hardSkillIds}
+            value={hardSelectionValue}
+            getItemKey={(item) => item}
+            getItemLabel={(item) => skillLabelMap.get(item) ?? item}
+            placeholder="Добавьте hard skills"
+            onChange={(value) => setHardSelection(value ?? [])}
+          />
+          <Text size="xs" view="secondary" className={styles.roleHint}>
+            Выбрано: {hardSelectionValue.length}
+          </Text>
+        </div>
+        <div className={styles.roleCard}>
+          <Text size="s" weight="semibold" className={styles.label}>
+            Ключевые soft skills
+          </Text>
+          <Text size="xs" view="secondary" className={styles.roleHint}>
+            Подберите универсальные навыки, которые помогут оценивать соответствие роли.
+          </Text>
+          <Combobox<string>
+            size="s"
+            multiple
+            items={softSkillIds}
+            value={softSelectionValue}
+            getItemKey={(item) => item}
+            getItemLabel={(item) => skillLabelMap.get(item) ?? item}
+            placeholder="Добавьте soft skills"
+            onChange={(value) => setSoftSelection(value ?? [])}
+          />
+          <Text size="xs" view="secondary" className={styles.roleHint}>
+            Выбрано: {softSelectionValue.length}
+          </Text>
+        </div>
+      </div>
+
+      <div className={styles.roleActions}>
+        <Button
+          size="s"
+          view="primary"
+          disabled={!selectedRole}
+          label="Сохранить набор компетенций"
+          onClick={handleSaveSkills}
+        />
+        <Text size="xs" view="secondary" className={styles.roleHint}>
+          Изменения применяются ко всем формам и импортам, где используется выбранная роль.
+        </Text>
+      </div>
+
+      {statusMessage && (
+        <Text size="s" view="secondary" className={styles.roleStatus}>
+          {statusMessage}
+        </Text>
+      )}
+    </div>
+  );
+};
+
+export default RoleCompetencyAdmin;

--- a/src/data.ts
+++ b/src/data.ts
@@ -25,16 +25,7 @@ export type ModuleOutput = {
   artifactId?: string;
 };
 
-export type TeamRole =
-  | 'Владелец продукта'
-  | 'Эксперт R&D'
-  | 'Аналитик'
-  | 'Backend'
-  | 'Frontend'
-  | 'Архитектор'
-  | 'Тестировщик'
-  | 'Руководитель проекта'
-  | 'UX';
+export type TeamRole = string;
 
 export type TeamMember = {
   id: string;
@@ -3035,6 +3026,7 @@ export {
   roleToSkillsMap,
   getSkillsByRole,
   getSkillIdsByRole,
+  getKnownRoles,
   getRolesForSkill,
   getSkillNameById,
   skillLevels,
@@ -3043,7 +3035,12 @@ export {
   ensureSkillDefinition,
   subscribeToSkillRegistry,
   getSkillRegistryVersion,
-  findSkillByName
+  findSkillByName,
+  defaultTeamRoles,
+  registerRole,
+  renameRole,
+  deleteRole,
+  setRoleSkills
 } from './data/skills';
 
 export type {

--- a/src/data.ts
+++ b/src/data.ts
@@ -3036,6 +3036,8 @@ export {
   subscribeToSkillRegistry,
   getSkillRegistryVersion,
   findSkillByName,
+  registerAdHocSkill,
+  slugifySkillId,
   defaultTeamRoles,
   registerRole,
   renameRole,

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -37,6 +37,18 @@ export type SkillDefinition = {
   roles: TeamRole[];
 };
 
+export const defaultTeamRoles: TeamRole[] = [
+  'Владелец продукта',
+  'Эксперт R&D',
+  'Аналитик',
+  'Backend',
+  'Frontend',
+  'Архитектор',
+  'Тестировщик',
+  'Руководитель проекта',
+  'UX'
+];
+
 export const skillLevels: SkillLevelDescriptor[] = [
   {
     id: 'A',
@@ -530,15 +542,37 @@ type SkillListener = () => void;
 
 const skillRegistry: Record<string, SkillDefinition> = {};
 const roleSkillIndex = new Map<TeamRole, Set<string>>();
+const roleRegistry = new Set<TeamRole>(defaultTeamRoles);
 
 let roleToSkillsMap: Record<TeamRole, string[]> = {} as Record<TeamRole, string[]>;
 let registryVersion = 0;
 const registryListeners = new Set<SkillListener>();
 
+const normalizeRole = (role: TeamRole): TeamRole | null => {
+  const normalized = role.trim();
+  return normalized ? (normalized as TeamRole) : null;
+};
+
+const registerRoleValue = (role: TeamRole): TeamRole | null => {
+  const normalized = normalizeRole(role);
+  if (!normalized) {
+    return null;
+  }
+  roleRegistry.add(normalized);
+  return normalized;
+};
+
 const rebuildRoleIndex = () => {
   const next: Record<TeamRole, string[]> = {} as Record<TeamRole, string[]>;
+  roleRegistry.forEach((role) => {
+    next[role] = [];
+  });
   roleSkillIndex.forEach((set, role) => {
-    next[role] = Array.from(set).sort((a, b) => a.localeCompare(b, 'ru'));
+    const normalized = normalizeRole(role);
+    if (!normalized) {
+      return;
+    }
+    next[normalized] = Array.from(set).sort((a, b) => a.localeCompare(b, 'ru'));
   });
   roleToSkillsMap = next;
 };
@@ -561,7 +595,7 @@ const normalizeSkillDefinition = (definition: SkillDefinition): SkillDefinition 
   const sources = Array.from(new Set(definition.sources.map((source) => source.trim()))).filter(
     (source) => source.length > 0
   ) as SkillSource[];
-  const roles = Array.from(new Set(definition.roles));
+  const roles = Array.from(new Set(definition.roles.map((role) => normalizeRole(role)).filter(Boolean))) as TeamRole[];
 
   return {
     ...definition,
@@ -579,6 +613,8 @@ const upsertSkillDefinition = (
 ): SkillDefinition => {
   const normalized = normalizeSkillDefinition(definition);
   const previous = skillRegistry[normalized.id];
+
+  normalized.roles.forEach((role) => registerRoleValue(role));
 
   if (previous) {
     previous.roles.forEach((role) => {
@@ -618,11 +654,7 @@ export const skills = skillRegistry;
 export { roleToSkillsMap };
 
 export const getKnownRoles = (): TeamRole[] => {
-  const roles = new Set<TeamRole>();
-  Object.keys(roleToSkillsMap).forEach((role) => {
-    roles.add(role as TeamRole);
-  });
-  return Array.from(roles).sort((a, b) => a.localeCompare(b, 'ru'));
+  return Array.from(roleRegistry).sort((a, b) => a.localeCompare(b, 'ru'));
 };
 
 export const getSkillRegistryVersion = (): number => registryVersion;
@@ -659,4 +691,103 @@ export const getSkillNameById = (skillId: string): string | undefined => skillRe
 export const findSkillByName = (name: string): SkillDefinition | undefined => {
   const normalized = name.trim().toLowerCase();
   return Object.values(skillRegistry).find((skill) => skill.name.toLowerCase() === normalized);
+};
+
+export const registerRole = (role: TeamRole): TeamRole | null => {
+  const normalized = registerRoleValue(role);
+  if (!normalized) {
+    return null;
+  }
+  rebuildRoleIndex();
+  notifyRegistryChange();
+  return normalized;
+};
+
+export const deleteRole = (role: TeamRole): void => {
+  const normalized = normalizeRole(role);
+  if (!normalized || !roleRegistry.has(normalized)) {
+    return;
+  }
+
+  roleRegistry.delete(normalized);
+  roleSkillIndex.delete(normalized);
+
+  Object.values(skillRegistry).forEach((definition) => {
+    if (!definition.roles.includes(normalized)) {
+      return;
+    }
+    const roles = definition.roles.filter((value) => value !== normalized);
+    upsertSkillDefinition({ ...definition, roles }, { silent: true });
+  });
+
+  rebuildRoleIndex();
+  notifyRegistryChange();
+};
+
+export const renameRole = (current: TeamRole, next: TeamRole): void => {
+  const currentNormalized = normalizeRole(current);
+  const nextNormalized = normalizeRole(next);
+
+  if (!currentNormalized || !nextNormalized) {
+    return;
+  }
+
+  if (currentNormalized === nextNormalized) {
+    registerRole(nextNormalized);
+    return;
+  }
+
+  const currentSkills = roleSkillIndex.get(currentNormalized);
+
+  if (currentSkills) {
+    roleSkillIndex.set(nextNormalized, new Set(currentSkills));
+    roleSkillIndex.delete(currentNormalized);
+  }
+
+  roleRegistry.delete(currentNormalized);
+  roleRegistry.add(nextNormalized);
+
+  Object.values(skillRegistry).forEach((definition) => {
+    if (!definition.roles.includes(currentNormalized)) {
+      return;
+    }
+    const roles = Array.from(
+      new Set(
+        definition.roles.map((role) => (role === currentNormalized ? nextNormalized : role))
+      )
+    ) as TeamRole[];
+    upsertSkillDefinition({ ...definition, roles }, { silent: true });
+  });
+
+  rebuildRoleIndex();
+  notifyRegistryChange();
+};
+
+export const setRoleSkills = (role: TeamRole, skillIds: string[]): void => {
+  const normalizedRole = registerRoleValue(role);
+  if (!normalizedRole) {
+    return;
+  }
+
+  const normalizedSkillIds = new Set<string>(
+    skillIds.map((id) => id.trim()).filter((id) => id.length > 0)
+  );
+
+  Object.values(skillRegistry).forEach((definition) => {
+    const hasRole = definition.roles.includes(normalizedRole);
+    const shouldHaveRole = normalizedSkillIds.has(definition.id);
+
+    if (hasRole === shouldHaveRole) {
+      return;
+    }
+
+    const roles = shouldHaveRole
+      ? [...definition.roles, normalizedRole]
+      : definition.roles.filter((value) => value !== normalizedRole);
+
+    upsertSkillDefinition({ ...definition, roles }, { silent: true });
+  });
+
+  rebuildRoleIndex();
+  notifyRegistryChange();
 };

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -579,7 +579,6 @@ type StoredSkillRegistry = {
 
 const resetRegistry = () => {
   roleRegistry.clear();
-  defaultTeamRoles.forEach((role) => roleRegistry.add(role));
   roleSkillIndex.clear();
   Object.keys(skillRegistry).forEach((key) => {
     delete skillRegistry[key];
@@ -759,9 +758,8 @@ const upsertSkillDefinition = (
 const hydrateRegistry = (snapshot: StoredSkillRegistry | null) => {
   resetRegistry();
 
-  if (snapshot?.roles) {
-    snapshot.roles.forEach((role) => registerRoleValue(role));
-  }
+  const baseRoles = snapshot?.roles ?? defaultTeamRoles;
+  baseRoles.forEach((role) => registerRoleValue(role));
 
   const definitions = snapshot?.skills ?? Object.values(initialSkills);
   definitions.forEach((definition) => {

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -37,6 +37,9 @@ export type SkillDefinition = {
   roles: TeamRole[];
 };
 
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string');
+
 export const slugifySkillId = (name: string): string => {
   const normalized = name.trim().toLowerCase();
   const base = normalized
@@ -563,9 +566,80 @@ const skillRegistry: Record<string, SkillDefinition> = {};
 const roleSkillIndex = new Map<TeamRole, Set<string>>();
 const roleRegistry = new Set<TeamRole>(defaultTeamRoles);
 
+const ROLE_SKILL_STORAGE_KEY = 'role-competency-registry:v1';
+
 let roleToSkillsMap: Record<TeamRole, string[]> = {} as Record<TeamRole, string[]>;
 let registryVersion = 0;
 const registryListeners = new Set<SkillListener>();
+
+type StoredSkillRegistry = {
+  roles: TeamRole[];
+  skills: SkillDefinition[];
+};
+
+const resetRegistry = () => {
+  roleRegistry.clear();
+  defaultTeamRoles.forEach((role) => roleRegistry.add(role));
+  roleSkillIndex.clear();
+  Object.keys(skillRegistry).forEach((key) => {
+    delete skillRegistry[key];
+  });
+};
+
+const isStoredSkillDefinition = (value: unknown): value is SkillDefinition => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.id === 'string' &&
+    typeof candidate.name === 'string' &&
+    typeof candidate.description === 'string' &&
+    ['hard', 'soft', 'domain'].includes(candidate.category as string) &&
+    isStringArray(candidate.sources) &&
+    isStringArray(candidate.roles) &&
+    ['A', 'W', 'P', 'Ad', 'E'].includes(candidate.recommendedLevel as string) &&
+    ['claimed', 'screened', 'observed', 'validated', 'refuted'].includes(
+      candidate.evidenceStatus as string
+    )
+  );
+};
+
+const loadRegistryFromStorage = (): StoredSkillRegistry | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const rawValue = window.localStorage.getItem(ROLE_SKILL_STORAGE_KEY);
+    if (!rawValue) {
+      return null;
+    }
+
+    const parsed = JSON.parse(rawValue) as unknown;
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+
+    const snapshot = parsed as Partial<StoredSkillRegistry>;
+
+    if (!Array.isArray(snapshot.skills) || !snapshot.skills.every(isStoredSkillDefinition)) {
+      return null;
+    }
+
+    const roles = Array.isArray(snapshot.roles)
+      ? snapshot.roles.filter((role): role is TeamRole => typeof role === 'string')
+      : [];
+
+    return {
+      roles,
+      skills: snapshot.skills
+    };
+  } catch {
+    return null;
+  }
+};
 
 const normalizeRole = (role: TeamRole): TeamRole | null => {
   const normalized = role.trim();
@@ -579,6 +653,23 @@ const registerRoleValue = (role: TeamRole): TeamRole | null => {
   }
   roleRegistry.add(normalized);
   return normalized;
+};
+
+const persistRegistry = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    const payload: StoredSkillRegistry = {
+      roles: Array.from(roleRegistry).sort((a, b) => a.localeCompare(b, 'ru')),
+      skills: Object.values(skillRegistry).sort((a, b) => a.name.localeCompare(b.name, 'ru'))
+    };
+
+    window.localStorage.setItem(ROLE_SKILL_STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // ignore storage errors
+  }
 };
 
 const rebuildRoleIndex = () => {
@@ -598,6 +689,7 @@ const rebuildRoleIndex = () => {
 
 const notifyRegistryChange = () => {
   registryVersion += 1;
+  persistRegistry();
   registryListeners.forEach((listener) => {
     try {
       listener();
@@ -664,9 +756,24 @@ const upsertSkillDefinition = (
   return normalized;
 };
 
-Object.values(initialSkills).forEach((definition) => {
-  upsertSkillDefinition(definition, { silent: true });
-});
+const hydrateRegistry = (snapshot: StoredSkillRegistry | null) => {
+  resetRegistry();
+
+  if (snapshot?.roles) {
+    snapshot.roles.forEach((role) => registerRoleValue(role));
+  }
+
+  const definitions = snapshot?.skills ?? Object.values(initialSkills);
+  definitions.forEach((definition) => {
+    upsertSkillDefinition(definition, { silent: true });
+  });
+
+  rebuildRoleIndex();
+
+  persistRegistry();
+};
+
+hydrateRegistry(loadRegistryFromStorage());
 
 export const skills = skillRegistry;
 

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -37,6 +37,25 @@ export type SkillDefinition = {
   roles: TeamRole[];
 };
 
+export const slugifySkillId = (name: string): string => {
+  const normalized = name.trim().toLowerCase();
+  const base = normalized
+    .replace(/[^0-9a-zа-яё\s-]+/gi, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+  const fallback = base || 'skill';
+
+  let candidate = fallback;
+  let counter = 1;
+  while (skillRegistry[candidate]) {
+    candidate = `${fallback}-${counter}`;
+    counter += 1;
+  }
+
+  return candidate;
+};
+
 export const defaultTeamRoles: TeamRole[] = [
   'Владелец продукта',
   'Эксперт R&D',
@@ -691,6 +710,46 @@ export const getSkillNameById = (skillId: string): string | undefined => skillRe
 export const findSkillByName = (name: string): SkillDefinition | undefined => {
   const normalized = name.trim().toLowerCase();
   return Object.values(skillRegistry).find((skill) => skill.name.toLowerCase() === normalized);
+};
+
+export const registerAdHocSkill = (
+  name: string,
+  category: Exclude<SkillCategory, 'domain'>,
+  roles: TeamRole[] = []
+): SkillDefinition | null => {
+  const normalizedName = name.trim();
+  if (!normalizedName) {
+    return null;
+  }
+
+  const existing = findSkillByName(normalizedName);
+
+  const normalizedRoles = Array.from(
+    new Set(
+      roles
+        .map((role) => registerRoleValue(role))
+        .filter((role): role is TeamRole => Boolean(role))
+    )
+  );
+
+  const mergedRoles = Array.from(
+    new Set([...(existing?.roles ?? []), ...normalizedRoles])
+  ) as TeamRole[];
+
+  const definition: SkillDefinition = existing
+    ? { ...existing, roles: mergedRoles }
+    : {
+        id: slugifySkillId(normalizedName),
+        name: normalizedName,
+        description: normalizedName,
+        category,
+        sources: [],
+        recommendedLevel: 'P',
+        evidenceStatus: 'claimed',
+        roles: mergedRoles
+      };
+
+  return upsertSkillDefinition(definition);
 };
 
 export const registerRole = (role: TeamRole): TeamRole | null => {


### PR DESCRIPTION
## Summary
- add an administration tab for managing roles, renaming/creating/removing them, and editing hard/soft skill assignments
- extend the skills registry to support dynamic role management and expose new helpers
- style the new role competency editor alongside the existing admin layouts

## Testing
- npm test -- --runInBand
- npm run lint *(fails: existing lint errors in unrelated files such as App.tsx, StatsDashboard.tsx, ExpertExplorer.tsx, etc.)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69235e861eb08332b3f0f8110d3bbb8d)