### PR TITLE
Refine graph visuals with interactive hover styling

### DIFF
--- a/src/components/ExpertExplorer.module.css
+++ b/src/components/ExpertExplorer.module.css
@@ -271,6 +271,21 @@
   background-position: -1px -1px;
 }
 
+:global(.Theme_preset_cyberpunk) .graphContainer {
+  background-color: #0f111a;
+  background-image:
+    linear-gradient(
+      0deg,
+      rgba(255, 255, 255, 0.06) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.06) 1px,
+      transparent 1px
+    );
+}
+
 .graphContainer :global(canvas) {
   background: transparent;
   filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.12));

--- a/src/components/ExpertExplorer.module.css
+++ b/src/components/ExpertExplorer.module.css
@@ -255,6 +255,25 @@
   border: 1px solid var(--color-bg-border);
   border-radius: 12px;
   overflow: hidden;
+  background-color: #ffffff;
+  background-image:
+    linear-gradient(
+      0deg,
+      rgba(0, 0, 0, 0.04) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0.04) 1px,
+      transparent 1px
+    );
+  background-size: 48px 48px;
+  background-position: -1px -1px;
+}
+
+.graphContainer :global(canvas) {
+  background: transparent;
+  filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.12));
 }
 
 .graphPlaceholder {

--- a/src/components/ExpertExplorer.tsx
+++ b/src/components/ExpertExplorer.tsx
@@ -291,6 +291,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   const [isSkillGraphVisible, setIsSkillGraphVisible] = useState(true);
   const [isRoleGraphVisible, setIsRoleGraphVisible] = useState(true);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+  const [selectedGraphNodeId, setSelectedGraphNodeId] = useState<string | null>(null);
 
   const graphRef = useRef<ForceGraphMethods | null>(null);
   const initialGraphZoomAppliedRef = useRef<Record<'graph' | 'assignments', boolean>>({
@@ -1644,6 +1645,28 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   }, [assignmentNeighborMap, roleNeighborMap, skillNeighborMap, viewMode]);
 
   useEffect(() => {
+    if (!selectedGraphNodeId) {
+      return;
+    }
+
+    if (!activeNeighborMap.has(selectedGraphNodeId)) {
+      setSelectedGraphNodeId(null);
+    }
+  }, [activeNeighborMap, selectedGraphNodeId]);
+
+  const focusNodeId = useMemo(() => {
+    if (hoveredNodeId) {
+      return hoveredNodeId;
+    }
+
+    if (selectedGraphNodeId && activeNeighborMap.has(selectedGraphNodeId)) {
+      return selectedGraphNodeId;
+    }
+
+    return null;
+  }, [activeNeighborMap, hoveredNodeId, selectedGraphNodeId]);
+
+  useEffect(() => {
     if (viewMode !== 'roles') {
       return;
     }
@@ -1976,6 +1999,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
       }
 
       const typed = node as ForceNode;
+      setSelectedGraphNodeId(typed.id);
       if (typed.type === 'expert') {
         handleSelectExpert(typed.originId);
         return;
@@ -2082,21 +2106,21 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
       const isSolid =
         typed.type === 'expert' || typed.type === 'role' || typed.type === 'initiative';
       const isHighlighted = highlightNodeIds.has(typed.id);
-      const isHovered = hoveredNodeId === typed.id;
+      const isFocusTarget = focusNodeId === typed.id;
       const isNeighbor =
-        hoveredNodeId && activeNeighborMap.get(hoveredNodeId)?.has(typed.id)
-          ? hoveredNodeId !== typed.id
+        focusNodeId && activeNeighborMap.get(focusNodeId)?.has(typed.id)
+          ? focusNodeId !== typed.id
           : false;
-      const hoverFactor = !hoveredNodeId
+      const hoverFactor = !focusNodeId
         ? 1
-        : isHovered
+        : isFocusTarget
           ? 1
           : isNeighbor
             ? 0.55
             : 0.18;
       const selectionDim =
         highlightNodeIds.size > 0 && !isHighlighted && !highlightNodeIds.has(typed.id) ? 0.28 : 1;
-      const baseAlpha = isHighlighted || isHovered ? 1 : isSolid ? 0.95 : 0.85;
+      const baseAlpha = isHighlighted || isFocusTarget ? 1 : isSolid ? 0.95 : 0.85;
       const effectiveAlpha = Math.max(0.1, Math.min(1, baseAlpha * selectionDim * hoverFactor));
 
       const scaleFactor = Math.max(0.75, Math.min(1.35, 1 / Math.sqrt(globalScale)));
@@ -2108,7 +2132,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
 
       const label = typed.label;
       const labelFontSize = Math.max(12 / Math.sqrt(globalScale), 9);
-      const shouldShowLabel = isHighlighted || isHovered || globalScale >= 0.95;
+      const shouldShowLabel = isHighlighted || isFocusTarget || globalScale >= 0.95;
       const textY = (node.y ?? 0) + outerRadius + 8;
 
       ctx.save();
@@ -2132,7 +2156,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
       ctx.fillStyle = accent;
       ctx.fill();
 
-      if (isHovered || isHighlighted) {
+      if (isFocusTarget || isHighlighted) {
         ctx.beginPath();
         ctx.arc(node.x ?? 0, node.y ?? 0, haloRadius, 0, 2 * Math.PI, false);
         ctx.strokeStyle = withAlpha(accent, 0.25);
@@ -2141,12 +2165,12 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
       }
 
       if (shouldShowLabel) {
-        const textAlpha = isHighlighted || isHovered ? 1 : effectiveAlpha;
+        const textAlpha = isHighlighted || isFocusTarget ? 1 : effectiveAlpha;
         ctx.globalAlpha = textAlpha;
         ctx.font = `${labelFontSize}px "Inter", "Segoe UI", sans-serif`;
         ctx.textAlign = 'center';
         ctx.textBaseline = 'top';
-        if (isHovered || isHighlighted) {
+        if (isFocusTarget || isHighlighted) {
           ctx.lineWidth = Math.max(2, labelFontSize / 3);
           ctx.strokeStyle = 'rgba(255, 255, 255, 0.92)';
           ctx.strokeText(label, node.x ?? 0, textY);
@@ -2157,7 +2181,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
 
       ctx.restore();
     },
-    [activeNeighborMap, highlightNodeIds, hoveredNodeId, palette]
+    [activeNeighborMap, focusNodeId, highlightNodeIds, palette]
   );
 
   const linkColor = useCallback(
@@ -2165,13 +2189,13 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
       const typed = link as ForceLink;
       const sourceId = typeof link.source === 'object' ? link.source.id : String(link.source);
       const targetId = typeof link.target === 'object' ? link.target.id : String(link.target);
-      const isHoverActive = Boolean(hoveredNodeId);
-      const isDirectHover = hoveredNodeId && (sourceId === hoveredNodeId || targetId === hoveredNodeId);
+      const isHoverActive = Boolean(focusNodeId);
+      const isDirectHover = focusNodeId && (sourceId === focusNodeId || targetId === focusNodeId);
       const isNeighborHover =
-        hoveredNodeId &&
-        (activeNeighborMap.get(hoveredNodeId)?.has(sourceId) ||
-          activeNeighborMap.get(hoveredNodeId)?.has(targetId));
-      const hoverTier = !hoveredNodeId
+        focusNodeId &&
+        (activeNeighborMap.get(focusNodeId)?.has(sourceId) ||
+          activeNeighborMap.get(focusNodeId)?.has(targetId));
+      const hoverTier = !focusNodeId
         ? 'none'
         : isDirectHover
           ? 'focused'
@@ -2218,7 +2242,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
       }
       return withAlpha(baseColor, 0.16);
     },
-    [activeNeighborMap, highlightLinkIds, hoveredNodeId, palette]
+    [activeNeighborMap, focusNodeId, highlightLinkIds, palette]
   );
 
   const linkWidth = useCallback(

--- a/src/components/ExpertExplorer.tsx
+++ b/src/components/ExpertExplorer.tsx
@@ -217,6 +217,29 @@ const getNodeRenderRadius = (node: ForceNode): number => {
   return baseRadius + Math.min(8, connectionIntensity * 2);
 };
 
+const buildNeighborMap = (nodes: ForceNode[], links: ForceLink[]): Map<string, Set<string>> => {
+  const map = new Map<string, Set<string>>();
+  nodes.forEach((node) => {
+    map.set(node.id, new Set());
+  });
+
+  links.forEach((link) => {
+    const sourceId = typeof link.source === 'object' ? link.source.id : String(link.source);
+    const targetId = typeof link.target === 'object' ? link.target.id : String(link.target);
+
+    const sourceSet = map.get(sourceId);
+    const targetSet = map.get(targetId);
+    if (sourceSet) {
+      sourceSet.add(targetId);
+    }
+    if (targetSet) {
+      targetSet.add(sourceId);
+    }
+  });
+
+  return map;
+};
+
 const skillTypeLabel: Record<SkillFocus['type'], string> = {
   domain: 'Домен',
   competency: 'Компетенция',
@@ -267,6 +290,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   const [roleGraphInstanceKey, setRoleGraphInstanceKey] = useState(0);
   const [isSkillGraphVisible, setIsSkillGraphVisible] = useState(true);
   const [isRoleGraphVisible, setIsRoleGraphVisible] = useState(true);
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
 
   const graphRef = useRef<ForceGraphMethods | null>(null);
   const initialGraphZoomAppliedRef = useRef<Record<'graph' | 'assignments', boolean>>({
@@ -1393,6 +1417,10 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   }, [viewMode]);
 
   useEffect(() => {
+    setHoveredNodeId(null);
+  }, [graphInstanceKey, roleGraphInstanceKey, viewMode]);
+
+  useEffect(() => {
     if (!isSkillGraphVisible || (viewMode !== 'graph' && viewMode !== 'assignments')) {
       return;
     }
@@ -1589,6 +1617,31 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
 
     return { nodes, links };
   }, [selectedRoleAggregate]);
+
+  const skillNeighborMap = useMemo(
+    () => buildNeighborMap(skillGraphNodes, skillGraphLinks),
+    [skillGraphLinks, skillGraphNodes]
+  );
+
+  const assignmentNeighborMap = useMemo(
+    () => buildNeighborMap(assignmentGraphNodes, assignmentGraphLinks),
+    [assignmentGraphLinks, assignmentGraphNodes]
+  );
+
+  const roleNeighborMap = useMemo(
+    () => buildNeighborMap(roleGraphData.nodes, roleGraphData.links),
+    [roleGraphData.links, roleGraphData.nodes]
+  );
+
+  const activeNeighborMap = useMemo(() => {
+    if (viewMode === 'roles') {
+      return roleNeighborMap;
+    }
+    if (viewMode === 'assignments') {
+      return assignmentNeighborMap;
+    }
+    return skillNeighborMap;
+  }, [assignmentNeighborMap, roleNeighborMap, skillNeighborMap, viewMode]);
 
   useEffect(() => {
     if (viewMode !== 'roles') {
@@ -2008,11 +2061,8 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
   const nodeCanvasObject = useCallback(
     (node: NodeObject, ctx: CanvasRenderingContext2D, globalScale: number) => {
       const typed = node as ForceNode;
-
-      const connectionIntensity = Math.sqrt(Math.max(typed.connectionCount ?? 0, 0));
       const radius = getNodeRenderRadius(typed);
-
-      const baseColor =
+      const accent =
         typed.type === 'expert'
           ? palette.expert
           : typed.type === 'initiative'
@@ -2032,66 +2082,94 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
       const isSolid =
         typed.type === 'expert' || typed.type === 'role' || typed.type === 'initiative';
       const isHighlighted = highlightNodeIds.has(typed.id);
-      const fillColor = isHighlighted || isSolid ? baseColor : withAlpha(baseColor, 0.22);
-      const accentTextColor = getReadableTextColor(baseColor, palette);
-      const labelTextColor = getReadableTextColor(palette.background, palette);
-      const solidTextColor = accentTextColor === labelTextColor ? accentTextColor : labelTextColor;
+      const isHovered = hoveredNodeId === typed.id;
+      const isNeighbor =
+        hoveredNodeId && activeNeighborMap.get(hoveredNodeId)?.has(typed.id)
+          ? hoveredNodeId !== typed.id
+          : false;
+      const isHoverRelated = !hoveredNodeId || isHovered || isNeighbor;
+      const selectionDim =
+        highlightNodeIds.size > 0 && !isHighlighted && !highlightNodeIds.has(typed.id) ? 0.28 : 1;
+      const baseAlpha = isHighlighted || isHovered ? 1 : isSolid ? 0.95 : 0.85;
+      const effectiveAlpha = Math.max(
+        0.1,
+        Math.min(1, baseAlpha * selectionDim * (isHoverRelated ? 1 : 0.18))
+      );
 
-      const fontSizeBase =
-        typed.type === 'expert'
-          ? 16
-          : typed.type === 'initiative'
-            ? 15
-            : typed.type === 'role'
-              ? 15
-              : typed.type === 'module' || typed.type === 'domain'
-                ? 14
-                : 12;
-      const fontSize =
-        (fontSizeBase + Math.min(4, connectionIntensity)) /
-        Math.sqrt(Math.max(globalScale, 0.6));
-      const textY = (node.y ?? 0) + radius + 4;
+      const scaleFactor = Math.max(0.75, Math.min(1.35, 1 / Math.sqrt(globalScale)));
+      const outerRadius = radius * scaleFactor;
+      const shellThickness = Math.max(2.5, Math.min(6, outerRadius * 0.28));
+      const coreRadius = Math.max(outerRadius * 0.45, outerRadius - shellThickness * 1.6);
+      const haloRadius = outerRadius + shellThickness * 0.9;
+      const shadowBlur = Math.max(6, Math.min(16, outerRadius * 1.15));
+
+      const label = typed.label;
+      const labelFontSize = Math.max(12 / Math.sqrt(globalScale), 9);
+      const shouldShowLabel = isHighlighted || isHoverRelated || globalScale >= 0.95;
+      const textY = (node.y ?? 0) + outerRadius + 8;
 
       ctx.save();
+      ctx.globalAlpha = effectiveAlpha;
+      ctx.shadowColor = withAlpha(accent, 0.32);
+      ctx.shadowBlur = shadowBlur;
+      ctx.shadowOffsetY = 2;
+
       ctx.beginPath();
-      ctx.arc(node.x ?? 0, node.y ?? 0, radius, 0, 2 * Math.PI, false);
-      ctx.fillStyle = fillColor;
-      ctx.globalAlpha = isHighlighted || isSolid ? 1 : 0.9;
+      ctx.arc(node.x ?? 0, node.y ?? 0, outerRadius, 0, 2 * Math.PI, false);
+      ctx.fillStyle = '#FFFFFF';
+      ctx.fill();
+      ctx.lineWidth = shellThickness;
+      ctx.strokeStyle = accent;
+      ctx.stroke();
+
+      ctx.shadowBlur = 0;
+      ctx.shadowOffsetY = 0;
+      ctx.beginPath();
+      ctx.arc(node.x ?? 0, node.y ?? 0, coreRadius, 0, 2 * Math.PI, false);
+      ctx.fillStyle = accent;
       ctx.fill();
 
-      if (isHighlighted) {
-        ctx.lineWidth = 2;
-        ctx.strokeStyle = baseColor;
+      if (isHovered || isHighlighted) {
+        ctx.beginPath();
+        ctx.arc(node.x ?? 0, node.y ?? 0, haloRadius, 0, 2 * Math.PI, false);
+        ctx.strokeStyle = withAlpha(accent, 0.25);
+        ctx.lineWidth = Math.max(2, shellThickness * 0.9);
         ctx.stroke();
       }
-      ctx.restore();
 
-      ctx.save();
-      ctx.font = `${fontSize}px "Inter", "Segoe UI", sans-serif`;
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'top';
-
-      if (isHighlighted) {
-        ctx.lineWidth = Math.max(2, fontSize / 3);
-        ctx.strokeStyle = withAlpha(palette.background, 0.9);
-        ctx.strokeText(typed.label, node.x ?? 0, textY);
-        ctx.fillStyle = solidTextColor;
-      } else {
-        ctx.fillStyle = isSolid ? solidTextColor : labelTextColor;
-        if (!isSolid) {
-          ctx.globalAlpha = Math.min(0.95, 0.55 + globalScale * 0.2);
+      if (shouldShowLabel) {
+        const textAlpha = isHighlighted || isHovered ? 1 : Math.max(effectiveAlpha, 0.65);
+        ctx.globalAlpha = textAlpha;
+        ctx.font = `${labelFontSize}px "Inter", "Segoe UI", sans-serif`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'top';
+        if (isHovered || isHighlighted) {
+          ctx.lineWidth = Math.max(2, labelFontSize / 3);
+          ctx.strokeStyle = 'rgba(255, 255, 255, 0.92)';
+          ctx.strokeText(label, node.x ?? 0, textY);
         }
+        ctx.fillStyle = palette.text;
+        ctx.fillText(label, node.x ?? 0, textY);
       }
 
-      ctx.fillText(typed.label, node.x ?? 0, textY);
       ctx.restore();
     },
-    [highlightNodeIds, palette]
+    [activeNeighborMap, highlightNodeIds, hoveredNodeId, palette]
   );
 
   const linkColor = useCallback(
     (link: LinkObject) => {
       const typed = link as ForceLink;
+      const sourceId = typeof link.source === 'object' ? link.source.id : String(link.source);
+      const targetId = typeof link.target === 'object' ? link.target.id : String(link.target);
+      const isHoverActive = Boolean(hoveredNodeId);
+      const isHoverRelated =
+        !hoveredNodeId ||
+        sourceId === hoveredNodeId ||
+        targetId === hoveredNodeId ||
+        activeNeighborMap.get(hoveredNodeId)?.has(sourceId) ||
+        activeNeighborMap.get(hoveredNodeId)?.has(targetId);
+
       if (typed.id && highlightLinkIds.has(typed.id)) {
         return palette.edgeHighlight;
       }
@@ -2108,11 +2186,16 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
         return palette.planEdge;
       }
       if (typed.type === 'soft') {
-        return withAlpha(palette.soft, 0.45);
+        const softColor = withAlpha(palette.soft, 0.45);
+        return isHoverActive && !isHoverRelated ? withAlpha(palette.soft, 0.16) : softColor;
       }
-      return palette.edge;
+      const baseColor = palette.edge;
+      if (isHoverActive && !isHoverRelated) {
+        return withAlpha(baseColor, 0.16);
+      }
+      return baseColor;
     },
-    [highlightLinkIds, palette]
+    [activeNeighborMap, highlightLinkIds, hoveredNodeId, palette]
   );
 
   const linkWidth = useCallback(
@@ -2521,10 +2604,13 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
                   width={graphDimensions.width}
                   height={graphDimensions.height}
                   graphData={displayedSkillGraphData}
-                  backgroundColor={palette.background}
+                  backgroundColor="rgba(255, 255, 255, 0)"
                   nodeRelSize={4}
                   cooldownTicks={80}
                   onNodeClick={handleNodeClick}
+                  onNodeHover={(node) =>
+                    setHoveredNodeId(node ? (node as ForceNode).id : null)
+                  }
                   nodeCanvasObject={nodeCanvasObject}
                   nodeCanvasObjectMode={() => 'replace'}
                   linkColor={linkColor}
@@ -2685,10 +2771,13 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
                   width={graphDimensions.width}
                   height={graphDimensions.height}
                   graphData={assignmentGraphData}
-                  backgroundColor={palette.background}
+                  backgroundColor="rgba(255, 255, 255, 0)"
                   nodeRelSize={4}
                   cooldownTicks={80}
                   onNodeClick={handleNodeClick}
+                  onNodeHover={(node) =>
+                    setHoveredNodeId(node ? (node as ForceNode).id : null)
+                  }
                   nodeCanvasObject={nodeCanvasObject}
                   nodeCanvasObjectMode={() => 'replace'}
                   linkColor={linkColor}
@@ -2826,10 +2915,13 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
                             width={roleGraphDimensions.width}
                             height={roleGraphDimensions.height}
                             graphData={roleGraphData}
-                            backgroundColor={palette.background}
+                            backgroundColor="rgba(255, 255, 255, 0)"
                             nodeRelSize={4}
                             cooldownTicks={80}
                             onNodeClick={handleNodeClick}
+                            onNodeHover={(node) =>
+                              setHoveredNodeId(node ? (node as ForceNode).id : null)
+                            }
                             nodeCanvasObject={nodeCanvasObject}
                             nodeCanvasObjectMode={() => 'replace'}
                             linkColor={linkColor}
@@ -3256,16 +3348,6 @@ function areExpertPalettesEqual(a: ExpertPalette, b: ExpertPalette): boolean {
     a.initiativeEdge === b.initiativeEdge &&
     a.planEdge === b.planEdge
   );
-}
-
-function getReadableTextColor(backgroundColor: string, palette: ExpertPalette): string {
-  const rgb = parseColor(backgroundColor);
-  if (!rgb) {
-    return palette.textOnAccent;
-  }
-
-  const brightness = (rgb.r * 299 + rgb.g * 587 + rgb.b * 114) / 1000;
-  return brightness > 180 ? palette.text : palette.textOnAccent;
 }
 
 function parseColor(color: string): RGBColor | null {

--- a/src/components/ExpertExplorer.tsx
+++ b/src/components/ExpertExplorer.tsx
@@ -2087,14 +2087,17 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
         hoveredNodeId && activeNeighborMap.get(hoveredNodeId)?.has(typed.id)
           ? hoveredNodeId !== typed.id
           : false;
-      const isHoverRelated = !hoveredNodeId || isHovered || isNeighbor;
+      const hoverFactor = !hoveredNodeId
+        ? 1
+        : isHovered
+          ? 1
+          : isNeighbor
+            ? 0.55
+            : 0.18;
       const selectionDim =
         highlightNodeIds.size > 0 && !isHighlighted && !highlightNodeIds.has(typed.id) ? 0.28 : 1;
       const baseAlpha = isHighlighted || isHovered ? 1 : isSolid ? 0.95 : 0.85;
-      const effectiveAlpha = Math.max(
-        0.1,
-        Math.min(1, baseAlpha * selectionDim * (isHoverRelated ? 1 : 0.18))
-      );
+      const effectiveAlpha = Math.max(0.1, Math.min(1, baseAlpha * selectionDim * hoverFactor));
 
       const scaleFactor = Math.max(0.75, Math.min(1.35, 1 / Math.sqrt(globalScale)));
       const outerRadius = radius * scaleFactor;
@@ -2163,12 +2166,18 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
       const sourceId = typeof link.source === 'object' ? link.source.id : String(link.source);
       const targetId = typeof link.target === 'object' ? link.target.id : String(link.target);
       const isHoverActive = Boolean(hoveredNodeId);
-      const isHoverRelated =
-        !hoveredNodeId ||
-        sourceId === hoveredNodeId ||
-        targetId === hoveredNodeId ||
-        activeNeighborMap.get(hoveredNodeId)?.has(sourceId) ||
-        activeNeighborMap.get(hoveredNodeId)?.has(targetId);
+      const isDirectHover = hoveredNodeId && (sourceId === hoveredNodeId || targetId === hoveredNodeId);
+      const isNeighborHover =
+        hoveredNodeId &&
+        (activeNeighborMap.get(hoveredNodeId)?.has(sourceId) ||
+          activeNeighborMap.get(hoveredNodeId)?.has(targetId));
+      const hoverTier = !hoveredNodeId
+        ? 'none'
+        : isDirectHover
+          ? 'focused'
+          : isNeighborHover
+            ? 'neighbor'
+            : 'dim';
 
       if (typed.id && highlightLinkIds.has(typed.id)) {
         return palette.edgeHighlight;
@@ -2186,14 +2195,28 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
         return palette.planEdge;
       }
       if (typed.type === 'soft') {
-        const softColor = withAlpha(palette.soft, 0.45);
-        return isHoverActive && !isHoverRelated ? withAlpha(palette.soft, 0.16) : softColor;
+        if (!isHoverActive || hoverTier === 'none') {
+          return withAlpha(palette.soft, 0.45);
+        }
+        if (hoverTier === 'focused') {
+          return withAlpha(palette.soft, 0.45);
+        }
+        if (hoverTier === 'neighbor') {
+          return withAlpha(palette.soft, 0.3);
+        }
+        return withAlpha(palette.soft, 0.16);
       }
       const baseColor = palette.edge;
-      if (isHoverActive && !isHoverRelated) {
-        return withAlpha(baseColor, 0.16);
+      if (!isHoverActive || hoverTier === 'none') {
+        return baseColor;
       }
-      return baseColor;
+      if (hoverTier === 'focused') {
+        return withAlpha(baseColor, 1);
+      }
+      if (hoverTier === 'neighbor') {
+        return withAlpha(baseColor, 0.6);
+      }
+      return withAlpha(baseColor, 0.16);
     },
     [activeNeighborMap, highlightLinkIds, hoveredNodeId, palette]
   );

--- a/src/components/ExpertExplorer.tsx
+++ b/src/components/ExpertExplorer.tsx
@@ -2105,7 +2105,8 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
 
       const label = typed.label;
       const labelFontSize = Math.max(12 / Math.sqrt(globalScale), 9);
-      const shouldShowLabel = isHighlighted || isHoverRelated || globalScale >= 0.95;
+      const shouldShowLabel =
+        isHoverRelated && (isHighlighted || isHovered || globalScale >= 0.95);
       const textY = (node.y ?? 0) + outerRadius + 8;
 
       ctx.save();

--- a/src/components/ExpertExplorer.tsx
+++ b/src/components/ExpertExplorer.tsx
@@ -2105,8 +2105,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
 
       const label = typed.label;
       const labelFontSize = Math.max(12 / Math.sqrt(globalScale), 9);
-      const shouldShowLabel =
-        isHoverRelated && (isHighlighted || isHovered || globalScale >= 0.95);
+      const shouldShowLabel = isHighlighted || isHovered || globalScale >= 0.95;
       const textY = (node.y ?? 0) + outerRadius + 8;
 
       ctx.save();
@@ -2139,7 +2138,7 @@ const ExpertExplorer: React.FC<ExpertExplorerProps> = ({
       }
 
       if (shouldShowLabel) {
-        const textAlpha = isHighlighted || isHovered ? 1 : Math.max(effectiveAlpha, 0.65);
+        const textAlpha = isHighlighted || isHovered ? 1 : effectiveAlpha;
         ctx.globalAlpha = textAlpha;
         ctx.font = `${labelFontSize}px "Inter", "Segoe UI", sans-serif`;
         ctx.textAlign = 'center';

--- a/src/components/GraphView.module.css
+++ b/src/components/GraphView.module.css
@@ -38,6 +38,25 @@
   position: relative;
   overflow: hidden;
   min-height: 0;
+  background-color: #ffffff;
+  background-image:
+    linear-gradient(
+      0deg,
+      rgba(0, 0, 0, 0.04) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0.04) 1px,
+      transparent 1px
+    );
+  background-size: 48px 48px;
+  background-position: -1px -1px;
+}
+
+.graphWrapper :global(canvas) {
+  filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.12));
+  background: transparent;
 }
 
 .controlButton {

--- a/src/components/GraphView.module.css
+++ b/src/components/GraphView.module.css
@@ -54,6 +54,21 @@
   background-position: -1px -1px;
 }
 
+:global(.Theme_preset_cyberpunk) .graphWrapper {
+  background-color: #0f111a;
+  background-image:
+    linear-gradient(
+      0deg,
+      rgba(255, 255, 255, 0.06) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.06) 1px,
+      transparent 1px
+    );
+}
+
 .graphWrapper :global(canvas) {
   filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.12));
   background: transparent;

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -1249,7 +1249,8 @@ function drawNode(
   const effectiveAlpha = clamp(baseAlpha * dimFactor, 0.08, 1);
   const labelFontSize = Math.max(12 / Math.sqrt(globalScale), 10);
   const iconFontSize = Math.max(14 / Math.sqrt(globalScale), 12);
-  const shouldShowLabel = isHighlighted || isHoverRelated || globalScale >= 0.95;
+  const shouldShowLabel =
+    isHoverRelated && (isHighlighted || isHovered || globalScale >= 0.95);
 
   const accent = resolveNodeColor(node, palette);
   const halo = withAlpha(accent, 0.18);

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -165,6 +165,7 @@ const GraphView: React.FC<GraphViewProps> = ({
   const [isFocusedView, setIsFocusedView] = useState(false);
   const [graphInstanceKey, setGraphInstanceKey] = useState(0);
   const [isGraphVisible, setIsGraphVisible] = useState(true);
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
 
   const refreshGraphInstance = useCallback(() => {
     const refresh = (graphRef.current as unknown as { refresh?: () => void })?.refresh;
@@ -393,6 +394,26 @@ const GraphView: React.FC<GraphViewProps> = ({
     });
     return map;
   }, [nodes]);
+
+  const neighborMap = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+
+    const register = (source: string, target: string) => {
+      if (!map.has(source)) {
+        map.set(source, new Set());
+      }
+      map.get(source)!.add(target);
+    };
+
+    graphLinks.forEach((link) => {
+      const sourceId = typeof link.source === 'object' ? link.source.id : String(link.source);
+      const targetId = typeof link.target === 'object' ? link.target.id : String(link.target);
+      register(sourceId, targetId);
+      register(targetId, sourceId);
+    });
+
+    return map;
+  }, [graphLinks]);
 
   const connectionCounts = useMemo(() => {
     const counts = new Map<string, number>();
@@ -1053,7 +1074,15 @@ const GraphView: React.FC<GraphViewProps> = ({
               graphData={graphData}
               nodeLabel={(node: ForceNode) => node.name ?? node.id}
               linkColor={(link: ForceLink) =>
-                resolveLinkColor(link, palette, visibleDomainIds, visibleModuleStatuses, moduleStatusMap)
+                resolveLinkColor(
+                  link,
+                  palette,
+                  visibleDomainIds,
+                  visibleModuleStatuses,
+                  moduleStatusMap,
+                  hoveredNodeId,
+                  neighborMap
+                )
               }
               nodeCanvasObject={(node: ForceNode, ctx, globalScale) => {
                 drawNode(
@@ -1061,6 +1090,8 @@ const GraphView: React.FC<GraphViewProps> = ({
                   ctx,
                   globalScale,
                   highlightedNode,
+                  hoveredNodeId,
+                  neighborMap,
                   palette,
                   visibleDomainIds,
                   visibleModuleStatuses
@@ -1080,6 +1111,9 @@ const GraphView: React.FC<GraphViewProps> = ({
               onEngineStop={handleEngineStop}
               onZoom={handleZoomTransform}
               onZoomEnd={handleZoomEnd}
+              onNodeHover={(node) => {
+                setHoveredNodeId(node ? (node as ForceNode).id : null);
+              }}
             />
           ) : (
             <Loader size="m" />
@@ -1186,6 +1220,8 @@ function drawNode(
   ctx: CanvasRenderingContext2D,
   globalScale: number,
   highlighted: string | null,
+  hoveredNodeId: string | null,
+  neighborMap: Map<string, Set<string>>,
   palette: GraphPalette,
   visibleDomainIds: Set<string>,
   visibleModuleStatuses: Set<ModuleStatus>
@@ -1194,83 +1230,84 @@ function drawNode(
   const x = typeof node.x === 'number' ? node.x : 0;
   const y = typeof node.y === 'number' ? node.y : 0;
   const isHighlighted = highlighted === node.id;
+  const isHovered = hoveredNodeId === node.id;
+  const isNeighbor =
+    hoveredNodeId && neighborMap.get(hoveredNodeId)?.has(node.id) ? hoveredNodeId !== node.id : false;
   const isDomainDimmed =
     node.type === 'domain' && visibleDomainIds.size > 0 && !visibleDomainIds.has(node.id);
   const isModuleDimmed =
     node.type === 'module' &&
     visibleModuleStatuses.size > 0 &&
     !visibleModuleStatuses.has(node.status);
-  const baseAlpha = isHighlighted ? 1 : 1;
+  const isHoverRelated = !hoveredNodeId || isHovered || isNeighbor;
+  const baseAlpha = isHighlighted || isHovered ? 1 : 0.95;
   const dimFactor =
-    (highlighted && node.id !== highlighted ? 0.4 : 1) *
-    (isModuleDimmed && !isHighlighted ? 0.35 : 1) *
-    (isDomainDimmed && !isHighlighted ? 0.35 : 1);
-  const effectiveAlpha = clamp(baseAlpha * dimFactor, 0.1, 1);
+    (highlighted && node.id !== highlighted ? 0.35 : 1) *
+    (isHoverRelated ? 1 : 0.2) *
+    (isModuleDimmed && !isHighlighted ? 0.3 : 1) *
+    (isDomainDimmed && !isHighlighted ? 0.3 : 1);
+  const effectiveAlpha = clamp(baseAlpha * dimFactor, 0.08, 1);
   const labelFontSize = Math.max(12 / Math.sqrt(globalScale), 10);
   const iconFontSize = Math.max(14 / Math.sqrt(globalScale), 12);
+  const shouldShowLabel = isHighlighted || isHoverRelated || globalScale >= 0.95;
+
+  const accent = resolveNodeColor(node, palette);
+  const halo = withAlpha(accent, 0.18);
+  const outerRadius = 13 * clamp(1 / Math.sqrt(globalScale), 0.85, 1.35);
+  const shellThickness = clamp(3 / Math.sqrt(globalScale), 2, 4);
+  const coreRadius = Math.max(outerRadius * 0.45, 4.5);
+  const shadowBlur = clamp(22 / Math.sqrt(globalScale), 8, 18);
+  const icon = resolveNodeIcon(node);
 
   ctx.save();
   ctx.globalAlpha = effectiveAlpha;
+  ctx.shadowColor = withAlpha(accent, 0.35);
+  ctx.shadowBlur = shadowBlur;
+  ctx.shadowOffsetY = 2;
 
-  let labelOffset = 14;
-  let iconColor = palette.text;
-  const icon = resolveNodeIcon(node);
+  // Outer white shell with colored ring
+  ctx.beginPath();
+  ctx.arc(x, y, outerRadius, 0, Math.PI * 2);
+  ctx.fillStyle = '#FFFFFF';
+  ctx.fill();
+  ctx.lineWidth = shellThickness;
+  ctx.strokeStyle = accent;
+  ctx.stroke();
 
-  switch (node.type) {
-    case 'module': {
-      const moduleRadius = 11;
-      const fill = resolveModuleColor(node.status, palette);
-      renderCircle(ctx, x, y, moduleRadius, fill, withAlpha(fill, 0.35));
-      labelOffset = moduleRadius + 8;
-      iconColor = '#FFFFFF';
-      break;
-    }
-    case 'domain': {
-      const domainRadius = 9;
-      renderDiamond(ctx, x, y, domainRadius, palette.domain, withAlpha(palette.domain, 0.35));
-      labelOffset = domainRadius + 10;
-      break;
-    }
-    case 'artifact': {
-      const artifactRadius = 8;
-      renderTriangle(ctx, x, y, artifactRadius, palette.artifact, withAlpha(palette.artifact, 0.35));
-      labelOffset = artifactRadius + 10;
-      break;
-    }
-    case 'initiative': {
-      const width = 26;
-      const height = 16;
-      renderRoundedRect(
-        ctx,
-        x - width / 2,
-        y - height / 2,
-        width,
-        height,
-        6,
-        palette.initiative,
-        withAlpha(palette.initiative, 0.35)
-      );
-      labelOffset = height / 2 + 10;
-      iconColor = '#FFFFFF';
-      break;
-    }
+  // Inner core
+  ctx.shadowBlur = 0;
+  ctx.shadowOffsetY = 0;
+  ctx.beginPath();
+  ctx.arc(x, y, coreRadius, 0, Math.PI * 2);
+  ctx.fillStyle = accent;
+  ctx.fill();
+
+  // Halo for hover/highlight
+  if (isHovered || isHighlighted) {
+    ctx.beginPath();
+    ctx.arc(x, y, outerRadius + shellThickness + 4, 0, Math.PI * 2);
+    ctx.strokeStyle = halo;
+    ctx.lineWidth = shellThickness;
+    ctx.stroke();
   }
 
   if (icon) {
     ctx.font = `${iconFontSize}px sans-serif`;
-    ctx.fillStyle = iconColor;
+    ctx.fillStyle = '#FFFFFF';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillText(icon, x, y);
   }
 
-  const textAlpha = isHighlighted ? 1 : Math.max(effectiveAlpha, 0.45);
-  ctx.globalAlpha = textAlpha;
-  ctx.font = `${labelFontSize}px sans-serif`;
-  ctx.fillStyle = palette.text;
-  ctx.textAlign = 'center';
-  ctx.textBaseline = 'top';
-  ctx.fillText(label, x, y + labelOffset);
+  if (shouldShowLabel) {
+    const textAlpha = isHighlighted || isHovered ? 1 : Math.max(effectiveAlpha, 0.6);
+    ctx.globalAlpha = textAlpha;
+    ctx.font = `${labelFontSize}px 'Inter', 'Segoe UI', sans-serif`;
+    ctx.fillStyle = palette.text;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    ctx.fillText(label, x, y + outerRadius + 10);
+  }
 
   ctx.restore();
 }
@@ -1280,8 +1317,20 @@ function resolveLinkColor(
   palette: GraphPalette,
   visibleDomainIds: Set<string>,
   visibleModuleStatuses: Set<ModuleStatus>,
-  moduleStatusMap: Map<string, ModuleStatus>
+  moduleStatusMap: Map<string, ModuleStatus>,
+  hoveredNodeId: string | null,
+  neighborMap: Map<string, Set<string>>
 ) {
+  const sourceId = typeof link.source === 'object' ? link.source.id : String(link.source);
+  const targetId = typeof link.target === 'object' ? link.target.id : String(link.target);
+  const isHoverActive = Boolean(hoveredNodeId);
+  const isHoverRelated =
+    !hoveredNodeId ||
+    sourceId === hoveredNodeId ||
+    targetId === hoveredNodeId ||
+    neighborMap.get(hoveredNodeId)?.has(sourceId) ||
+    neighborMap.get(hoveredNodeId)?.has(targetId);
+
   if (link.type === 'initiative-plan') {
     const moduleId =
       typeof link.target === 'object' ? (link.target as ForceNode).id : String(link.target);
@@ -1315,14 +1364,16 @@ function resolveLinkColor(
             : palette.linkRelates;
 
   if ((link.type === 'domain' || link.type === 'initiative-domain') && visibleDomainIds.size > 0) {
-    const targetId =
-      typeof link.target === 'object' ? (link.target as ForceNode).id : String(link.target);
     if (!visibleDomainIds.has(targetId)) {
       return withAlpha(baseColor, 0.2);
     }
   }
 
-  return baseColor;
+  if (isHoverActive && !isHoverRelated) {
+    return withAlpha(baseColor, 0.15);
+  }
+
+  return isHoverRelated ? withAlpha(baseColor, 0.95) : baseColor;
 }
 
 function withAlpha(color: string, alpha: number) {
@@ -1342,91 +1393,20 @@ function withAlpha(color: string, alpha: number) {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
-function renderCircle(
-  ctx: CanvasRenderingContext2D,
-  x: number,
-  y: number,
-  radius: number,
-  fill: string,
-  outline: string
-) {
-  ctx.beginPath();
-  ctx.arc(x, y, radius, 0, 2 * Math.PI);
-  ctx.fillStyle = fill;
-  ctx.fill();
-  ctx.strokeStyle = outline;
-  ctx.lineWidth = 1.5;
-  ctx.stroke();
-}
+function resolveNodeColor(node: GraphNode, palette: GraphPalette): string {
+  if (node.type === 'module') {
+    return resolveModuleColor(node.status, palette);
+  }
 
-function renderDiamond(
-  ctx: CanvasRenderingContext2D,
-  x: number,
-  y: number,
-  radius: number,
-  fill: string,
-  outline: string
-) {
-  ctx.beginPath();
-  ctx.moveTo(x, y - radius);
-  ctx.lineTo(x + radius, y);
-  ctx.lineTo(x, y + radius);
-  ctx.lineTo(x - radius, y);
-  ctx.closePath();
-  ctx.fillStyle = fill;
-  ctx.fill();
-  ctx.strokeStyle = outline;
-  ctx.lineWidth = 1.5;
-  ctx.stroke();
-}
+  if (node.type === 'domain') {
+    return palette.domain;
+  }
 
-function renderTriangle(
-  ctx: CanvasRenderingContext2D,
-  x: number,
-  y: number,
-  radius: number,
-  fill: string,
-  outline: string
-) {
-  ctx.beginPath();
-  ctx.moveTo(x, y - radius);
-  ctx.lineTo(x + radius, y + radius);
-  ctx.lineTo(x - radius, y + radius);
-  ctx.closePath();
-  ctx.fillStyle = fill;
-  ctx.fill();
-  ctx.strokeStyle = outline;
-  ctx.lineWidth = 1.5;
-  ctx.stroke();
-}
+  if (node.type === 'initiative') {
+    return palette.initiative;
+  }
 
-function renderRoundedRect(
-  ctx: CanvasRenderingContext2D,
-  x: number,
-  y: number,
-  width: number,
-  height: number,
-  radius: number,
-  fill: string,
-  outline: string
-) {
-  const r = Math.min(radius, width / 2, height / 2);
-  ctx.beginPath();
-  ctx.moveTo(x + r, y);
-  ctx.lineTo(x + width - r, y);
-  ctx.quadraticCurveTo(x + width, y, x + width, y + r);
-  ctx.lineTo(x + width, y + height - r);
-  ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
-  ctx.lineTo(x + r, y + height);
-  ctx.quadraticCurveTo(x, y + height, x, y + height - r);
-  ctx.lineTo(x, y + r);
-  ctx.quadraticCurveTo(x, y, x + r, y);
-  ctx.closePath();
-  ctx.fillStyle = fill;
-  ctx.fill();
-  ctx.strokeStyle = outline;
-  ctx.lineWidth = 1.5;
-  ctx.stroke();
+  return palette.artifact;
 }
 
 function resolveModuleColor(status: ModuleStatus, palette: GraphPalette): string {

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -1249,8 +1249,7 @@ function drawNode(
   const effectiveAlpha = clamp(baseAlpha * dimFactor, 0.08, 1);
   const labelFontSize = Math.max(12 / Math.sqrt(globalScale), 10);
   const iconFontSize = Math.max(14 / Math.sqrt(globalScale), 12);
-  const shouldShowLabel =
-    isHoverRelated && (isHighlighted || isHovered || globalScale >= 0.95);
+  const shouldShowLabel = isHighlighted || isHovered || globalScale >= 0.95;
 
   const accent = resolveNodeColor(node, palette);
   const halo = withAlpha(accent, 0.18);
@@ -1301,7 +1300,7 @@ function drawNode(
   }
 
   if (shouldShowLabel) {
-    const textAlpha = isHighlighted || isHovered ? 1 : Math.max(effectiveAlpha, 0.6);
+    const textAlpha = isHighlighted || isHovered ? 1 : effectiveAlpha;
     ctx.globalAlpha = textAlpha;
     ctx.font = `${labelFontSize}px 'Inter', 'Segoe UI', sans-serif`;
     ctx.fillStyle = palette.text;

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -1239,11 +1239,17 @@ function drawNode(
     node.type === 'module' &&
     visibleModuleStatuses.size > 0 &&
     !visibleModuleStatuses.has(node.status);
-  const isHoverRelated = !hoveredNodeId || isHovered || isNeighbor;
+  const hoverFactor = !hoveredNodeId
+    ? 1
+    : isHovered
+      ? 1
+      : isNeighbor
+        ? 0.55
+        : 0.2;
   const baseAlpha = isHighlighted || isHovered ? 1 : 0.95;
   const dimFactor =
     (highlighted && node.id !== highlighted ? 0.35 : 1) *
-    (isHoverRelated ? 1 : 0.2) *
+    hoverFactor *
     (isModuleDimmed && !isHighlighted ? 0.3 : 1) *
     (isDomainDimmed && !isHighlighted ? 0.3 : 1);
   const effectiveAlpha = clamp(baseAlpha * dimFactor, 0.08, 1);
@@ -1324,12 +1330,17 @@ function resolveLinkColor(
   const sourceId = typeof link.source === 'object' ? link.source.id : String(link.source);
   const targetId = typeof link.target === 'object' ? link.target.id : String(link.target);
   const isHoverActive = Boolean(hoveredNodeId);
-  const isHoverRelated =
-    !hoveredNodeId ||
-    sourceId === hoveredNodeId ||
-    targetId === hoveredNodeId ||
-    neighborMap.get(hoveredNodeId)?.has(sourceId) ||
-    neighborMap.get(hoveredNodeId)?.has(targetId);
+  const isDirectHover = hoveredNodeId && (sourceId === hoveredNodeId || targetId === hoveredNodeId);
+  const isNeighborHover =
+    hoveredNodeId &&
+    (neighborMap.get(hoveredNodeId)?.has(sourceId) || neighborMap.get(hoveredNodeId)?.has(targetId));
+  const hoverTier = !hoveredNodeId
+    ? 'none'
+    : isDirectHover
+      ? 'focused'
+      : isNeighborHover
+        ? 'neighbor'
+        : 'dim';
 
   if (link.type === 'initiative-plan') {
     const moduleId =
@@ -1369,11 +1380,19 @@ function resolveLinkColor(
     }
   }
 
-  if (isHoverActive && !isHoverRelated) {
-    return withAlpha(baseColor, 0.15);
+  if (!isHoverActive || hoverTier === 'none') {
+    return baseColor;
   }
 
-  return isHoverRelated ? withAlpha(baseColor, 0.95) : baseColor;
+  if (hoverTier === 'focused') {
+    return withAlpha(baseColor, 1);
+  }
+
+  if (hoverTier === 'neighbor') {
+    return withAlpha(baseColor, 0.6);
+  }
+
+  return withAlpha(baseColor, 0.15);
 }
 
 function withAlpha(color: string, alpha: number) {

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -166,6 +166,7 @@ const GraphView: React.FC<GraphViewProps> = ({
   const [graphInstanceKey, setGraphInstanceKey] = useState(0);
   const [isGraphVisible, setIsGraphVisible] = useState(true);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
   const refreshGraphInstance = useCallback(() => {
     const refresh = (graphRef.current as unknown as { refresh?: () => void })?.refresh;
@@ -414,6 +415,16 @@ const GraphView: React.FC<GraphViewProps> = ({
 
     return map;
   }, [graphLinks]);
+
+  useEffect(() => {
+    if (!selectedNodeId) {
+      return;
+    }
+
+    if (!neighborMap.has(selectedNodeId)) {
+      setSelectedNodeId(null);
+    }
+  }, [neighborMap, selectedNodeId]);
 
   const connectionCounts = useMemo(() => {
     const counts = new Map<string, number>();
@@ -876,6 +887,18 @@ const GraphView: React.FC<GraphViewProps> = ({
     showEntireGraph();
   }, [showEntireGraph]);
 
+  const focusNodeId = useMemo(() => {
+    if (hoveredNodeId) {
+      return hoveredNodeId;
+    }
+
+    if (selectedNodeId && neighborMap.has(selectedNodeId)) {
+      return selectedNodeId;
+    }
+
+    return null;
+  }, [hoveredNodeId, neighborMap, selectedNodeId]);
+
   const handleZoomTransform = useCallback(
     (transform?: { k: number; x: number; y: number }) => {
       const { width, height } = getViewportSize();
@@ -1080,7 +1103,7 @@ const GraphView: React.FC<GraphViewProps> = ({
                   visibleDomainIds,
                   visibleModuleStatuses,
                   moduleStatusMap,
-                  hoveredNodeId,
+                  focusNodeId,
                   neighborMap
                 )
               }
@@ -1090,7 +1113,7 @@ const GraphView: React.FC<GraphViewProps> = ({
                   ctx,
                   globalScale,
                   highlightedNode,
-                  hoveredNodeId,
+                  focusNodeId,
                   neighborMap,
                   palette,
                   visibleDomainIds,
@@ -1099,6 +1122,7 @@ const GraphView: React.FC<GraphViewProps> = ({
               }}
               nodeCanvasObjectMode={() => 'replace'}
               onNodeClick={(node) => {
+                setSelectedNodeId((prev) => ((node as ForceNode).id === prev ? prev : (node as ForceNode).id));
                 onSelect(node as ForceNode);
               }}
               onNodeDoubleClick={(node) => {
@@ -1220,7 +1244,7 @@ function drawNode(
   ctx: CanvasRenderingContext2D,
   globalScale: number,
   highlighted: string | null,
-  hoveredNodeId: string | null,
+  focusNodeId: string | null,
   neighborMap: Map<string, Set<string>>,
   palette: GraphPalette,
   visibleDomainIds: Set<string>,
@@ -1230,23 +1254,23 @@ function drawNode(
   const x = typeof node.x === 'number' ? node.x : 0;
   const y = typeof node.y === 'number' ? node.y : 0;
   const isHighlighted = highlighted === node.id;
-  const isHovered = hoveredNodeId === node.id;
+  const isFocusTarget = focusNodeId === node.id;
   const isNeighbor =
-    hoveredNodeId && neighborMap.get(hoveredNodeId)?.has(node.id) ? hoveredNodeId !== node.id : false;
+    focusNodeId && neighborMap.get(focusNodeId)?.has(node.id) ? focusNodeId !== node.id : false;
   const isDomainDimmed =
     node.type === 'domain' && visibleDomainIds.size > 0 && !visibleDomainIds.has(node.id);
   const isModuleDimmed =
     node.type === 'module' &&
     visibleModuleStatuses.size > 0 &&
     !visibleModuleStatuses.has(node.status);
-  const hoverFactor = !hoveredNodeId
+  const hoverFactor = !focusNodeId
     ? 1
-    : isHovered
+    : isFocusTarget
       ? 1
       : isNeighbor
         ? 0.55
         : 0.2;
-  const baseAlpha = isHighlighted || isHovered ? 1 : 0.95;
+  const baseAlpha = isHighlighted || isFocusTarget ? 1 : 0.95;
   const dimFactor =
     (highlighted && node.id !== highlighted ? 0.35 : 1) *
     hoverFactor *
@@ -1255,7 +1279,7 @@ function drawNode(
   const effectiveAlpha = clamp(baseAlpha * dimFactor, 0.08, 1);
   const labelFontSize = Math.max(12 / Math.sqrt(globalScale), 10);
   const iconFontSize = Math.max(14 / Math.sqrt(globalScale), 12);
-  const shouldShowLabel = isHighlighted || isHovered || globalScale >= 0.95;
+  const shouldShowLabel = isHighlighted || isFocusTarget || globalScale >= 0.95;
 
   const accent = resolveNodeColor(node, palette);
   const halo = withAlpha(accent, 0.18);
@@ -1289,7 +1313,7 @@ function drawNode(
   ctx.fill();
 
   // Halo for hover/highlight
-  if (isHovered || isHighlighted) {
+  if (isFocusTarget || isHighlighted) {
     ctx.beginPath();
     ctx.arc(x, y, outerRadius + shellThickness + 4, 0, Math.PI * 2);
     ctx.strokeStyle = halo;
@@ -1306,7 +1330,7 @@ function drawNode(
   }
 
   if (shouldShowLabel) {
-    const textAlpha = isHighlighted || isHovered ? 1 : effectiveAlpha;
+    const textAlpha = isHighlighted || isFocusTarget ? 1 : effectiveAlpha;
     ctx.globalAlpha = textAlpha;
     ctx.font = `${labelFontSize}px 'Inter', 'Segoe UI', sans-serif`;
     ctx.fillStyle = palette.text;
@@ -1324,17 +1348,17 @@ function resolveLinkColor(
   visibleDomainIds: Set<string>,
   visibleModuleStatuses: Set<ModuleStatus>,
   moduleStatusMap: Map<string, ModuleStatus>,
-  hoveredNodeId: string | null,
+  focusNodeId: string | null,
   neighborMap: Map<string, Set<string>>
 ) {
   const sourceId = typeof link.source === 'object' ? link.source.id : String(link.source);
   const targetId = typeof link.target === 'object' ? link.target.id : String(link.target);
-  const isHoverActive = Boolean(hoveredNodeId);
-  const isDirectHover = hoveredNodeId && (sourceId === hoveredNodeId || targetId === hoveredNodeId);
+  const isHoverActive = Boolean(focusNodeId);
+  const isDirectHover = focusNodeId && (sourceId === focusNodeId || targetId === focusNodeId);
   const isNeighborHover =
-    hoveredNodeId &&
-    (neighborMap.get(hoveredNodeId)?.has(sourceId) || neighborMap.get(hoveredNodeId)?.has(targetId));
-  const hoverTier = !hoveredNodeId
+    focusNodeId &&
+    (neighborMap.get(focusNodeId)?.has(sourceId) || neighborMap.get(focusNodeId)?.has(targetId));
+  const hoverTier = !focusNodeId
     ? 'none'
     : isDirectHover
       ? 'focused'


### PR DESCRIPTION
## Summary
- add neighbour tracking to highlight hovered nodes and fade unrelated links
- restyle graph nodes with white shells, colored cores, drop-shadows, and label level-of-detail logic
- apply a blueprint-like grid background and canvas drop-shadow for the graph viewport

## Testing
- npm test -- --runInBand *(fails: vitest package missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e188b0e348332bca5c758244b3ebe)