### PR TITLE
Include initiatives in active node layout tracking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2020,9 +2020,10 @@ function App() {
     moduleData.forEach((module) => ids.add(module.id));
     artifactData.forEach((artifact) => ids.add(artifact.id));
     flattenDomainTree(domainData).forEach((domain) => ids.add(domain.id));
+    initiativeData.forEach((initiative) => ids.add(initiative.id));
 
     return ids;
-  }, [artifactData, domainData, moduleData]);
+  }, [artifactData, domainData, initiativeData, moduleData]);
 
   const handleLayoutChange = useCallback(
     (positions: Record<string, GraphLayoutNodePosition>, reason: 'drag' | 'engine') => {

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -334,6 +334,20 @@ const GraphView: React.FC<GraphViewProps> = ({
   );
 
   const nodes = useMemo(() => {
+    const targetIds = new Set(
+      domainNodes
+        .map((node) => node.id)
+        .concat(artifactNodes.map((node) => node.id))
+        .concat(moduleNodes.map((node) => node.id))
+        .concat(initiativeNodes.map((node) => node.id))
+    );
+
+    nodeCacheRef.current.forEach((_, id) => {
+      if (!targetIds.has(id)) {
+        nodeCacheRef.current.delete(id);
+      }
+    });
+
     const nextNodes: ForceNode[] = [];
 
     const upsertNode = (node: GraphNode) => {
@@ -844,41 +858,53 @@ const GraphView: React.FC<GraphViewProps> = ({
         return;
       }
 
-      const entries: Array<[string, GraphLayoutNodePosition]> = [];
-    nodeCacheRef.current.forEach((node, id) => {
-      if (
-        typeof node.x !== 'number' ||
-        Number.isNaN(node.x) ||
-        typeof node.y !== 'number' ||
-        Number.isNaN(node.y)
-      ) {
+      if (nodeCacheRef.current.size === 0 || nodes.length === 0) {
         return;
       }
 
-      const payload: GraphLayoutNodePosition = {
-        x: roundCoordinate(node.x),
-        y: roundCoordinate(node.y)
-      };
+      const visibleIds = new Set(nodes.map((node) => node.id));
+      const entries: Array<[string, GraphLayoutNodePosition]> = [];
 
-      if (typeof node.fx === 'number' && !Number.isNaN(node.fx)) {
-        payload.fx = roundCoordinate(node.fx);
+      nodeCacheRef.current.forEach((node, id) => {
+        if (!visibleIds.has(id)) {
+          return;
+        }
+
+        if (
+          typeof node.x !== 'number' ||
+          Number.isNaN(node.x) ||
+          typeof node.y !== 'number' ||
+          Number.isNaN(node.y)
+        ) {
+          return;
+        }
+
+        const payload: GraphLayoutNodePosition = {
+          x: roundCoordinate(node.x),
+          y: roundCoordinate(node.y)
+        };
+
+        if (typeof node.fx === 'number' && !Number.isNaN(node.fx)) {
+          payload.fx = roundCoordinate(node.fx);
+        }
+
+        if (typeof node.fy === 'number' && !Number.isNaN(node.fy)) {
+          payload.fy = roundCoordinate(node.fy);
+        }
+
+        entries.push([id, payload]);
+      });
+
+      const serialized = JSON.stringify(Object.fromEntries(entries));
+      if (serialized === lastReportedLayoutRef.current) {
+        return;
       }
 
-      if (typeof node.fy === 'number' && !Number.isNaN(node.fy)) {
-        payload.fy = roundCoordinate(node.fy);
-      }
-
-      entries.push([id, payload]);
-    });
-
-    const serialized = JSON.stringify(Object.fromEntries(entries));
-    if (serialized === lastReportedLayoutRef.current) {
-      return;
-    }
-
-    lastReportedLayoutRef.current = serialized;
-    onLayoutChange(Object.fromEntries(entries), reason);
-  }, [onLayoutChange]);
+      lastReportedLayoutRef.current = serialized;
+      onLayoutChange(Object.fromEntries(entries), reason);
+    },
+    [nodes, onLayoutChange]
+  );
 
   const handleNodeDragEnd = useCallback(
     (node: ForceNode) => {

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -528,9 +528,41 @@ const GraphView: React.FC<GraphViewProps> = ({
     scheduleCameraCapture(320);
   }, [getViewportSize, scheduleCameraCapture]);
 
+  const graphStructureKey = useMemo(() => {
+    const nodeKey = nodes
+      .map((node) => node.id)
+      .sort()
+      .join('|');
+
+    const linkKey = graphLinks
+      .map((link) => {
+        const source =
+          typeof link.source === 'object' && link.source !== null
+            ? (link.source as ForceNode).id
+            : String(link.source);
+        const target =
+          typeof link.target === 'object' && link.target !== null
+            ? (link.target as ForceNode).id
+            : String(link.target);
+
+        return `${source}->${target}:${link.type}`;
+      })
+      .sort()
+      .join('|');
+
+    return `${nodeKey}__${linkKey}`;
+  }, [graphLinks, nodes]);
+
+  const lastGraphStructureRef = useRef<string>('');
+
   useEffect(() => {
+    if (graphStructureKey === lastGraphStructureRef.current) {
+      return;
+    }
+
+    lastGraphStructureRef.current = graphStructureKey;
     restoreCamera();
-  }, [graphData, restoreCamera]);
+  }, [graphStructureKey, restoreCamera]);
 
   useEffect(() => {
     if (!normalizationRequest || nodes.length === 0) {

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -938,8 +938,21 @@ const GraphView: React.FC<GraphViewProps> = ({
     [nodes, onLayoutChange]
   );
 
+  const handleNodeDragStart = useCallback(
+    (node: ForceNode) => {
+      if (node) {
+        onSelect(node);
+      }
+    },
+    [onSelect]
+  );
+
   const handleNodeDragEnd = useCallback(
     (node: ForceNode) => {
+      if (node) {
+        onSelect(node);
+      }
+
       if (node && typeof node.id === 'string') {
         const layout = layoutPositions[node.id];
         const hasFixedX = typeof layout?.fx === 'number' && Number.isFinite(layout.fx);
@@ -990,7 +1003,7 @@ const GraphView: React.FC<GraphViewProps> = ({
 
       emitLayoutUpdate('drag');
     },
-    [emitLayoutUpdate, layoutPositions]
+    [emitLayoutUpdate, layoutPositions, onSelect]
   );
 
   const handleEngineStop = useCallback(() => {
@@ -1059,6 +1072,9 @@ const GraphView: React.FC<GraphViewProps> = ({
               }}
               onNodeDoubleClick={(node) => {
                 handleNodeDoubleClick(node as ForceNode);
+              }}
+              onNodeDragStart={(node) => {
+                handleNodeDragStart(node as ForceNode);
               }}
               onNodeDragEnd={handleNodeDragEnd}
               onEngineStop={handleEngineStop}


### PR DESCRIPTION
## Summary
- include initiative ids when tracking active graph nodes for layout updates
- prevent initiative layout data from being pruned, keeping node and link alignment when dragging without a selection

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692774af52b083329e9f774df05d2748)